### PR TITLE
feat: Docker Web UI to use Docker label for icons as fallback

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -302,7 +302,7 @@ class DockerTemplates {
 			if ($ct['Url'] && !$tmp['url']) $tmp['url'] = $ct['Url'];
 			if ($ct['Icon']) $tmp['icon'] = $ct['Icon'];
 			if ( ! $communityApplications ) {
-				if (!is_file($tmp['icon']) || $reload) $tmp['icon'] = $this->getIcon($image,$name);
+				if (!is_file($tmp['icon']) || $reload) $tmp['icon'] = $this->getIcon($image,$name,$tmp['icon']);
 			}
 			if ($ct['Running']) {
 				$port = &$ct['Ports'][0];
@@ -335,9 +335,10 @@ class DockerTemplates {
 		return $info;
 	}
 
-	public function getIcon($Repository,$contName) {
+	public function getIcon($Repository,$contName,$tmpIconUrl='') {
 		global $docroot, $dockerManPaths;
 		$imgUrl = $this->getTemplateValue($Repository, 'Icon','all',$contName);
+		if (!$imgUrl) $imgUrl = $tmpIconUrl;
 		if (!$imgUrl || trim($imgUrl) == "/plugins/dynamix.docker.manager/images/question.png") return '';
 
 		$imageName = $contName ?: $name;


### PR DESCRIPTION
### Purpose for this PR
This PR aims to bring proper icon support for Docker containers not spun up
using template files. In the latest minor update to unRAID (6.10), Docker
manager now supports the use of labels for redirects to the containers' web UIs
and icons. While the former works fine, the latter simply does not work if the
containers are not spun up the 'traditional unRAID way' with templates. This
applies to both containers spun up using `docker run` and `docker-compose` with
the appropriate labels.

I found out that the reason why this is happening lies in how icons not in the
cache are retrieved. Image source links for the icons are still only read from
the template files as seen in the source code for [`getIcon`](https://github.com/limetech/webgui/blob/0a66bb862e6a190a50c1512c91600c4908345fda/plugins/dynamix.docker.manager/include/DockerClient.php#L338-L340). 

This is despite the fact that earlier on in `getAllInfo`, the `$tmp` array does
actually retrieve the right source link as declared in the Docker label when
the container is spun up using `docker run` or `docker-compose`.
[Permalink](https://github.com/limetech/webgui/blob/0a66bb862e6a190a50c1512c91600c4908345fda/plugins/dynamix.docker.manager/include/DockerClient.php#L303)


### Changes made in this PR
What I have done to go about this problem is to expand `getIcon` to take in an
additional optional parameter. This optional parameter will take in the image
source link if declared as a Docker label that gets from the Docker API in
`getAllInfo`. In `getIcon`, the variable `$imgUrl` will first check if an unRAID
template exists and takes the value if it exists. Otherwise, it will then take
the value passed into the additional optional parameter. If it is still null, it
will then take the default of the question mark.

Removing the container will also remove the icon from the cache, so there is no
worry of unhandled clutter.


### Suggestion for future change
I would suggest that `getIcon` stop parsing the template file for icons anymore
since unRAID 6.10 can do so through the Docker label `net.unraid.docker.icon`.
This may improve load time on the Docker UI page since the server would not need
to parse XML template files (it actually gets quite annoyingly long with a lot
of containers).