### PR TITLE
DRAFT Run FCP scan during diagnostics

### DIFF
--- a/emhttp/plugins/dynamix/scripts/diagnostics
+++ b/emhttp/plugins/dynamix/scripts/diagnostics
@@ -326,7 +326,7 @@ if ($cli) {
 // Run Fix Common Problems if present and results are old / not present
 if ( is_file("/usr/local/emhttp/plugins/fix.common.problems/scripts/scan.php") ) {
   if ( ! is_file("/tmp/fix.common.problems/errors.json") || (time() - filemtime("/tmp/fix.common.problems/errors.json")) > 86400) {
-    run("/usr/local/emhttp/plugins/fix.common.problems/scripts/scan.php",$ignore,60);
+    run("/usr/local/emhttp/plugins/fix.common.problems/scripts/scan.php diagnostics",$ignore,60);
   }
 }
 // don't anonymize system share names

--- a/emhttp/plugins/dynamix/scripts/diagnostics
+++ b/emhttp/plugins/dynamix/scripts/diagnostics
@@ -50,12 +50,12 @@ function write(...$messages){
   }
   curl_close($com);
 }
-function run($cmd, &$save=null) {
+function run($cmd, &$save=null, $timeout=30) {
   global $cli,$diag;
   // output command for display
   write($cmd);
   // execute command with timeout of 30s
-  exec("timeout -s9 30 $cmd", $save);
+  exec("timeout -s9 $timeout $cmd", $save);
   return implode("\n",$save);
 }
 
@@ -323,6 +323,12 @@ if ($cli) {
   $date = "{$split[2]}-{$split[3]}";
 }
 
+// Run Fix Common Problems if present and results are old / not present
+if ( is_file("/usr/local/emhttp/plugins/fix.common.problems/scripts/scan.php") ) {
+  if ( ! is_file("/tmp/fix.common.problems/errors.json") || (time() - filemtime("/tmp/fix.common.problems/errors.json")) > 86400) {
+    run("/usr/local/emhttp/plugins/fix.common.problems/scripts/scan.php",$ignore,60);
+  }
+}
 // don't anonymize system share names
 $vardomain    = @parse_ini_file('/boot/config/domain.cfg') ?: [];
 $vardocker    = @parse_ini_file('/boot/config/docker.cfg') ?: [];


### PR DESCRIPTION
Pending Larry approval

Runs FCP scan if one hasn't been already run within 24 hours.  (FCP by default logs issues in syslog.  If user does disable logging then FCP still logs "issues found, but not logged due to user choice)