### PR TITLE
Provide target string in rc.nginx for plugin configurations

### DIFF
--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -371,6 +371,9 @@ build_locations() {
 	    add_header Cache-Control no-cache;
 	}
 	#
+	# Plugins: add custom entries to locations.conf here
+	#
+	#
 	# pass PHP scripts to FastCGI server listening on unix:/var/run/php5-fpm.sock
 	#
 	location ~ \.php$ {


### PR DESCRIPTION
Tailscale includes a built-in interface which helps users connect and configure Tailscale. This interface is provided via CGI. The Tailscale plugin for Unraid uses a PHP script to wrap the CGI interface and present it as part of the WebGUI.

Tailscale is adding functionality to the web interface, which will soon require that path information be sent with each request. The default nginx configuration does not provide this information.

This change adds a location entry to the nginx configuration that will send the path information for requests to `/plugins/tailscale/interface.php`. I have tested this change with the dev version of Tailscale and confirmed that it works correctly. Since the location block is scoped to `/plugins/tailscale/interface.php`, it will not affect any other functionality in nginx.

Normally, I would try to add the needed entry during plugin installation. However, in this case, doing so would require patching `/etc/rc.d/rc.nginx` during install, which could result in problems for either the plugin or the WebGUI when the contents of `/etc/rc.d/rc.nginx` change in the future. Therefore, I think it is better to include the configuration upstream.

Ref: dkaser/unraid-tailscale#86