### PR TITLE
Improved handling of USB-mirrored syslogs

### DIFF
--- a/emhttp/plugins/dynamix/Syslog.page
+++ b/emhttp/plugins/dynamix/Syslog.page
@@ -18,18 +18,27 @@ Tag="list"
 <?
 $zip    = htmlspecialchars(str_replace(' ','_',strtolower($var['NAME'])));
 $log    = '/var/log/syslog';
+$prev   = '/boot/logs/syslog-previous';
 $cfg    = '/boot/config/rsyslog.cfg';
 $max    = 5000;
 $select = [];
+$logs = [];
 if (file_exists($cfg)) {
   $syslog = parse_ini_file($cfg);
   if (isset($syslog['local_server']) && isset($syslog['server_folder']) && $logs = glob($syslog['server_folder'].'/syslog-*.log',GLOB_NOSORT)) {
     natsort($logs);
-    $select[] = "<select onchange='showLog(this.value)'>";
-    $select[] = mk_option(1,$log,'syslog');
-    foreach ($logs as $file) $select[] = mk_option(1,$file,basename($file));
-    $select[] = "</select>";
   }
+}
+if (file_exists($prev)) {
+  // add syslog-previous to front of logs array
+  array_unshift($logs, $prev);
+}
+if (count($logs)) {
+  // add syslog to front of logs array
+  array_unshift($logs, $log);
+  $select[] = "<select onchange='showLog(this.value)'>";
+  foreach ($logs as $file) $select[] = mk_option(1,$file,basename($file));
+  $select[] = "</select>";
 }
 $select = implode($select);
 ?>

--- a/emhttp/plugins/dynamix/Syslog.page
+++ b/emhttp/plugins/dynamix/Syslog.page
@@ -22,10 +22,10 @@ $prev   = '/boot/logs/syslog-previous';
 $cfg    = '/boot/config/rsyslog.cfg';
 $max    = 5000;
 $select = [];
