### PR TITLE
6.12 Fix for downgrade

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -966,6 +966,16 @@ private static $encoding = 'UTF-8';
 		return $arrValidMachineTypes;
 	}
 
+	function ValidateMachineType($machinetype) {
+		$machinetypes=getValidMachineTypes();
+		$type = substr($machinetype,0,strpos($machinetype,'-',3));
+		foreach($machinetypes as $machinetypekey => $machinedetails){
+			$check_type = substr($machinetypekey,0,strlen($type));
+			if ($check_type == $type) break;
+		}
+		return($machinetypekey) ;	
+	}	
+
 	function getLatestMachineType($strType = 'i440fx') {
 		$arrMachineTypes = getValidMachineTypes();
 

--- a/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -410,6 +410,12 @@
 		</blockquote>
 	</div>
 
+	<?
+	if (!isset($arrValidMachineTypes[$arrConfig['domain']['machine']]))  {
+		$arrConfig['domain']['machine'] = ValidateMachineType($arrConfig['domain']['machine']);
+	}
+	?>
+	
 	<table>
 		<tr class="advanced">
 			<td>_(Machine)_:</td>


### PR DESCRIPTION
When downgrading if the VM template has been updated to the latest QEMU machine type it will not be found. It will default to i440fx which can create an issue if the machine was Q35.

This PR finds latest current version for a given machine type.