### PR TITLE
Set bash shebang on scripts

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/scripts/libvirt_init
+++ b/emhttp/plugins/dynamix.vm.manager/scripts/libvirt_init
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Intialize libvirt config storage
 # Invoked by emhttp after mounting libvirt loopback but before starting libvirt.
 

--- a/etc/rc.d/rc.inet1
+++ b/etc/rc.d/rc.inet1
@@ -1,8 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 # /etc/rc.d/rc.inet1
 # This script is used to bring up the various network interfaces.
 #
 # @(#)/etc/rc.d/rc.inet1 10.2  Sun Jul 24 12:45:56 PDT 2005  (pjv)
+#
+# LimeTech - Modified for Unraid OS
 
 # Adapted by Bergware for use in unRAID - April 2016
 # - improved interface configuration

--- a/etc/rc.d/rc.inet2
+++ b/etc/rc.d/rc.inet2
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # rc.inet2	This shell script boots up the entire network system.
 #		Note, that when this script is used to also fire
@@ -11,7 +11,8 @@
 #
 # Author:	Fred N. van Kempen, <waltje@uwalt.nl.mugnet.org>
 # Modified for Slackware by Patrick Volkerding <volkerdi@slackware.com>
-
+#
+# LimeTech - Modified for Unraid OS
 
 # At this point, we are (almost) ready to talk to The World...
 

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -2,6 +2,7 @@
 # Used by nfsd, ntpd, rpc, samba, nginx, sshd, avahidaemon, show_interfaces
 #
 # bergware - updated for Unraid, June 2023
+# shellcheck shell=bash
 
 WIREGUARD="/etc/wireguard"
 NETWORK_INI="/var/local/emhttp/network.ini"

--- a/etc/rc.d/rc.local_shutdown
+++ b/etc/rc.d/rc.local_shutdown
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 #
 # /etc/rc.d/rc.local_shutdown:  Local system shutdown script.
 #
+# LimeTech - Modified for Unraid OS
 
 # Beep the motherboard speaker
 beep -r 2

--- a/etc/rc.d/rc.mcelog
+++ b/etc/rc.d/rc.mcelog
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # 
 # Startup script for mcelog
 #

--- a/etc/rc.d/rc.nfsd
+++ b/etc/rc.d/rc.nfsd
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Start/stop/restart the NFS server.
 #
 # This is an init script for the knfsd NFS daemons.
@@ -6,6 +6,8 @@
 # See exports(5) for information on /etc/exports format.
 #
 # Written for Slackware Linux by Patrick J. Volkerding <volkerdi@slackware.com>.
+#
+# LimeTech - Modified for Unraid OS
 #
 # bergware - added interface bind functionality
 

--- a/etc/rc.d/rc.ntpd
+++ b/etc/rc.d/rc.ntpd
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Start/stop/restart ntpd.
 
 # limetech - modified to initialize ntp.conf file from config

--- a/etc/rc.d/rc.php-fpm
+++ b/etc/rc.d/rc.php-fpm
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+#
+# LimeTech - Modified for Unraid OS
 
 ### BEGIN INIT INFO
 # Provides:          php-fpm

--- a/etc/rc.d/rc.rpc
+++ b/etc/rc.d/rc.rpc
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # rc.rpc:  start/stop/restart RPC daemons needed to use NFS.
 #
 # You must run these daemons in order to mount NFS partitions

--- a/etc/rc.d/rc.samba
+++ b/etc/rc.d/rc.samba
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # /etc/rc.d/rc.samba
 #

--- a/etc/rc.d/rc.serial
+++ b/etc/rc.d/rc.serial
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # /etc/rc.serial 
 #	Initializes the serial ports on your system
@@ -15,6 +16,7 @@
 # using the multiport feature; it doesn't save the multiport configuration
 # (for now).  Autosave also doesn't work for the hayes devices.  
 #
+# LimeTech - Modified for Unraid OS
 
 RCLOCKFILE=/var/lock/subsys/serial
 DIRS="/lib/modules/`uname -r`/misc /lib/modules /usr/lib/modules ."

--- a/etc/rc.d/rc.sshd
+++ b/etc/rc.d/rc.sshd
@@ -1,5 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 # Start/stop/restart the secure shell server:
+#
+# LimeTech - Modified for Unraid OS
 # bergware - added interface bind functionality
 
 CALLER="ssh"

--- a/etc/rc.d/rc.udev
+++ b/etc/rc.d/rc.udev
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This is a script to initialize udev, which populates the /dev
 # directory with device nodes, scans for devices, loads the
 # appropriate kernel modules, and configures the devices.

--- a/sbin/create_network_ini
+++ b/sbin/create_network_ini
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2005-2023, Lime Technology
 # Copyright 2012-2023, Bergware International.
 #

--- a/sbin/mount_image
+++ b/sbin/mount_image
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #Copyright 2005-2021, Lime Technology
 #License: GPLv2 only
 

--- a/sbin/vfio-pci
+++ b/sbin/vfio-pci
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # limetech - wrapper for Andre Ritchter's vfio-bind script:
 # https://github.com/andre-richter/vfio-pci-bind/blob/master/vfio-pci-bind.sh
 # additional changes by ljm42


### PR DESCRIPTION
Any shell scripts that have been modified for Unraid should have the correct `#!/bin/bash` shebang to aid with linting.