### PR TITLE
Add 'SSD endurance remaining' SMART Attribute.

### DIFF
--- a/emhttp/plugins/dynamix/include/SmartInfo.php
+++ b/emhttp/plugins/dynamix/include/SmartInfo.php
@@ -62,6 +62,7 @@ case "attributes":
   $hot    = _var($disk,'hotTemp',-1)>=0 ? $disk['hotTemp'] : ($hotNVME>=0 ? $hotNVME : (_var($disk,'rotational',1)==0 && $display['hotssd']>=0 ? $display['hotssd'] : $display['hot']));
   $max    = _var($disk,'maxTemp',-1)>=0 ? $disk['maxTemp'] : ($maxNVME>=0 ? $maxNVME : (_var($disk,'rotational',1)==0 && $display['maxssd']>=0 ? $display['maxssd'] : $display['max']));
   $top    = $_POST['top'] ?? 120;
+  $ssd_remaining = NULL;
   $empty  = true;
   exec("smartctl -n standby -A $type ".escapeshellarg("/dev/$port"),$output);
   // remove empty rows
@@ -101,11 +102,33 @@ case "attributes":
       case 'Power on hours':
         if (is_numeric(size($value))) duration($value);
         break;
+      case 'Percentage used':
+          $ssd_remaining = 100 - str_replace('%', '', $value);
+        break;
       }
       echo "<tr{$color}><td>-</td><td>$name</td><td colspan='8'>$value</td></tr>";
       $empty = false;
     }
   }
+  if (is_null($ssd_remaining)) {
+    // Try to look up SSD's 'Percentage Used Endurance Indicator' with special command
+    exec("smartctl -n standby -l ssd $type ".escapeshellarg("/dev/$port"), $ssd_out);
+    $ssd_out = array_filter($ssd_out);
+    foreach ($ssd_out as $row) {
+      if (str_ends_with($row, 'Percentage Used Endurance Indicator')) {
+        // Probably a SATA SSD
+        $info = explode(' ', trim(preg_replace('/\s+/',' ',$row)), 6);
+        $ssd_remaining = 100 - $info[3];
+      } elseif (str_starts_with($row, 'Percentage used endurance indicator:')) {
+        // Probably a SAS SSD
+        [$name,$value] = array_map('trim',explode(':', $row));
+        $ssd_remaining = 100 - str_replace('%','',$value);
+      }
+    }    
+  }
+  if (!is_null($ssd_remaining)) {
+    echo "<tr><td>-</td><td>SSD endurance remaining</td><td colspan='8'>$ssd_remaining %</td></tr>";
+  }  
   if ($empty) echo "<tr><td colspan='10' style='text-align:center;padding-top:12px'>"._('Attributes not available')."</td></tr>";
   break;
 case "capabilities":


### PR DESCRIPTION
This PR adds a new 'SSD endurance remaining' indicator (%) to the bottom of the SMART Attributes page for NVMe/SATA/SAS SSDs.  This is useful for a quick at-a-glance indication of SSD health without requiring extra cognitive load and parsing various mfg. specific attributes.  Additionally, (most?) SAS SSDs and some SATA SSDs don't even currently display any attributes that could be used to determine this, requiring the user to resort to the command line to look it up.  More information here: https://forums.unraid.net/topic/147041-feature-request-additional-smart-data-for-sas-ssds/

For NVME SSDs, this uses the inverse of the `Percentage Used` attribute that is already reported.

For SATA and SAS SSDs, this uses the special smartctl command (`smartctl -l ssd <dev>`) that can return 'Percentage Used Endurance Indicator'.

Example for SATA SSD:
```
# smartctl -l ssd /dev/sdb
smartctl 7.4 2023-08-01 r5530 [x86_64-linux-6.1.64-Unraid] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

Device Statistics (GP Log 0x04)
Page  Offset Size        Value Flags Description
0x07  =====  =               =  ===  == Solid State Device Statistics (rev 1) ==
0x07  0x008  1              20  N--  Percentage Used Endurance Indicator
                                |||_ C monitored condition met
                                ||__ D supports DSN
                                |___ N normalized value
```

Example for SAS SSD:
```
# smartctl -l ssd /dev/sdu
smartctl 7.4 2023-08-01 r5530 [x86_64-linux-6.1.64-Unraid] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF READ SMART DATA SECTION ===
Percentage used endurance indicator: 10%
```

This command is safe to run on non-SSDs as well, it just doesn't return anything useful.

Currently I have this being displayed as 'SSD endurance remaining', but it could be renamed to 'SSD runtime remaining', 'SSD health', or something else if there is a general consensus for something better.  I've seen it represented in all three ways in various tools over the years.  Also, I believe having a '% remaining' / '% health' indicator is easier for people to process quickly than a '% used' indicator, hence displaying '100 - used' for this (matches what a lot of other tools do as well).

Note: This indicator is allowed to go negative.  I don't think this will cause any issues.  The endurance indicator is just an estimate, mainly based on mfg. warranty, but many SSDs can be used far beyond what they are warrantied for.

I have personally tested this on 5 different UnRaid boxes with a mix of different NVMe/SAS/SATA SSDs as well as some SAS/SATA HDDs.  It seems to be working properly on everything I've tested it on, although there is a possibility smartctl doesn't return proper data for some SSDs.  This is written in a way that it will just not include the new indicator if smartctl doesn't return the proper data, so it should be benign in that case.
