### PR TITLE
adding support for per user chroot jails to Unraid's stock FTP powered by vsftpd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ sftp-config.json
 
 # Auto-generated when emhttpd/webGUI start
 languages/en_US/helptext.dot
+
+.vscode

--- a/languages/en_US/helptext.txt
+++ b/languages/en_US/helptext.txt
@@ -1234,24 +1234,15 @@ Enable or disable the FTP server daemon. By default the FTP server is enabled.
 This setting is not saved, i.e. upon system reboot it will revert to its default setting.
 :end
 
-:ftp_users_help:
-Enter a semicolon (;) separated list of users and their chroot jailed share using the format `username=/path/to/share`.
-
-For example:
-
-    dataUser=/mnt/user/data;videoUser=/mnt/user/video;picUser=/mnt/user/pictures
-
-To disallow any user access, clear this setting.
-
-**Note:** do not enter user name `root` since this may cause problems in the future.
+:ftp_syslog_enable_help:
+Should log be sent to syslog.
+This setting is not saved, i.e. upon system reboot it will revert to its default setting.
 :end
 
 :ftp_overview_help:
 ### Overview
 
-Unraid includes the popular `vsftpd` FTP server.  The configuration of `vsftp` is currently very
-simple: **All** user names entered above are permitted to access the server via FTP and will have
-*full read/write/delete access* to the entire server, so use with caution.
+Unraid includes the popular `vsftpd` FTP server.  The configuration of `vsftp` allows you to specify users and their root directory that their FTP session will be chroot jailed to. This will ensure they can only access a specific share/folder.
 :end
 
 :smb_enable_help:

--- a/languages/en_US/helptext.txt
+++ b/languages/en_US/helptext.txt
@@ -1235,7 +1235,12 @@ This setting is not saved, i.e. upon system reboot it will revert to its default
 :end
 
 :ftp_users_help:
-Enter the user names (separated by spaces) permitted to access the server using FTP.
+Enter a semicolon (;) separated list of users and their chroot jailed share using the format `username=/path/to/share`.
+
+For example:
+
+    dataUser=/mnt/user/data;videoUser=/mnt/user/video;picUser=/mnt/user/pictures
+
 To disallow any user access, clear this setting.
 
 **Note:** do not enter user name `root` since this may cause problems in the future.

--- a/languages/en_US/helptext.txt
+++ b/languages/en_US/helptext.txt
@@ -1239,6 +1239,14 @@ Should log be sent to syslog.
 This setting is not saved, i.e. upon system reboot it will revert to its default setting.
 :end
 
