### PR TITLE
Add Override File support and default support for Coral TPu

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -756,6 +756,15 @@ private static $encoding = 'UTF-8';
 		$arrWhitelistGPUClassIDregex = '/^(0001|03)/';
 		$arrWhitelistAudioClassIDregex = '/^(0403)/';
 
+		# "System peripheral [0880]" "Global unichip corp. [1ac1]" "Coral Edge Tpu [089a]" -pff "Global unichip corp. [1ac1]" "Coral Edge Tpu [089a]" 
+		#                    typeid													productid
+		# file is csv typeid:productid
+		#
+		if (is_file("/boot/config/VMPCIOverride.cfg")) {
+			$arrWhiteListOverride = str_getcsv(file_get_contents("/boot/config/VMPCIOverride.cfg")) ;
+		} 
+		$arrWhiteListOverride[] = "0880:089a" ;
+
 		$arrValidPCIDevices = [];
 
 		exec("lspci -m -nn 2>/dev/null", $arrAllPCIDevices);
@@ -769,6 +778,9 @@ private static $encoding = 'UTF-8';
 					// Device blacklisted, skip device
 					$boolBlacklisted = true;
 				}
+
+				$overrideCheck = "${arrMatch['typeid']}:${arrMatch['productid']}" ;
+				if (in_array($overrideCheck,$arrWhiteListOverride) ) $boolBlacklisted = false;
 
 				$strClass = 'other';
 				if (preg_match($arrWhitelistGPUClassIDregex, $arrMatch['typeid'])) {


### PR DESCRIPTION
Add PCI Override file

# "System peripheral [0880]" "Global unichip corp. [1ac1]" "Coral Edge Tpu [089a]" -pff "Global unichip corp. [1ac1]" "Coral Edge Tpu [089a]" 
#                    typeid											productid
# file is csv typeid:productid
#

Add Coral TPu by default.