-$logs = [];
+$logs   = [];
 if (file_exists($cfg)) {
   $syslog = parse_ini_file($cfg);
-  if (isset($syslog['local_server']) && isset($syslog['server_folder']) && $logs = glob($syslog['server_folder'].'/syslog-*.log',GLOB_NOSORT)) {
+  if (!empty($syslog['local_server']) && !empty($syslog['server_folder']) && $logs = glob($syslog['server_folder'].'/syslog-*.log',GLOB_NOSORT)) {
     natsort($logs);
   }
 }

--- a/emhttp/plugins/dynamix/scripts/diagnostics
+++ b/emhttp/plugins/dynamix/scripts/diagnostics
@@ -306,6 +306,36 @@ function geturls() {
   return str_replace("\n", "\r\n", $urls);
 }
 
+// anonymize individual syslog files
+function anonymize_syslog($file) {
+  global $diag, $all;
+  $max = 2*1024*1024; //=2MB
+  $log = "/$diag/logs/".basename($file);
+  run("todos <".escapeshellarg($file)." >".escapeshellarg("$log.txt"));
+  if (!$all) {
+    unset($titles,$rows);
+    run("grep -Po 'file: \K[^\"\\x27]+' ".escapeshellarg("$log.txt")." 2>/dev/null|sort|uniq", $titles);
+    run("sed -ri 's|\b\S+@\S+\.\S+\b|email@removed.com|;s|\b(username\|password)([=:])\S+\b|\\1\\2xxx|;s|(GUID: \S)\S+(\S) |\\1..\\2 |;s|(moving \"\S\|\"/mnt/user/\S).*(\S)\"|\\1..\\2\"|' ".escapeshellarg("$log.txt"));
+    run("sed -ri 's|(server: ).+(\.(my)?unraid\.net(:[0-9]+)?,)|\\1hash\\2|;s|(host: \").+(\.(my)?unraid\.net(:[0-9]+)?\")|\\1hash\\2|;s|(referrer: \"https?://).+(\.(my)?unraid\.net)|\\1hash\\2|' ".escapeshellarg("$log.txt"));
+    maskIP("$log.txt");
+    foreach ($titles as $mover) {
+      if (!$mover) continue;
+      $title = "/{$mover[0]}..".substr($mover,-1)."/...";
+      run("sed -i 's/".str_replace("/","\/",$mover)."/".str_replace("/","\/",$title)."/g' ".escapeshellarg("$log.txt")." 2>/dev/null");
+      //run("sed -ri 's|(file: [.>cr].*)[ /]$mover/.*$|\\1 file: $title|' ".escapeshellarg("$log.txt")." 2>/dev/null");
+    }
+    run("grep -n ' cache_dirs: -' ".escapeshellarg("$log.txt")." 2>/dev/null|cut -d: -f1", $rows);
+    for ($i = 0; $i < count($rows); $i += 2) for ($row = $rows[$i]+1; $row < $rows[$i+1]; $row++) run("sed -ri '$row s|(cache_dirs: \S).*(\S)|\\1..\\2|' ".escapeshellarg("$log.txt")." 2>/dev/null");
+  }
+  // replace consecutive repeated lines in syslog
+  run("awk -i inplace '{if(s!=substr(\$0,17)){if(x>0)print\"### [PREVIOUS LINE REPEATED \"x\" TIMES] ###\\r\";print;x=0}else{x++}s=substr(\$0,17)}END{if(x>0)print\"### [PREVIOUS LINE REPEATED \"x\" TIMES] ###\\r\"}' ".escapeshellarg("$log.txt"));
+  // remove SHA256 hashes
+  run("sed -ri 's/(SHA256:).+[^\s\b]/SHA256:***REMOVED***/gm' $log.txt");
+  // truncate syslog if too big
+  if (basename($file)=='syslog' && filesize($file)>=$max) run("tail -n 200 ".escapeshellarg("$log.txt")." >".escapeshellarg("$log.last200.txt"));
+  run("truncate -s '<$max' ".escapeshellarg("$log.txt"));
+}
+
 // diagnostics start
 run("mkdir -p /boot/logs");
 
@@ -612,32 +642,11 @@ foreach ($all_xml as $xml) {
 }
 
 // copy syslog information (anonymize if applicable)
-$max = 2*1024*1024; //=2MB
 foreach (glob("/var/log/syslog*") as $file) {
-  $log = "/$diag/logs/".basename($file);
-  run("todos <".escapeshellarg($file)." >".escapeshellarg("$log.txt"));
-  if (!$all) {
-    unset($titles,$rows);
-    run("grep -Po 'file: \K[^\"\\x27]+' ".escapeshellarg("$log.txt")." 2>/dev/null|sort|uniq", $titles);
-    run("sed -ri 's|\b\S+@\S+\.\S+\b|email@removed.com|;s|\b(username\|password)([=:])\S+\b|\\1\\2xxx|;s|(GUID: \S)\S+(\S) |\\1..\\2 |;s|(moving \"\S\|\"/mnt/user/\S).*(\S)\"|\\1..\\2\"|' ".escapeshellarg("$log.txt"));
-    run("sed -ri 's|(server: ).+(\.(my)?unraid\.net(:[0-9]+)?,)|\\1hash\\2|;s|(host: \").+(\.(my)?unraid\.net(:[0-9]+)?\")|\\1hash\\2|;s|(referrer: \"https?://).+(\.(my)?unraid\.net)|\\1hash\\2|' ".escapeshellarg("$log.txt"));
-    maskIP("$log.txt");
-    foreach ($titles as $mover) {
-      if (!$mover) continue;
-      $title = "/{$mover[0]}..".substr($mover,-1)."/...";
-      run("sed -i 's/".str_replace("/","\/",$mover)."/".str_replace("/","\/",$title)."/g' ".escapeshellarg("$log.txt")." 2>/dev/null");
-      //run("sed -ri 's|(file: [.>cr].*)[ /]$mover/.*$|\\1 file: $title|' ".escapeshellarg("$log.txt")." 2>/dev/null");
-    }
-    run("grep -n ' cache_dirs: -' ".escapeshellarg("$log.txt")." 2>/dev/null|cut -d: -f1", $rows);
-    for ($i = 0; $i < count($rows); $i += 2) for ($row = $rows[$i]+1; $row < $rows[$i+1]; $row++) run("sed -ri '$row s|(cache_dirs: \S).*(\S)|\\1..\\2|' ".escapeshellarg("$log.txt")." 2>/dev/null");
-  }
-  // replace consecutive repeated lines in syslog
-  run("awk -i inplace '{if(s!=substr(\$0,17)){if(x>0)print\"### [PREVIOUS LINE REPEATED \"x\" TIMES] ###\\r\";print;x=0}else{x++}s=substr(\$0,17)}END{if(x>0)print\"### [PREVIOUS LINE REPEATED \"x\" TIMES] ###\\r\"}' ".escapeshellarg("$log.txt"));
-  // remove SHA256 hashes
-  run("sed -ri 's/(SHA256:).+[^\s\b]/SHA256:***REMOVED***/gm' $log.txt");
-  // truncate syslog if too big
-  if (basename($file)=='syslog' && filesize($file)>=$max) run("tail -n 200 ".escapeshellarg("$log.txt")." >".escapeshellarg("$log.last200.txt"));
-  run("truncate -s '<$max' ".escapeshellarg("$log.txt"));
+  anonymize_syslog($file);
+}
+foreach (glob("/boot/logs/syslog-previous*") as $file) {
+  anonymize_syslog($file);
 }
 
 // copy dhcplog

--- a/etc/rc.d/rc.M
+++ b/etc/rc.d/rc.M
@@ -50,6 +50,8 @@ dmesg -s 65536 > /var/log/dmesg
 
 # Start the system logger.
 if [[ -x /etc/rc.d/rc.rsyslogd ]]; then
+  [[ -f /boot/logs/syslog-previous ]] && rm /boot/logs/syslog-previous
+  [[ -f /boot/logs/syslog ]] && mv /boot/logs/syslog /boot/logs/syslog-previous
   /etc/rc.d/rc.rsyslogd start
 fi
 


### PR DESCRIPTION
This solves three issues:
* mirrored logs are now cleaned up on each boot, rather than growing forever
* mirrored logs from the previous boot are now included in diagnostics
* mirrored logs from the previous boot are now available in the webgui on Tools -> Syslog