### PR TITLE
Fix display of 'Accumulated power on time, hours:minutes xxxxx:yy' SMART attribute

### DIFF
--- a/emhttp/plugins/dynamix/include/SmartInfo.php
+++ b/emhttp/plugins/dynamix/include/SmartInfo.php
@@ -102,6 +102,11 @@ case "attributes":
         if (is_numeric(size($value))) duration($value);
         break;
       }
+      if (str_ends_with($name, ', hours') && str_starts_with($value, 'minutes ')) {
+        $name = substr($name, 0, -7);
+        $value = substr($value, 8);
+        if (is_numeric(size($value))) duration($value);
+      }
       echo "<tr{$color}><td>-</td><td>$name</td><td colspan='8'>$value</td></tr>";
       $empty = false;
     }


### PR DESCRIPTION
I've noticed that (at least some) SAS HDDs report their 'Power on time' SMART attribute in a way that isn't displayed coherently in the Unraid webui.

See this link for a screenshot of current state: https://forums.unraid.net/topic/147041-feature-request-additional-smart-data-for-sas-ssds/?do=findComment&comment=1320371

The data returned by smartctl is: `Accumulated power on time, hours:minutes 27979:25` which gets displayed in a misleading way as:
```
Accumulated power on time, hours            minutes 27979
```

This PR fixes this so it now displays properly as:
```
Accumulated power on time                   27979 (3y, 2m, 9d, 19h)
```