+:ftp_pasv_min_port_help:
+See [http://vsftpd.beasts.org/vsftpd_conf.html](http://vsftpd.beasts.org/vsftpd_conf.html).
+:end
+
+:ftp_pasv_max_port_help:
+See [http://vsftpd.beasts.org/vsftpd_conf.html](http://vsftpd.beasts.org/vsftpd_conf.html).
+:end
+
 :ftp_overview_help:
 ### Overview
 

--- a/plugins/dynamix/FTP.page
+++ b/plugins/dynamix/FTP.page
@@ -21,6 +21,8 @@ Tag="globe"
 $user_config_dir = "/boot/config/vsftpd.user_config_dir";
 $is_ftp_server_running = exec("lsof -i:21 -Pln|awk '/\(LISTEN\)/{print $2;exit}'") ? 1 : 0;
 $is_ftp_syslog_enabled = preg_match('/syslog_enable\s*=\s*yes/i', exec("grep syslog_enable /etc/vsftpd.conf"));
+$pasv_min_port = exec("grep pasv_min_port /etc/vsftpd.conf | awk -F '=' '{print $2}'");
+$pasv_max_port = exec("grep pasv_max_port /etc/vsftpd.conf | awk -F '=' '{print $2}'");
 ?>
 
 <script>
@@ -65,6 +67,16 @@ _(Log to Syslog)_:
   </select>
 
 :ftp_syslog_enable_help:
+
+_(PASV Min Port)_:
+: <input class='narrow' type="number" name="#arg[3]" min='1' max='65535' value='<?= $pasv_min_port ?>'>
+
+:ftp_pasv_min_port_help:
+
+_(PASV Max Port)_:
+: <input class='narrow' type="number" name="#arg[4]" min='1' max='65535' value='<?= $pasv_max_port ?>'>
+
+:ftp_pasv_max_port_help:
 
 &nbsp;
 : <input type="submit" value="_(Apply)_" disabled><input type="button" value="_(Done)_" onclick="done()">

--- a/plugins/dynamix/FTP.page
+++ b/plugins/dynamix/FTP.page
@@ -108,8 +108,6 @@ echo "</tbody></table>";
 
 <?PHP
 
-# copied from plugins\dynamix.docker.manager\include\CreateDocker.php
-
 $bgcolor = strstr('white,azure',$display['theme']) ? '#f2f2f2' : '#1c1c1c';
 
 ?>

--- a/plugins/dynamix/FTP.page
+++ b/plugins/dynamix/FTP.page
@@ -16,12 +16,38 @@ Tag="globe"
  */
 ?>
 <?
-$ftp_userlist_file = "/boot/config/vsftpd.user_list";
+// Don't need this file any more - IMTheNachoMan on 2021-09-16
+// $ftp_userlist_file = "/boot/config/vsftpd.user_list";
+
+// Where we'll save what each user's chroot jail is - IMTheNachoMan on 2021-09-16
+$user_config_dir = "/boot/config/vsftpd.user_config_dir";
+
 $ftp_userlist = "";
-if (file_exists($ftp_userlist_file)) {
-  $ftp_userlist = str_replace("\n", " ", trim(file_get_contents($ftp_userlist_file)));
-  if ($ftp_userlist === false) $ftp_userlist = "";
+// We can't just get the conents of a file. We have to iterate through the files in a directory - IMTheNachoMan on 2021-09-16
+// if (file_exists($ftp_userlist_file)) {
+//   $ftp_userlist = str_replace("\n", " ", trim(file_get_contents($ftp_userlist_file)));
+//   if ($ftp_userlist === false) $ftp_userlist = "";
+// }
+
+// new code start - IMTheNachoMan on 2021-09-16
+
+$ftp_userlist_items = array();
+
+// make sure we have a folder
+if(file_exists($user_config_dir) && is_dir($user_config_dir))
+{
+    // go through all of the files, read their content, and piece together the necessary syntax
+    foreach(array_diff(scandir($user_config_dir), array(".", "..")) as $filename)
+    {
+        $user_config = trim(file_get_contents($user_config_dir . "/" . $filename));
+        $user_config_parts = explode("=", $user_config);
+        array_push($ftp_userlist_items, $filename . "=" . $user_config_parts[1]);
+    }
 }
+
+$ftp_userlist = implode("; ", $ftp_userlist_items);
+
+// end new code - IMTheNachoMan on 2021-09-16
 $ftp_server = exec("lsof -i:21 -Pln|awk '/\(LISTEN\)/{print $2;exit}'") ? 1 : 0;
 ?>
 <script>

--- a/plugins/dynamix/FTP.page
+++ b/plugins/dynamix/FTP.page
@@ -79,17 +79,22 @@ _(Log to Syslog)_:
 
 echo "<table class='ftp_permissions' style='margin-top:20px'><thead><tr><td>" . _('User') . "</td><td>" . _('Current Root Folder') . "</td><td>" . _('New Root Folder') . "</td></tr></thead><tbody>";
 
+// go through every user
 foreach($users as $user)
 {
   $user_config_file = $user_config_dir . "/" . $user["name"];
   $user_root_folder = "";
+  
+  // if the user has a config file
   if(file_exists($user_config_file) && is_file($user_config_file))
   {
+    // get the root folder from the config file
     $user_config = trim(file_get_contents($user_config_file));
     $user_config_parts = explode("=", $user_config);
     $user_root_folder = $user_config_parts[1];
   }
 
+  // show on the screen
   echo "<tr><td>" . $user["name"] . "</td><td>" . $user_root_folder . "</td><td><input type='text' name='" . $user["name"] . "' value='" . $user_root_folder . "'></td></tr>";
 }
 

--- a/plugins/dynamix/FTP.page
+++ b/plugins/dynamix/FTP.page
@@ -16,65 +16,137 @@ Tag="globe"
  */
 ?>
 <?
-// Don't need this file any more - IMTheNachoMan on 2021-09-16
-// $ftp_userlist_file = "/boot/config/vsftpd.user_list";
 
 // Where we'll save what each user's chroot jail is - IMTheNachoMan on 2021-09-16
 $user_config_dir = "/boot/config/vsftpd.user_config_dir";
-
-$ftp_userlist = "";
-// We can't just get the conents of a file. We have to iterate through the files in a directory - IMTheNachoMan on 2021-09-16
-// if (file_exists($ftp_userlist_file)) {
-//   $ftp_userlist = str_replace("\n", " ", trim(file_get_contents($ftp_userlist_file)));
-//   if ($ftp_userlist === false) $ftp_userlist = "";
-// }
-
-// new code start - IMTheNachoMan on 2021-09-16
-
-$ftp_userlist_items = array();
-
-// make sure we have a folder
-if(file_exists($user_config_dir) && is_dir($user_config_dir))
-{
-    // go through all of the files, read their content, and piece together the necessary syntax
-    foreach(array_diff(scandir($user_config_dir), array(".", "..")) as $filename)
-    {
-        $user_config = trim(file_get_contents($user_config_dir . "/" . $filename));
-        $user_config_parts = explode("=", $user_config);
-        array_push($ftp_userlist_items, $filename . "=" . $user_config_parts[1]);
-    }
-}
-
-$ftp_userlist = implode("; ", $ftp_userlist_items);
-
-// end new code - IMTheNachoMan on 2021-09-16
-$ftp_server = exec("lsof -i:21 -Pln|awk '/\(LISTEN\)/{print $2;exit}'") ? 1 : 0;
+$is_ftp_server_running = exec("lsof -i:21 -Pln|awk '/\(LISTEN\)/{print $2;exit}'") ? 1 : 0;
+$is_ftp_syslog_enabled = preg_match('/syslog_enable\s*=\s*yes/i', exec("grep syslog_enable /etc/vsftpd.conf"));
 ?>
+
 <script>
 $(function() {
   showStatus('21');
 });
+
+function updateFTPPermissions(form)
+{
+  var permissions = [];
+  
+  $(form).find(".ftp_permissions input[type='text']").each(function(){
+    var value = this.value;
+    var name = this.name;
+    permissions.push(`${name}=${value}`);
+  });
+
+  $(form).find('input[name="#arg[1]"]').val(permissions.join("|"));
+
+  return true;
+}
+
 </script>
 
+:ftp_overview_help:
+
 <form markdown="1" method="POST" action="/update.php" target="progressFrame">
-<input type="hidden" name="#command" value="/webGui/scripts/ftpusers">
+<input type="hidden" name="#command" value="/webGui/scripts/ftpconfiguration">
 
 _(FTP server)_:
 : <select name="#arg[1]">
-  <?=mk_option($ftp_server, "0", _("Disabled"))?>
-  <?=mk_option($ftp_server, "1", _("Enabled"))?>
+  <?=mk_option($is_ftp_server_running, "0", _("Disabled"))?>
+  <?=mk_option($is_ftp_server_running, "1", _("Enabled"))?>
   </select>
 
 :ftp_server_help:
 
-_(FTP user(s))_:
-: <input type="text" name="#arg[2]" size="40" maxlength="80" value="<?=htmlspecialchars($ftp_userlist)?>">
+_(Log to Syslog)_:
+: <select name="#arg[2]">
+  <?=mk_option($is_ftp_syslog_enabled, "0", _("Disabled"))?>
+  <?=mk_option($is_ftp_syslog_enabled, "1", _("Enabled"))?>
+  </select>
 
-:ftp_users_help:
+:ftp_syslog_enable_help:
 
 &nbsp;
 : <input type="submit" value="_(Apply)_" disabled><input type="button" value="_(Done)_" onclick="done()">
 
 </form>
 
-:ftp_overview_help:
+<form markdown="1" method="POST" action="/update.php" target="progressFrame" onsubmit="return updateFTPPermissions(this)">
+<input type="hidden" name="#command" value="/webGui/scripts/ftpusers">
+<input type="hidden" name="#arg[1]" value="root=test">
+
+<?php
+
+echo "<table class='ftp_permissions' style='margin-top:20px'><thead><tr><td>" . _('User') . "</td><td>" . _('Current Root Folder') . "</td><td>" . _('New Root Folder') . "</td></tr></thead><tbody>";
+
+foreach($users as $user)
+{
+  $user_config_file = $user_config_dir . "/" . $user["name"];
+  $user_root_folder = "";
+  if(file_exists($user_config_file) && is_file($user_config_file))
+  {
+    $user_config = trim(file_get_contents($user_config_file));
+    $user_config_parts = explode("=", $user_config);
+    $user_root_folder = $user_config_parts[1];
+  }
+
+  echo "<tr><td>" . $user["name"] . "</td><td>" . $user_root_folder . "</td><td><input type='text' name='" . $user["name"] . "' value='" . $user_root_folder . "'></td></tr>";
+}
+
+echo "</tbody></table>";
+
+?>
+
+&nbsp;
+: <input type="submit" value="_(Apply)_" disabled><input type="button" value="_(Done)_" onclick="done()">
+</form>
+
+<?PHP
+
+# copied from plugins\dynamix.docker.manager\include\CreateDocker.php
+
+$bgcolor = strstr('white,azure',$display['theme']) ? '#f2f2f2' : '#1c1c1c';
+
+?>
+
+<link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/jquery.filetree.css")?>">
+<style>
+.fileTree{width:240px;max-height:200px;overflow-y:scroll;overflow-x:hidden;position:absolute;z-index:100;display:none;background:<?=$bgcolor?>}
+</style>
+<script src="<?autov('/webGui/javascript/jquery.filetree.js')?>" charset="utf-8"></script>
+
+<script>
+
+function openFileBrowser(el, root, filter, on_folders, on_files, close_on_select) {
+  if (on_folders === undefined) on_folders = true;
+  if (on_files   === undefined) on_files = true;
+  if (!filter && !on_files) filter = 'HIDE_FILES_FILTER';
+  if (!root.trim()) root = "/mnt/user/";
+  p = $(el);
+  // Skip is fileTree is already open
+  if (p.next().hasClass('fileTree')) return null;
+  // create a random id
+  var r = Math.floor((Math.random()*1000)+1);
+  // Add a new span and load fileTree
+  p.after("<span id='fileTree"+r+"' class='textarea fileTree'></span>");
+  var ft = $('#fileTree'+r);
+  ft.fileTree({
+    root: root,
+    filter: filter,
+    allowBrowsing: true
+  },
+  function(file){if(on_files){p.val(file);p.trigger('change');if(close_on_select){ft.slideUp('fast',function(){ft.remove();});}}},
+  function(folder){if(on_folders){p.val(folder.replace(/\/\/+/g,'/'));p.trigger('change');if(close_on_select){$(ft).slideUp('fast',function(){$(ft).remove();});}}});
+  // Format fileTree according to parent position, height and width
+  ft.css({'left':p.position().left,'top':(p.position().top+p.outerHeight()),'width':(p.width())});
+  // close if click elsewhere
+  $(document).mouseup(function(e){if(!ft.is(e.target) && ft.has(e.target).length === 0){ft.slideUp('fast',function(){$(ft).remove();});}});
+  // close if parent changed
+  p.bind("keydown", function(){ft.slideUp('fast', function(){$(ft).remove();});});
+  // Open fileTree
+  ft.slideDown('fast');
+}
+
+$(".ftp_permissions input[type='text']").attr("onclick", "openFileBrowser(this,$(this).val()||'/mnt/user','',true,false);");
+
+</script>

--- a/plugins/dynamix/scripts/ftpconfiguration
+++ b/plugins/dynamix/scripts/ftpconfiguration
@@ -4,9 +4,11 @@
 // enable: 0 = disable, 1 = enable FTP server daemon
 // syslog_enable: 0 = disable, 1 = enable logging to syslog
 
+// enable or disable listening on port 21 for FTP
 $ftp_state = $argv[1] ? "'s/^#\(ftp.*vsftpd\)\$/\\1/'" : "'s/^\(ftp.*vsftpd\)\$/#\\1/'";
 exec("sed -i $ftp_state /etc/inetd.conf");
 
+// enable or disable syslog logging for vsftpd
 $syslog_enable_state = $argv[2] ? "'s/syslog_enable\s*=\s*no/syslog_enable=YES/i'" : "'s/syslog_enable\s*=\s*yes/syslog_enable=NO/i'";
 exec("sed -i -e $syslog_enable_state /etc/vsftpd.conf");
 

--- a/plugins/dynamix/scripts/ftpconfiguration
+++ b/plugins/dynamix/scripts/ftpconfiguration
@@ -1,0 +1,14 @@
+#!/usr/bin/php -q
+<?php
+// usage: ftpconfiguration [enable = 0|1] [syslog_enable = 0|1]
+// enable: 0 = disable, 1 = enable FTP server daemon
+// syslog_enable: 0 = disable, 1 = enable logging to syslog
+
+$ftp_state = $argv[1] ? "'s/^#\(ftp.*vsftpd\)\$/\\1/'" : "'s/^\(ftp.*vsftpd\)\$/#\\1/'";
+exec("sed -i $ftp_state /etc/inetd.conf");
+
+$syslog_enable_state = $argv[2] ? "'s/syslog_enable\s*=\s*no/syslog_enable=YES/i'" : "'s/syslog_enable\s*=\s*yes/syslog_enable=NO/i'";
+exec("sed -i -e $syslog_enable_state /etc/vsftpd.conf");
+
+exec("killall -HUP inetd");
+?>

--- a/plugins/dynamix/scripts/ftpconfiguration
+++ b/plugins/dynamix/scripts/ftpconfiguration
@@ -1,8 +1,13 @@
 #!/usr/bin/php -q
 <?php
-// usage: ftpconfiguration [enable = 0|1] [syslog_enable = 0|1]
+// usage: ftpconfiguration [enable = 0|1] [syslog_enable = 0|1] [pasv_min_port] [pasv_max_port]
 // enable: 0 = disable, 1 = enable FTP server daemon
 // syslog_enable: 0 = disable, 1 = enable logging to syslog
+// pasv_min_port: http://vsftpd.beasts.org/vsftpd_conf.html
+// pasv_max_port: http://vsftpd.beasts.org/vsftpd_conf.html
+
+$pasv_min_port = $argv[3];
+$pasv_max_port = $argv[4];
 
 // enable or disable listening on port 21 for FTP
 $ftp_state = $argv[1] ? "'s/^#\(ftp.*vsftpd\)\$/\\1/'" : "'s/^\(ftp.*vsftpd\)\$/#\\1/'";
@@ -11,6 +16,15 @@ exec("sed -i $ftp_state /etc/inetd.conf");
 // enable or disable syslog logging for vsftpd
 $syslog_enable_state = $argv[2] ? "'s/syslog_enable\s*=\s*no/syslog_enable=YES/i'" : "'s/syslog_enable\s*=\s*yes/syslog_enable=NO/i'";
 exec("sed -i -e $syslog_enable_state /etc/vsftpd.conf");
+
+exec("sed -i '/^pasv_min_port/d' /etc/vsftpd.conf");
+exec("sed -i '/^pasv_max_port/d' /etc/vsftpd.conf");
+
+if($pasv_min_port !== "" && $pasv_max_port !== "")
+{
+    exec("echo 'pasv_min_port=$pasv_min_port' >> /etc/vsftpd.conf");
+    exec("echo 'pasv_max_port=$pasv_max_port' >> /etc/vsftpd.conf");
+}
 
 // restart inetd to implement the changes
 exec("killall -HUP inetd");

--- a/plugins/dynamix/scripts/ftpconfiguration
+++ b/plugins/dynamix/scripts/ftpconfiguration
@@ -12,5 +12,6 @@ exec("sed -i $ftp_state /etc/inetd.conf");
 $syslog_enable_state = $argv[2] ? "'s/syslog_enable\s*=\s*no/syslog_enable=YES/i'" : "'s/syslog_enable\s*=\s*yes/syslog_enable=NO/i'";
 exec("sed -i -e $syslog_enable_state /etc/vsftpd.conf");
 
+// restart inetd to implement the changes
 exec("killall -HUP inetd");
 ?>

--- a/plugins/dynamix/scripts/ftpusers
+++ b/plugins/dynamix/scripts/ftpusers
@@ -1,13 +1,46 @@
 #!/usr/bin/php -q
 <?php
-// usage: ftpusers 0|1 ['user1 user2 .. ']
+// usage: ftpusers 0|1 ['user1=/path/to/share; user2=/path/to/another share; .. ']
 // 0 = disable, 1 = enable FTP server daemon
-// the list of users must be within quotes, ie, as one argument
+// a semicolon separated list of users configuration using the format username=/path/to/share
+// must be within quotes, ie, as one argument
 // if no user(s) specified, deletes the config file
 
 $config_file = "/boot/config/vsftpd.user_list";
+
+// Where we'll save what each user's chroot jail is - IMTheNachoMan on 2021-09-16
+$user_config_dir = "/boot/config/vsftpd.user_config_dir";
+
 if (trim($argv[2]))
-  file_put_contents($config_file, implode("\n", explode(' ', trim($argv[2])))."\n");
+{
+  // the user field in the UI has a specific syntax that has to be processed so we can't just write it to a file - IMTheNachoMan on 2021-09-16
+  // file_put_contents($config_file, implode("\n", explode(' ', trim($argv[2])))."\n");
+
+  // new code start - IMTheNachoMan on 2021-09-16
+  // first we need to empty out or create $config_file
+  file_put_contents($config_file, "");
+
+  // we need to make sure the directory for the user config exists
+  exec("mkdir -p '$user_config_dir'");
+
+  // go through each user configuration
+  foreach(explode(";", trim($argv[2])) as $user_config)
+  {
+    if(trim($user_config))
+    {
+      // get the user configuration parts
+      $user_config_parts = explode("=", trim($user_config));
+      
+      // write the configuration information to a file in $user_config_dir
+      file_put_contents($user_config_dir."/".$user_config_parts[0], "local_root=".$user_config_parts[1]."\n");
+
+      // also append the user to $config_file
+      file_put_contents($config_file, $user_config_parts[0]."\n", FILE_APPEND);
+    }
+  }
+
+  // end new code - IMTheNachoMan on 2021-09-16
+}
 else
   @unlink($config_file);
 

--- a/plugins/dynamix/scripts/ftpusers
+++ b/plugins/dynamix/scripts/ftpusers
@@ -1,50 +1,28 @@
 #!/usr/bin/php -q
 <?php
-// usage: ftpusers 0|1 ['user1=/path/to/share; user2=/path/to/another share; .. ']
-// 0 = disable, 1 = enable FTP server daemon
-// a semicolon separated list of users configuration using the format username=/path/to/share
-// must be within quotes, ie, as one argument
-// if no user(s) specified, deletes the config file
+// usage: ftpusers user_config_data
+// user_config_data = pipe (|) delimited root folders for user in the format of user=/path/to/root/folder
 
-$config_file = "/boot/config/vsftpd.user_list";
-
-// Where we'll save what each user's chroot jail is - IMTheNachoMan on 2021-09-16
 $user_config_dir = "/boot/config/vsftpd.user_config_dir";
 
-if (trim($argv[2]))
+$user_options = explode("|", $argv[1]);
+
+foreach(explode("|", $argv[1]) as $user_config)
 {
-  // the user field in the UI has a specific syntax that has to be processed so we can't just write it to a file - IMTheNachoMan on 2021-09-16
-  // file_put_contents($config_file, implode("\n", explode(' ', trim($argv[2])))."\n");
+  $user_config_parts = explode("=", trim($user_config));
+  $user_config_file = $user_config_dir . "/" . $user_config_parts[0];
+  $user_config_root_folder = $user_config_parts[1];
 
-  // new code start - IMTheNachoMan on 2021-09-16
-  // first we need to empty out or create $config_file
-  file_put_contents($config_file, "");
-
-  // we need to make sure the directory for the user config exists
-  exec("mkdir -p '$user_config_dir'");
-
-  // go through each user configuration
-  foreach(explode(";", trim($argv[2])) as $user_config)
+  // if no root folder and this user has an existing config file
+  if($user_config_root_folder === "" && file_exists($user_config_file) && is_file($user_config_file))
   {
-    if(trim($user_config))
-    {
-      // get the user configuration parts
-      $user_config_parts = explode("=", trim($user_config));
-      
-      // write the configuration information to a file in $user_config_dir
-      file_put_contents($user_config_dir."/".$user_config_parts[0], "local_root=".$user_config_parts[1]."\n");
-
-      // also append the user to $config_file
-      file_put_contents($config_file, $user_config_parts[0]."\n", FILE_APPEND);
-    }
+    // delete the config file
+    unlink($user_config_file);
   }
-
-  // end new code - IMTheNachoMan on 2021-09-16
+  else if($user_config_root_folder !== "" && file_exists($user_config_root_folder) && is_dir($user_config_root_folder))
+  {
+    file_put_contents($user_config_file, "local_root=" . $user_config_root_folder . "\n");
+  }
 }
-else
-  @unlink($config_file);
 
-$state = $argv[1] ? "'s/^#\(ftp.*vsftpd\)\$/\\1/'" : "'s/^\(ftp.*vsftpd\)\$/#\\1/'";
-exec("sed -i $state /etc/inetd.conf");
-exec("killall -HUP inetd");
 ?>

--- a/plugins/dynamix/scripts/ftpusers
+++ b/plugins/dynamix/scripts/ftpusers
@@ -4,10 +4,16 @@
 // user_config_data = pipe (|) delimited root folders for user in the format of user=/path/to/root/folder
 
 // where user config files are stored
+$config_file = "/boot/config/vsftpd.user_list";
 $user_config_dir = "/boot/config/vsftpd.user_config_dir";
 
+// make the folder if it does not exist
+exec("mkdir -p $user_config_dir");
+
+// empty the config file
+file_put_contents($config_file, "");
+
 // go through each user's configuration option
-$user_options = explode("|", $argv[1]);
 foreach(explode("|", $argv[1]) as $user_config)
 {
   // figure out what their root folder should be
@@ -26,6 +32,9 @@ foreach(explode("|", $argv[1]) as $user_config)
   {
     // save it to the config
     file_put_contents($user_config_file, "local_root=" . $user_config_root_folder . "\n");
+
+    // add the user to the list
+    file_put_contents($config_file, $user_config_parts[0] . "\n", FILE_APPEND);
   }
 }
 

--- a/plugins/dynamix/scripts/ftpusers
+++ b/plugins/dynamix/scripts/ftpusers
@@ -3,12 +3,14 @@
 // usage: ftpusers user_config_data
 // user_config_data = pipe (|) delimited root folders for user in the format of user=/path/to/root/folder
 
+// where user config files are stored
 $user_config_dir = "/boot/config/vsftpd.user_config_dir";
 
+// go through each user's configuration option
 $user_options = explode("|", $argv[1]);
-
 foreach(explode("|", $argv[1]) as $user_config)
 {
+  // figure out what their root folder should be
   $user_config_parts = explode("=", trim($user_config));
   $user_config_file = $user_config_dir . "/" . $user_config_parts[0];
   $user_config_root_folder = $user_config_parts[1];
@@ -19,8 +21,10 @@ foreach(explode("|", $argv[1]) as $user_config)
     // delete the config file
     unlink($user_config_file);
   }
+  // else if the root folder exists
   else if($user_config_root_folder !== "" && file_exists($user_config_root_folder) && is_dir($user_config_root_folder))
   {
+    // save it to the config
     file_put_contents($user_config_file, "local_root=" . $user_config_root_folder . "\n");
   }
 }

--- a/plugins/dynamix/styles/default-white.css
+++ b/plugins/dynamix/styles/default-white.css
@@ -321,3 +321,11 @@ a.bannerDismiss {float:right;cursor:pointer;text-decoration:none;margin-right:1r
 .bannerDismiss::before {content:"\e92f";font-family:Unraid;color:#e68a00;}
 a.bannerInfo {cursor:pointer;text-decoration:none;}
 .bannerInfo::before {content:"\f05a";font-family:fontAwesome;color:#e68a00;}
+
+table.ftp_permissions{white-space:nowrap}
+table.ftp_permissions thead tr:first-child td{font-size:1.1rem;text-transform:uppercase;letter-spacing:1px;background-color:#e8e8e8}
+table.ftp_permissions tr>td{text-align:left;padding-left:12px}
+table.ftp_permissions tr>td+td{padding-left:0}
+table.ftp_permissions tr.share_status_size>td{padding-left:40px}
+table.ftp_permissions tr.share_status_size>td+td{padding-left:15px}
+table.ftp_permissions tbody tr:nth-child(even){background-color:#ededed}


### PR DESCRIPTION
# What and Why

I made some changes to enable per user chroot jails for vsftpd. This is the same functionality offered by ProFTPD but since vsftpd comes with Unraid and can also do it I figured it made sense.

- You can select the root folder for each user
- Users are restricted to this folder
- You can enable/disable logging to syslog

I couldn't figure out how to test the changes to the help text because I don't know how to update the helptext.dot file.

# One More File

Along with the three files listed in this commit, the `/etc/vsftpd.conf` file needs to be edited. I couldn't find it in this repo so I am putting those details here. These three settings need to be added:

    # new code start - IMTheNachoMan
    chroot_local_user=YES
    allow_writeable_chroot=YES
    user_config_dir=/boot/config/vsftpd.user_config_dir
    # end new code - IMTheNachoMan

# How It Works

- `chroot_local_user` forces users to stay within their "home directory". 
- `user_config_dir` tells `vsftpd` where to look for per user settings

I don't have a way to spin up an Unraid VM or second box so I can't do a full thorough test but testing it on my main/only/production Unraid box worked fine.

# Screenshot

![image](https://user-images.githubusercontent.com/83817/134841564-c28e075d-e9c4-4e77-9c28-af2b6a3de0b3.png)

# Known FTP Enabled Bug

I opened a bug report about this: https://forums.unraid.net/bug-reports/stable-releases/ftp-server-in-692-still-auto-starts-on-reboot-r1588/.

I think it happens because `/etc/inetd.conf` is replaced on reboot and in the stock one the ftp line is not commented out. 

To fix it, my thought was to save some FTP enable/disable status in `/boot/config/vsftpd.cfg` and then something in `/boot/config/go` that would read it but I am not convinced that is the right approach within the Unraid ecosystem.