### PR TITLE
Fix browsers leaving dashboard visibility cookies in malformed state

### DIFF
--- a/emhttp/plugins/dynamix/DashStats.page
+++ b/emhttp/plugins/dynamix/DashStats.page
@@ -745,6 +745,28 @@ jQuery.prototype.mixedView = function(s) {
     });
   }
 }
+function sanitizeMultiCookie(cookieName, delimiter, removeDuplicates = false) {
+  // Some browser states leave multi-value cookies with nulls, empties or duplicates.
+  // This function cleans up any such cookies so that they do not break functionality.
+  try {
+    var uncleanCookie = $.cookie(cookieName);
+    if (uncleanCookie) {
+      uncleanCookie = uncleanCookie.split(delimiter);
+      var cleanCookie = uncleanCookie.filter(n => n);
+      if (removeDuplicates) { cleanCookie = [...new Set(cleanCookie)]; }
+      if (JSON.stringify(uncleanCookie) !== JSON.stringify(cleanCookie)) {
+        $.cookie(cookieName,cleanCookie.join(delimiter),{expires:3650});
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  } catch (ex) {
+    return false;
+  }
+}
 
 var ports   = [<?=implode(',',array_map('escapestring',$ports))?>];
 var cpu     = [];
@@ -1175,6 +1197,7 @@ function addProperties() {
 }
 function showContent() {
   var count = {'db-box1':$('table#db-box1 tbody').length, 'db-box2':$('table#db-box2 tbody').length, 'db-box3':$('table#db-box3 tbody').length}
+  sanitizeMultiCookie('inactive_content', ';', true);
   var inactive = $.cookie('inactive_content');
   if (inactive) {
     inactive = inactive.split(';');
@@ -1186,6 +1209,7 @@ function showContent() {
       tbody.prev().hide();
     }
   }
+  sanitizeMultiCookie('hidden_content', ';', true);
   var hidden = $.cookie('hidden_content');
   if (hidden) {
     hidden = hidden.split(';');


### PR DESCRIPTION
After an unexpected JS interruption or rapid toggling of visibility settings in the dashboard, dashboard visibility cookies such as the `hidden_content` or `inactive_content` cookies can be left in a broken state by the browser. Such broken cookies then include either unwanted duplicate md5 values, empty or null values (i.e. due to lone leading/trailing delimiters), resulting in problems.

This - at present - breaks the entire functionality of the affected cookie and results i.e. in unwanted showing/expansion of set to hidden/collapsed dashboard panels. Such broken cookies can - at present - not be recovered from, they need to be removed or expire in order for the user's dashboard visibility settings to function normally and be respected in the dashboard again.

This PR accounts for such broken cookie states. The two major dashboard visibility cookies are sanitized before the dashboard is loaded and furthermore a function is introduced which can be utilized to sanitize other such cookies prone to becoming broken.

**The problem itself can be reproduced, as an example, by setting the `hidden_content` cookie to such a broken value:**

`;;5daf3d28cea920ff31c7d2ad156f9f2d;2397947828b3f7532b5eb42f6daf5aaa;2397947828b3f7532b5eb42f6daf5aaa`
_(urldecoded for better readability)_

The motherboard and system panels should be collapsed, but both stay expanded because of the malformed cookie.

**After sanitizing the cookie with the function introduced in this PR, the cookie is repaired as follows:**

`5daf3d28cea920ff31c7d2ad156f9f2d;2397947828b3f7532b5eb42f6daf5aaa`
_(urldecoded for better readability)_

The motherboard and system panels are hidden as intended by the user.