### PR TITLE
Backport: Docker: fix WG routes added to the correct interface

### DIFF
--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -183,11 +183,12 @@ add_route(){
   local CT=($(docker inspect --format='{{.State.Pid}} {{.NetworkSettings.Networks}}' $1))
   local PID=${CT[0]}
   local NET=${CT[1]#*[}
-  if [[ $PID -gt 0 && ${NET%%:*} == br0 ]]; then
+  local LAN=${NET%:*}
+  if [[ $PID -gt 0 && "eth0 br0 bond0" =~ $LAN ]]; then
     local THISIP=$(sed -n '/^\[eth0\]$/,/^TYPE/p' $INI|grep -Pom1 '^IPADDR:0="\K[^"]+')
     for CFG in /etc/wireguard/wg*.cfg ; do
       local NETWORK=$(grep -Pom1 '^Network:0="\K[^"]+' $CFG)
-      [[ -n $NETWORK ]] && nsenter -n -t $PID ip -4 route add $NETWORK via $THISIP dev br0 2>/dev/null
+      [[ -n $NETWORK ]] && nsenter -n -t $PID ip -4 route add $NETWORK via $THISIP dev $LAN 2>/dev/null
     done
   fi
 }


### PR DESCRIPTION
(br0 or eth0 or bond0)