### PR TITLE
Replace domain for container webui with document.domain

### DIFF
--- a/plugins/dynamix.docker.manager/javascript/docker.js
+++ b/plugins/dynamix.docker.manager/javascript/docker.js
@@ -3,7 +3,12 @@ var eventURL = '/plugins/dynamix.docker.manager/include/Events.php';
 function addDockerContainerContext(container, image, template, started, paused, update, autostart, webui, shell, id, Support, Project, Registry, donateLink, ReadMe) {
   var opts = [];
   if (started && !paused) {
-    if (webui !== '' && webui != '#') opts.push({text:_('WebUI'), icon:'fa-globe', href:webui, target:'_blank'});
+    if (webui !== '' && webui != '#') {
+      var url = new URL(webui);
+      url.hostname = document.domain;
+      webui = url.toString();
+      opts.push({text:_('WebUI'), icon:'fa-globe', href:webui, target:'_blank'});
+    }
     opts.push({text:_('Console'), icon:'fa-terminal', action:function(e){e.preventDefault(); openTerminal('docker',container,shell);}});
     opts.push({divider:true});
   }


### PR DESCRIPTION
Right now the webui links all point to the IP of unRaid in the local network (e.g. `192.168.0.5`). If one uses a VPN or has a domain that points to the webui, the container links to the webui will still point to `192.168.0.5`.
This PR replaces the hostname of the URL to the webui with `document.domain`, ensuring that the URL to the container webUIs is always using the same hostname as the one the user is currently using.