### PR TITLE
Display KB/MB/GB/TB written in SMART Attributes for SSDs

### DIFF
--- a/emhttp/plugins/dynamix/include/SmartInfo.php
+++ b/emhttp/plugins/dynamix/include/SmartInfo.php
@@ -38,6 +38,9 @@ function duration(&$hrs) {
   $age = date_diff($poh,$now);
   $hrs = "$hrs (".($age->y?"{$age->y}y, ":"").($age->m?"{$age->m}m, ":"").($age->d?"{$age->d}d, ":"")."{$age->h}h)";
 }
+function blocks_size(&$blks,$blk_size) {
+  $blks = "$blks (".my_scale($blks*$blk_size,$unit)." $unit)";
+}
 function append(&$ref, &$info) {
   if ($info) $ref .= ($ref ? " " : "").$info;
 }
@@ -83,8 +86,8 @@ case "attributes":
       }
       if ($info[8]=='-') $info[8] = 'Never';
       if ($info[0]==9 && is_numeric(size($info[9]))) duration($info[9]);
-      if (str_starts_with($info[1], 'Total_LBAs_')) $info[9] = "$info[9] (".my_scale($info[9] * 512, $unit)." $unit)"; // Assumes 512 byte sectors
-      if (str_ends_with($info[1], '32MiB')) $info[9] = "$info[9] (".my_scale($info[9] * 32*1024*1024, $unit)." $unit)";
+      if (str_starts_with($info[1], 'Total_LBAs_')) blocks_size($info[9],512); // Assumes 512 byte sectors
+      if (str_ends_with($info[1], '_32MiB')) blocks_size($info[9],32*1024*1024);
       echo "<tr{$color}>".implode('',array_map('normalize', $info))."</tr>";
       $empty = false;
     }

--- a/emhttp/plugins/dynamix/include/SmartInfo.php
+++ b/emhttp/plugins/dynamix/include/SmartInfo.php
@@ -38,16 +38,6 @@ function duration(&$hrs) {
   $age = date_diff($poh,$now);
   $hrs = "$hrs (".($age->y?"{$age->y}y, ":"").($age->m?"{$age->m}m, ":"").($age->d?"{$age->d}d, ":"")."{$age->h}h)";
 }
-function fmt_bytes($bytes) {
-  $kb = $bytes / 1000;
-  $mb = $kb / 1000;
-  $gb = $mb / 1000;
-  $tb = $gb / 1000;
-  if ($mb < 1) return "".round($kb,1)." KB";
-  elseif ($gb < 1) return "".round($mb,1)." MB";
-  elseif ($tb < 1) return "".round($gb,1)." GB";
-  else return "".round($tb,1)." TB";
-}
 function append(&$ref, &$info) {
   if ($info) $ref .= ($ref ? " " : "").$info;
 }
@@ -93,8 +83,8 @@ case "attributes":
       }
       if ($info[8]=='-') $info[8] = 'Never';
       if ($info[0]==9 && is_numeric(size($info[9]))) duration($info[9]);
-      if (str_starts_with($info[1], 'Total_LBAs_')) $info[9] = "$info[9] (".fmt_bytes($info[9] * 512).")"; // Assumes 512 byte sectors      
-      if (str_ends_with($info[1], '32MiB')) $info[9] = "$info[9] (".fmt_bytes($info[9] * 32*1024*1024).")";
+      if (str_starts_with($info[1], 'Total_LBAs_')) $info[9] = "$info[9] (".my_scale($info[9] * 512, $unit)." $unit)"; // Assumes 512 byte sectors
+      if (str_ends_with($info[1], '32MiB')) $info[9] = "$info[9] (".my_scale($info[9] * 32*1024*1024, $unit)." $unit)";
       echo "<tr{$color}>".implode('',array_map('normalize', $info))."</tr>";
       $empty = false;
     }

--- a/emhttp/plugins/dynamix/include/SmartInfo.php
+++ b/emhttp/plugins/dynamix/include/SmartInfo.php
@@ -38,6 +38,16 @@ function duration(&$hrs) {
   $age = date_diff($poh,$now);
   $hrs = "$hrs (".($age->y?"{$age->y}y, ":"").($age->m?"{$age->m}m, ":"").($age->d?"{$age->d}d, ":"")."{$age->h}h)";
 }
+function fmt_bytes($bytes) {
+  $kb = $bytes / 1000;
+  $mb = $kb / 1000;
+  $gb = $mb / 1000;
+  $tb = $gb / 1000;
+  if ($mb < 1) return "".round($kb,1)." KB";
+  elseif ($gb < 1) return "".round($mb,1)." MB";
+  elseif ($tb < 1) return "".round($gb,1)." GB";
+  else return "".round($tb,1)." TB";
+}
 function append(&$ref, &$info) {
   if ($info) $ref .= ($ref ? " " : "").$info;
 }
@@ -83,6 +93,8 @@ case "attributes":
       }
       if ($info[8]=='-') $info[8] = 'Never';
       if ($info[0]==9 && is_numeric(size($info[9]))) duration($info[9]);
+      if (str_starts_with($info[1], 'Total_LBAs_')) $info[9] = "$info[9] (".fmt_bytes($info[9] * 512).")"; // Assumes 512 byte sectors      
+      if (str_ends_with($info[1], '32MiB')) $info[9] = "$info[9] (".fmt_bytes($info[9] * 32*1024*1024).")";
       echo "<tr{$color}>".implode('',array_map('normalize', $info))."</tr>";
       $empty = false;
     }


### PR DESCRIPTION
Many SSDs report how many bytes have been written to and/or read from the flash using some combination of:
 * Total_LBAs_Written
 * Total_LBAs_Read
 * Host_Writes_32MiB
 * Host_Reads_32MiB
 * TLC_Writes_32MiB

The raw value is a bit hard to grok at a glance, so this PR adds in the calculated KB/MB/GB/TB values (similar to how Power on hours is modified to show years/months/days).

Before:
```
241 | Total lbas written | 0x0032 | 099 | 099 | 000 | Old age | Always | Never | 86530637427
...
241 | Host writes 32mib | 0x0000 | 100 | 100 | 000 | Old age | Offline | Never | 18546
242 | Host reads 32mib | 0x0000 | 100 | 100 | 000 | Old age | Offline | Never | 9189
245 | TLC writes 32mib | 0x0000 | 100 | 100 | 000 | Old age | Offline | Never | 12764
```

After:
```
241 | Total lbas written | 0x0032 | 099 | 099 | 000 | Old age | Always | Never | 86530637427 (44.3 TB)
...
241 | Host writes 32mib | 0x0000 | 100 | 100 | 000 | Old age | Offline | Never | 18546 (622 GB)
242 | Host reads 32mib | 0x0000 | 100 | 100 | 000 | Old age | Offline | Never | 9189 (308 GB)
245 | TLC writes 32mib | 0x0000 | 100 | 100 | 000 | Old age | Offline | Never | 12764 (428 GB)
```

Note:  This assumes an LBA is 512 bytes, which is true for most SSDs.  There might be some out there, however, that use a different size LBA.  Maybe it should be looked up via the general SMART values?