### PR TITLE
Add syslog filename support

### DIFF
--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -1493,12 +1493,21 @@ This will increase write performance but might possibly decrease read performanc
 Let the server act as a central syslog server and collect syslog messages from other systems.
 The server can listen on UDP, TCP or both with a selectable port number.
 
-Syslog information is stored per IP address. That is every system gets its own syslog file.
+Syslog information is stored either per IP address or per hostname. That is every system gets its own syslog file.
 :end
 
 :syslog_local_folder_help:
 Select the share folder where the syslogs will be stored.
 It is recommended that you use a share located on the cache drive to prevent array disk spinups.
+:end
+
+:syslog_remote_system_identifier_help:
+Select the identifier for the remote system (used in the logfile name). 
+
+* "IP Address" uses the IP address (IPv4 or IPv6) of the sending system.
+* "Hostname (from syslog message)" uses the hostname included in each syslog message.
+* "Hostname (from DNS reverse lookup)" performs a DNS reverse lookup for the sending IP and uses the result.
+
 :end
 
 :syslog_local_rotation_help:

--- a/emhttp/plugins/dynamix/SyslogSettings.page
+++ b/emhttp/plugins/dynamix/SyslogSettings.page
@@ -108,6 +108,15 @@ _(Local syslog folder)_:
 
 :syslog_local_folder_help:
 
+_(System identifier for logfile name)_:
+: <select name="server_filename">
+  <?=mk_option($syslog['server_filename'], "syslog-%FROMHOST-IP%.log", _("IP Address"))?>
+  <?=mk_option($syslog['server_filename'], "syslog-%HOSTNAME%.log", _("Hostname (from syslog message)"))?>
+  <?=mk_option($syslog['server_filename'], "syslog-%FROMHOST%.log", _("Hostname (from DNS reverse lookup)"))?>
+  </select>
+
+:syslog_remote_system_identifier_help:
+
 _(Local syslog rotation)_:
 : <select name="log_rotation" onchange="logOptions(this.value,'slow')">
   <?=mk_option(_var($syslog,'log_rotation'), "", _("Disabled"))?>
@@ -146,7 +155,7 @@ _(Local syslog number of files)_:
 </div>
 
 _(Remote syslog server)_:
-: <span class="span"><input type="text" name="remote_server" class="narrow" value="<?=_var($syslog,'remote_server')?>" maxlength="23" placeholder="_(name or ip address)_"></span>
+: <span class="span"><input type="text" name="remote_server" class="narrow" value="<?=_var($syslog,'remote_server')?>" maxlength="50" placeholder="_(name or ip address)_"></span>
   <select name="remote_protocol" class="narrow">
   <?=mk_option(_var($syslog,'remote_protocol'), "udp", _("UDP"))?>
   <?=mk_option(_var($syslog,'remote_protocol'), "tcp", _("TCP"))?>

--- a/emhttp/plugins/dynamix/scripts/rsyslog_config
+++ b/emhttp/plugins/dynamix/scripts/rsyslog_config
@@ -35,7 +35,7 @@ if [[ -n $local_server ]]; then
     sed -ri "\$a\\\$InputUDPServerBindRuleset remote\n\\\$UDPServerRun ${server_port:-514}" $ETC
     [[ $server_protocol == udp ]] && sed -ri 's/^(\$ModLoad imtcp)/#\1/;/^\$InputTCPServerBindRuleset remote$/d;/^\$InputTCPServerRun [0-9]+$/d' $ETC
   fi
-  sed -ri "/^\\\$template remote,.*$/d;/^#\\\$UDPServerRun [0-9]+.*$/a\\\$template remote,\"${server_folder:-/mnt/user/system}/syslog-%FROMHOST-IP%.log\"" $ETC
+  sed -ri "/^\\\$template remote,.*$/d;/^#\\\$UDPServerRun [0-9]+.*$/a\\\$template remote,\"${server_folder:-/mnt/user/system}/${server_filename:-syslog-%FROMHOST-IP%.log}\"" $ETC
 else
   sed -ri '/^\$RuleSet remote$/d;/^\$FileOwner nobody$/d;/^\$FileGroup users$/d;/^\$FileCreateMode 06[46][46]$/d;/^\$IncludeConfig \/etc\/rsyslog\.d\/\*\.conf # remote$/d;/^\*\.\* \?remote$/d;/^\$template remote,".*"$/d;/^\$Input(TCP|UDP)ServerBindRuleset remote$/d;/^\$(InputTCP|UDP)ServerRun [0-9]+$/d;s/^#?\$(ModLoad imtcp|ModLoad imudp)/#\$\1/' $ETC
 fi


### PR DESCRIPTION
I've tried using the built-in Syslog server in UnRAID and found two issues: 

A) the HTML input field for the syslog server is limited to 23 characters, my hostname is longer. I increased it to 50 and it works fine.

B) as stated [on the forums](https://forums.unraid.net/topic/150195-unraid-syslog-server-use-device-name-for-filename-instead-of-ip/), I don't like how UnRAID adds the client's IP address to the syslog file name. 

Some clients may switch between IPv4 and IPv6, or they have IPv6 privacy extensions, or they switch between different IPv6 networks. All of which will result in tons of different logfiles for each client. 

To work around this issue, I added a new config field that allows people to enter a template for the syslog file name instead of hardcoding it to `syslog-%FROMHOST-IP%.log`. By default, it still uses this path so nothing should change for existing configurations - but if needed, it can now be customized to something like `syslog-%HOSTNAME%.log` to use the host name sent in each syslog message for the filename instead.