### PR TITLE
fix: account for table visibility cookies left in broken state

### DIFF
--- a/emhttp/plugins/dynamix/DashStats.page
+++ b/emhttp/plugins/dynamix/DashStats.page
@@ -1223,7 +1223,7 @@ function openClose(button) {
     } else {
       button.removeClass('fa-chevron-up fa-chevron-down').addClass('fa-chevron-up');
       tbody.mixedView(1);
-      hidden.splice(hidden.indexOf(tbody.attr('sort')));
+      hidden = hidden.filter(a => a !== tbody.attr('sort'));
     }
     $.cookie('hidden_content',hidden.join(';'),{expires:3650});
   } else {

--- a/emhttp/plugins/dynamix/DashStats.page
+++ b/emhttp/plugins/dynamix/DashStats.page
@@ -1189,6 +1189,7 @@ function showContent() {
   var hidden = $.cookie('hidden_content');
   if (hidden) {
     hidden = hidden.split(';');
+    hidden = hidden.filter(n => n);
     for (var n=0,md5; md5=hidden[n]; n++) {
       var tbody = $('div.frame tbody[sort="'+md5+'"]');
       tbody.find('.openclose').removeClass('fa-chevron-up fa-chevron-down').addClass('fa-chevron-down');
@@ -1211,6 +1212,7 @@ function setColor(l, t1, t2) {
 function openClose(button) {
   var hidden = $.cookie('hidden_content');
   hidden = hidden==null ? [] : hidden.split(';');
+  hidden = hidden==null ? [] : hidden.filter(n => n);
   if (button) {
     // show/hide single tile content
     var tbody = button.closest('tbody');
@@ -1221,7 +1223,7 @@ function openClose(button) {
     } else {
       button.removeClass('fa-chevron-up fa-chevron-down').addClass('fa-chevron-up');
       tbody.mixedView(1);
-      hidden.splice(hidden.indexOf(tbody.attr('sort')),1);
+      hidden.splice(hidden.indexOf(tbody.attr('sort')));
     }
     $.cookie('hidden_content',hidden.join(';'),{expires:3650});
   } else {


### PR DESCRIPTION
After an unexpected JS interruption or the too rapid toggling of the visibility of individual/multiple dashboard panels, the `hidden_content` cookie can be left in a broken state by the browser. This means the cookie then includes either duplicate md5 values, empties or null values (i.e. due to leading/trailing delimiters) which - at present - break that entire functionality and force the unwanted showing of all (set to hidden) dashboard panels. At present the cookie needs to be removed to regain its function.

This PR accounts for such broken cookie states. The cookie is now cleaned up (from duplicates, empties and nulls) before being rewritten every time the user toggles the visibility of an individual panel element and, as an additional safe-guard, before evaluation of which panel elements should be hidden or displayed when the dashboard is first loaded.