### PR TITLE
also show USB-mirrored syslogs in GUI

### DIFF
--- a/emhttp/plugins/dynamix/Syslog.page
+++ b/emhttp/plugins/dynamix/Syslog.page
@@ -30,6 +30,19 @@ if (file_exists($cfg)) {
     foreach ($logs as $file) $select[] = mk_option(1,$file,basename($file));
     $select[] = "</select>";
   }
+  if (isset($syslog['syslog_flash']) && $logs = glob('/boot/logs/syslog*',GLOB_NOSORT)) {
+  natsort($logs);
+  if (empty($select)) {
+    $select[] = "<select onchange='showLog(this.value)'>";
+    $select[] = mk_option(1,$log,'syslog');
+    foreach ($logs as $file) $select[] = mk_option(1,$file,basename($file)."(on USB)");
+    $select[] = "</select>";
+  } else {
+    array_pop($select);
+    foreach ($logs as $file) $select[] = mk_option(1,$file,basename($file)."(on USB)");
+    $select[] = "</select>";
+  }
+  }
 }
 $select = implode($select);
 ?>


### PR DESCRIPTION
Since we already have the option to mirror the SYSLOG to USB (`Settings->Syslog Server->Mirror syslog to flash`) for post mortem (after crash/shutdown) diagnostics, I propose users should also be able to view those in the GUI (on the SYSLOG page) when such mirrored logfiles exists on the USB. This should be useful when users want to know what was going on before a system shutdown without having to manually extract the relevant mirrored SYSLOG files from the USB themselves.

**This integrates seamlessly into the already present dropdown code used for when multiple log files are present.**

only regular SYSLOG present
![grafik](https://github.com/unraid/webgui/assets/24509509/cf04675d-c138-41f7-a9c6-bdacf34aa208)

regular SYSLOG + mirrored SYSLOG present on USB
![grafik](https://github.com/unraid/webgui/assets/24509509/414caffa-3d64-4a5b-ba55-3dcd4c4ea69a)

regular SYSLOG + mirrored SYSLOG present on USB + other SYSLOGs present in server folder (i.e. from log rotation)
![grafik](https://github.com/unraid/webgui/assets/24509509/f815115c-13b9-423b-a30d-bb1d1ddfbd2e)

