### PR TITLE
CSS: set overflow-x to 'auto'

### DIFF
--- a/emhttp/plugins/dynamix/styles/default-black.css
+++ b/emhttp/plugins/dynamix/styles/default-black.css
@@ -62,7 +62,7 @@ div.title span.right{font-size:1.4rem;padding-top:2px;padding-right:10px;float:r
 div.title span img{padding-right:4px}
 div.title.shift{margin-top:-30px}
 #menu{position:absolute;top:90px;left:0;right:0;display:grid;grid-template-columns:auto max-content;z-index:101}
-.nav-tile{height:4rem;line-height:4rem;padding:0;margin:0;font-size:1.2rem;letter-spacing:1.8px;background-color:#f2f2f2;white-space:nowrap;overflow-x:scroll;overflow-y:hidden;scrollbar-width:thin}
+.nav-tile{height:4rem;line-height:4rem;padding:0;margin:0;font-size:1.2rem;letter-spacing:1.8px;background-color:#f2f2f2;white-space:nowrap;overflow-x:auto;overflow-y:hidden;scrollbar-width:thin}
 .nav-tile::-webkit-scrollbar{height:8px}
 .nav-tile.right{text-align:right}
 .nav-item,.nav-user{position:relative;display:inline-block;text-align:center;margin:0}

--- a/emhttp/plugins/dynamix/styles/default-white.css
+++ b/emhttp/plugins/dynamix/styles/default-white.css
@@ -62,7 +62,7 @@ div.title span.right{font-size:1.4rem;padding-top:2px;padding-right:10px;float:r
 div.title span img{padding-right:4px}
 div.title.shift{margin-top:-30px}
 #menu{position:absolute;top:90px;left:0;right:0;display:grid;grid-template-columns:auto max-content;z-index:101}
-.nav-tile{height:4rem;line-height:4rem;padding:0;margin:0;font-size:1.2rem;letter-spacing:1.8px;background-color:#1c1b1b;white-space:nowrap;overflow-x:scroll;overflow-y:hidden;scrollbar-width:thin}
+.nav-tile{height:4rem;line-height:4rem;padding:0;margin:0;font-size:1.2rem;letter-spacing:1.8px;background-color:#1c1b1b;white-space:nowrap;overflow-x:auto;overflow-y:hidden;scrollbar-width:thin}
 .nav-tile::-webkit-scrollbar{height:8px}
 .nav-tile.right{text-align:right}
 .nav-item,.nav-user{position:relative;display:inline-block;text-align:center;margin:0}


### PR DESCRIPTION
When overflow-x is set to 'scroll',
in some browsers, it will reserve
space for the scrollbar and will
override the background color even
when no scrollbar is necessary.