### PR TITLE
Add option for no keymap.

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt.php
@@ -789,7 +789,7 @@
 					if ($gpu['id'] == 'virtual') {
 						$strKeyMap = '';
 						if (!empty($gpu['keymap'])) {
-							$strKeyMap = "keymap='" . $gpu['keymap'] . "'";
+							if ($gpu['keymap'] != "none")  $strKeyMap = "keymap='" . $gpu['keymap'] . "'";
 						}
 
 						$passwdstr = '';
@@ -2085,7 +2085,7 @@
 		function domain_get_vnc_keymap($domain) {
 			$tmp = $this->get_xpath($domain, '//domain/devices/graphics/@keymap', false);
 			if (!$tmp)
-				return 'en-us';
+				return 'none';
 
 			$var = $tmp[0];
 			unset($tmp);

--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -1089,6 +1089,7 @@ private static $encoding = 'UTF-8';
 
 	function getValidKeyMaps() {
 		$arrValidKeyMaps = [
+			'none' => 'No Keymap',
 			'ar' => 'Arabic (ar)',
 			'hr' => 'Croatian (hr)',
 			'cz' => 'Czech (cz)',
@@ -1413,6 +1414,7 @@ private static $encoding = 'UTF-8';
 		// preserve vnc/spice port settings
 		// unset($new['devices']['graphics']['@attributes']['port'],$new['devices']['graphics']['@attributes']['autoport']);
 		if (!$new['devices']['graphics']) unset($old['devices']['graphics']);
+		if (!isset($new['devices']['graphics']['@attributes']['keymap']) && isset($old['devices']['graphics']['@attributes']['keymap'])) unset($old['devices']['graphics']['@attributes']['keymap']) ;
 		// update parent arrays
 		if (!$old['devices']['hostdev']) unset($old['devices']['hostdev']);
 		if (!$new['devices']['hostdev']) unset($new['devices']['hostdev']);


### PR DESCRIPTION
Setting keymap to No Keymap should allow the keys to be sent directly to vm for languages without qemu keymaps.

![image](https://github.com/unraid/webgui/assets/39065407/65e8683e-8363-4b83-b9d8-f1f153f352c4)
