### PR TITLE
Add fix to remove downloaded .vv file when used.

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/include/VMajax.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/VMajax.php
@@ -121,6 +121,7 @@ case 'domain-start-consoleRV':
 	$vvarray[] = "type=$protocol\n";
 	$vvarray[] = "host="._var($_SERVER,'HTTP_HOST')."\n" ;
 	$vvarray[] = "port=$port\n" ;
+	$vvarray[] = "delete-this-file=1\n" ;
 	if (!is_dir("/mnt/user/system/remoteviewer")) mkdir("/mnt/user/system/remoteviewer") ;
 	$vvfile = "/mnt/user/system/remoteviewer/rv"._var($_SERVER,'HTTP_HOST').".$port.vv" ;
 	file_put_contents($vvfile,$vvarray) ;
@@ -139,6 +140,7 @@ case 'domain-consoleRV':
 	$vvarray[] = "type=$protocol\n";
 	$vvarray[] = "host="._var($_SERVER,'HTTP_HOST')."\n" ;
 	$vvarray[] = "port=$port\n" ;
+	$vvarray[] = "delete-this-file=1\n" ;
 	if (!is_dir("/mnt/user/system/remoteviewer")) mkdir("/mnt/user/system/remoteviewer") ;
 	$vvfile = "/mnt/user/system/remoteviewer/rv"._var($_SERVER,'HTTP_HOST').".$port.vv" ;
 	file_put_contents($vvfile,$vvarray) ;


### PR DESCRIPTION
Remove the .vv file when remote view is used. Otherwise it is left in downloads.