### PR TITLE
Set temperature thresholds for SSD devices automatically higher

### DIFF
--- a/emhttp/plugins/dynamix/DeviceInfo.page
+++ b/emhttp/plugins/dynamix/DeviceInfo.page
@@ -26,6 +26,14 @@ $events     = explode('|',$disk['smEvents'] ?? $var['smEvents'] ?? $numbers);
 $mode       = ['Disabled','Hourly','Daily','Weekly','Monthly'];
 $days       = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
 
+function setTemp(&$disk, $zone) {
+  global $display;
+  switch ($zone) {
+    case 'hot': $nvme = 'wctemp'; break;
+    case 'max': $nvme = 'cctemp'; break;
+  }
+ return _var($disk,'transport')=='nvme' ? get_nvme_info(_var($disk,'device'),$nvme) : (_var($disk,'rotational',1)==0 ? ($display[$zone]>0 ? $display[$zone]+15 : 0) : $display[$zone]);
+}
 function sanitize(&$val) {
   $data = explode('.',str_replace([' ',','],['','.'],$val));
   $last = array_pop($data);
@@ -1175,12 +1183,12 @@ _(xfs_repair status)_:
 <input type="hidden" name="smEvents" value="">
 <input type="hidden" name="smGlue"   value="<?=_var($var,'smGlue')?>">
 _(Warning disk temperature threshold)_ (&deg;<?=_var($display,'unit','C')?>):
-: <input type="number" min="0" max="300" name="hotTemp" class="narrow" value="<?=displayTemp(_var($disk,'hotTemp'))?>" placeholder="<?=displayTemp(_var($disk,'transport')=='nvme' ? get_nvme_info(_var($disk,'device'),'wctemp') : _var($display,'hot'))?>">
+: <input type="number" min="0" max="300" name="hotTemp" class="narrow" value="<?=displayTemp(_var($disk,'hotTemp'))?>" placeholder="<?=displayTemp(setTemp($disk,'hot'))?>">
 
 :info_warning_temp_help:
 
 _(Critical disk temperature threshold)_ (&deg;<?=_var($display,'unit','C')?>):
-: <input type="number" min="0" max="300" name="maxTemp" class="narrow" value="<?=displayTemp(_var($disk,'maxTemp'))?>" placeholder="<?=displayTemp(_var($disk,'transport')=='nvme' ? get_nvme_info(_var($disk,'device'),'cctemp') : _var($display,'max'))?>">
+: <input type="number" min="0" max="300" name="maxTemp" class="narrow" value="<?=displayTemp(_var($disk,'maxTemp'))?>" placeholder="<?=displayTemp(setTemp($disk,'max'))?>">
 
 :info_critical_temp_help:
 

--- a/emhttp/plugins/dynamix/include/SmartInfo.php
+++ b/emhttp/plugins/dynamix/include/SmartInfo.php
@@ -59,8 +59,8 @@ case "attributes":
   $events = explode('|',get_value($disk,'smEvents',$numbers));
   extract(parse_plugin_cfg('dynamix',true));
   [$hotNVME,$maxNVME] = _var($disk,'transport')=='nvme' ? get_nvme_info(_var($disk,'device'),'temp') : [-1,-1];
-  $hot    = _var($disk,'hotTemp',-1)>=0 ? $disk['hotTemp'] : ($hotNVME>=0 ? $hotNVME : (_var($display,'hot',-1)>=0 ? $display['hot'] : 0));
-  $max    = _var($disk,'maxTemp',-1)>=0 ? $disk['maxTemp'] : ($maxNVME>=0 ? $maxNVME : (_var($display,'max',-1)>=0 ? $display['max'] : 0));
+  $hot    = _var($disk,'hotTemp',-1)>=0 ? $disk['hotTemp'] : ($hotNVME>=0 ? $hotNVME : (_var($disk,'rotational',1)==0 ? ($display['hot']>0 ? $display['hot']+15 : 0) : $display['hot']));
+  $max    = _var($disk,'maxTemp',-1)>=0 ? $disk['maxTemp'] : ($maxNVME>=0 ? $maxNVME : (_var($disk,'rotational',1)==0 ? ($display['max']>0 ? $display['max']+15 : 0) : $display['max']));
   $top    = $_POST['top'] ?? 120;
   $empty  = true;
   exec("smartctl -n standby -A $type ".escapeshellarg("/dev/$port"),$output);

--- a/emhttp/plugins/dynamix/nchan/update_2
+++ b/emhttp/plugins/dynamix/nchan/update_2
@@ -160,8 +160,8 @@ function device_temp(&$disk, &$red, &$orange) {
   $spin = strpos(_var($disk,'color'),'blink')===false;
   $temp = _var($disk,'temp','*');
   [$hotNVME,$maxNVME] = _var($disk,'transport')=='nvme' ? get_nvme_info(_var($disk,'device'),'temp') : [-1,-1];
-  $hot  = _var($disk,'hotTemp',-1)>=0 ? $disk['hotTemp'] : ($hotNVME>=0 ? $hotNVME : (_var($display,'hot',-1)>=0 ? $display['hot'] : 0));
-  $max  = _var($disk,'maxTemp',-1)>=0 ? $disk['maxTemp'] : ($maxNVME>=0 ? $maxNVME : (_var($display,'max',-1)>=0 ? $display['max'] : 0));
+  $hot  = _var($disk,'hotTemp',-1)>=0 ? $disk['hotTemp'] : ($hotNVME>=0 ? $hotNVME : (_var($disk,'rotational',1)==0 ? ($display['hot']>0 ? $display['hot']+15 : 0) : $display['hot']));
+  $max  = _var($disk,'maxTemp',-1)>=0 ? $disk['maxTemp'] : ($maxNVME>=0 ? $maxNVME : (_var($disk,'rotational',1)==0 ? ($display['max']>0 ? $display['max']+15 : 0) : $display['max']));
   $top  = $display['top'] ?? 120;
   $heat = false; $color = 'green';
   if (exceed($temp,$max,$top)) {

--- a/emhttp/plugins/dynamix/scripts/monitor
+++ b/emhttp/plugins/dynamix/scripts/monitor
@@ -48,8 +48,8 @@ function check_temp(&$disk,$text,$info) {
   $named = no_tilde($name);
   $temp  = _var($disk,'temp','*');
   [$hotNVME,$maxNVME] = _var($disk,'transport')=='nvme' ? get_nvme_info(_var($disk,'device'),'temp') : [-1,-1];
-  $hot   = _var($disk,'hotTemp',-1)>=0 ? $disk['hotTemp'] : ($hotNVME>=0 ? $hotNVME : (_var($display,'hot',-1)>=0 ? $display['hot'] : 0));
-  $max   = _var($disk,'maxTemp',-1)>=0 ? $disk['maxTemp'] : ($maxNVME>=0 ? $maxNVME : (_var($display,'max',-1)>=0 ? $display['max'] : 0));
+  $hot   = _var($disk,'hotTemp',-1)>=0 ? $disk['hotTemp'] : ($hotNVME>=0 ? $hotNVME : (_var($disk,'rotational',1)==0 ? ($display['hot']>0 ? $display['hot']+15 : 0) : $display['hot']));
+  $max   = _var($disk,'maxTemp',-1)>=0 ? $disk['maxTemp'] : ($maxNVME>=0 ? $maxNVME : (_var($disk,'rotational',1)==0 ? ($display['max']>0 ? $display['max']+15 : 0) : $display['max']));
   $warn  = exceed($temp,$max,$top) ? 'alert' : (exceed($temp,$hot,$top) ? 'warning' : false);
   $item  = 'temp';
   $last  = $saved[$item][$named] ?? 0;

--- a/emhttp/plugins/dynamix/scripts/statuscheck
+++ b/emhttp/plugins/dynamix/scripts/statuscheck
@@ -95,8 +95,8 @@ function my_array(&$disk) {
   global $data,$display,$error0,$error1,$error2,$error3;
   $name = _var($disk,'name');
   [$hotNVME,$maxNVME] = _var($disk,'transport')=='nvme' ? get_nvme_info(_var($disk,'device'),'temp') : [-1,-1];
-  $hot  = _var($disk,'hotTemp',-1)>=0 ? $disk['hotTemp'] : ($hotNVME>=0 ? $hotNVME : (_var($display,'hot',-1)>=0 ? $display['hot'] : 0));
-  $max  = _var($disk,'maxTemp',-1)>=0 ? $disk['maxTemp'] : ($maxNVME>=0 ? $maxNVME : (_var($display,'max',-1)>=0 ? $display['max'] : 0));
+  $hot  = _var($disk,'hotTemp',-1)>=0 ? $disk['hotTemp'] : ($hotNVME>=0 ? $hotNVME : (_var($disk,'rotational',1)==0 ? ($display['hot']>0 ? $display['hot']+15 : 0) : $display['hot']));
+  $max  = _var($disk,'maxTemp',-1)>=0 ? $disk['maxTemp'] : ($maxNVME>=0 ? $maxNVME : (_var($disk,'rotational',1)==0 ? ($display['max']>0 ? $display['max']+15 : 0) : $display['max']));
   if (strpos(_var($disk,'status'),'_NP')!==false) return false;
   $temp = _var($disk,'temp');
   if ($max>0 && $temp>=$max) {


### PR DESCRIPTION
- Add 15 degrees extra for SSD devices as standard 'hot' and 'max' thresholds
- User can still overwrite defaults by setting thresholds for a specific device