### PR TITLE
Fixes for QCOW2 images

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/include/VMMachines.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/VMMachines.php
@@ -70,7 +70,7 @@ foreach ($vms as $vm) {
   if (($diskcnt = $lv->get_disk_count($res)) > 0) {
     $disks = $diskcnt.' / '.$lv->get_disk_capacity($res);
     $fstype = $lv->get_disk_fstype($res);
-    $diskdesc = 'Current physical size: '.$lv->get_disk_capacity($res, true)."\nDefault snapshot type:$fstype";
+    $diskdesc = 'Current physical size: '.$lv->get_disk_capacity($res, true)."\nDefault snapshot type: $fstype";
   }
   $arrValidDiskBuses = getValidDiskBuses();
   $vmrcport = $lv->domain_get_vnc_port($res);

--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt.php
@@ -200,7 +200,8 @@
 
 					$this->set_folder_nodatacow($path_parts['dirname']);
 
-					$strImgPath = $strImgFolder;
+					$strExt = ($disk['driver'] == 'raw') ? 'img' : $disk['driver'];
+					$strImgPath = $path_parts['dirname'] . '/vdisk' . $diskid . '.' . $strExt;
 				}
 
 

--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -1287,7 +1287,6 @@ private static $encoding = 'UTF-8';
 				'new' => $strPath,
 				'size' => '',
 				'driver' => $disk['type'],
-				'driver' => 'raw',
 				'dev' => $disk['device'],
 				'bus' => $disk['bus'],
 				'boot' => $disk['boot order'],

--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -1278,9 +1278,8 @@ private static $encoding = 'UTF-8';
 				!file_exists($domain_cfg['DOMAINDIR']) ||
 				!is_file($strPath) ||
 				strpos($domain_cfg['DOMAINDIR'], dirname(dirname($strPath))) === false ||
-				basename($strPath) != 'vdisk'.($i+1).'.img') {
-
-				$default_option = 'manual';
+				basename($strPath) != 'vdisk'.($i+1).'.img' || basename($strPath) != 'vdisk'.($i+1).'.qcow2') {
+				if (($disk['type'] == "qcow2" && (basename($strPath) == 'vdisk'.($i+1).'.qcow2')) || ($disk['type'] == "raw" && (basename($strPath) == 'vdisk'.($i+1).'.img'))) $default_option = "auto"; else $default_option = 'manual';
 			}
 
 			$arrDisks[] = [

--- a/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -706,7 +706,7 @@
 									basename($arrDisk['new']) != 'vdisk'.($i+1).'.img') {
 									$default_option = 'manual';
 								}
-								if (file_exists(dirname(dirname($arrDisk['new'])).'/'.$arrConfig['domain']['name'].'/vdisk'.($i+1).'.img') || file_exists(dirname(dirname($arrDisk['new'])).'/'.$arrConfig['domain']['name'].'/vdisk'.($i+1).'.qcow2')) {
+								if (file_exists(dirname(dirname($arrDisk['new'])).'/'.$arrConfig['domain']['name'].'/vdisk'.($i+1).'.img')) {
 									// hide all the disks because the auto disk already has been created
 									$boolShowAllDisks = false;
 								}
@@ -777,7 +777,7 @@
 			<tr class="advanced disk_file_options">
 				<td>_(vDisk Type)_:</td>
 				<td>
-					<select name="disk[<?=$i?>][driver]" class="narrow" title="_(type of storage image)_" onchange="updatefileext()">
+					<select name="disk[<?=$i?>][driver]" class="disk_driver narrow" title="_(type of storage image)_">
 					<?mk_dropdown_options($arrValidDiskDrivers, $arrDisk['driver']);?>
 					</select>
 				</td>
@@ -921,7 +921,7 @@
 			<tr class="advanced disk_file_options">
 				<td>_(vDisk Type)_:</td>
 				<td>
-					<select name="disk[{{INDEX}}][driver]" class="narrow" title="_(type of storage image)_">
+					<select name="disk[{{INDEX}}][driver]" class="disk_driver narrow" title="_(type of storage image)_">
 					<?mk_dropdown_options($arrValidDiskDrivers, '');?>
 					</select>
 				</td>
@@ -1884,6 +1884,9 @@ $(function() {
 			var $disk_input = $table.find('.disk');
 			var $disk_preview = $table.find('.disk_preview');
 			var $disk_serial = $table.find('.disk_serial');
+			var $disk_driver = $table.find('.disk_driver').val();
+			var $disk_ext = "img";
+			//if ($disk_driver == "raw") $disk_ext = "img"; else $disk_ext = $disk_driver;
 
 			if (disk_select == 'manual') {
 
@@ -1912,7 +1915,7 @@ $(function() {
 			} else if (disk_select !== '') {
 
 				// Auto disk
-				var auto_disk_path = domaindir + '/vdisk' + (index+1) + '.img';
+				var auto_disk_path = domaindir + '/vdisk' + (index+1) + '.' + $disk_ext;
 				$disk_preview.html(auto_disk_path);
 				$disk_input.fadeOut('fast', function() {
 					$disk_preview.fadeIn('fast');
@@ -2041,6 +2044,10 @@ $(function() {
 	});
 
 	$("#vmform").on("change", ".disk_select", function changeDiskSelectEvent() {
+		regenerateDiskPreview($(this).closest('table').data('index'));
+	});
+
+	$("#vmform").on("change", ".disk_driver", function changeDiskSelectEvent() {
 		regenerateDiskPreview($(this).closest('table').data('index'));
 	});
 

--- a/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -706,7 +706,7 @@
 									basename($arrDisk['new']) != 'vdisk'.($i+1).'.img') {
 									$default_option = 'manual';
 								}
-								if (file_exists(dirname(dirname($arrDisk['new'])).'/'.$arrConfig['domain']['name'].'/vdisk'.($i+1).'.img')) {
+								if (file_exists(dirname(dirname($arrDisk['new'])).'/'.$arrConfig['domain']['name'].'/vdisk'.($i+1).'.img') || file_exists(dirname(dirname($arrDisk['new'])).'/'.$arrConfig['domain']['name'].'/vdisk'.($i+1).'.qcow2')) {
 									// hide all the disks because the auto disk already has been created
 									$boolShowAllDisks = false;
 								}
@@ -777,7 +777,7 @@
 			<tr class="advanced disk_file_options">
 				<td>_(vDisk Type)_:</td>
 				<td>
-					<select name="disk[<?=$i?>][driver]" class="narrow" title="_(type of storage image)_">
+					<select name="disk[<?=$i?>][driver]" class="narrow" title="_(type of storage image)_" onchange="updatefileext()">
 					<?mk_dropdown_options($arrValidDiskDrivers, $arrDisk['driver']);?>
 					</select>
 				</td>

--- a/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -702,11 +702,12 @@
 
 							if (!empty($arrDisk['new'])) {
 								if (strpos($domain_cfg['DOMAINDIR'], dirname(dirname($arrDisk['new']))) === false ||
-									basename(dirname($arrDisk['new'])) != $arrConfig['domain']['name'] ||
-									basename($arrDisk['new']) != 'vdisk'.($i+1).'.img') {
+									basename(dirname($arrDisk['new'])) != $arrConfig['domain']['name'] || (
+									basename($arrDisk['new']) != 'vdisk'.($i+1).'.img') && basename($arrDisk['new']) != 'vdisk'.($i+1).'.qcow2') {
+									if ($arrDisk['driver'] == "qcow2" && (basename($arrDisk['new']) == 'vdisk'.($i+1).'.qcow2')) $default_option = "auto"; else	
 									$default_option = 'manual';
 								}
-								if (file_exists(dirname(dirname($arrDisk['new'])).'/'.$arrConfig['domain']['name'].'/vdisk'.($i+1).'.img')) {
+								if (file_exists(dirname(dirname($arrDisk['new'])).'/'.$arrConfig['domain']['name'].'/vdisk'.($i+1).'.img') || file_exists(dirname(dirname($arrDisk['new'])).'/'.$arrConfig['domain']['name'].'/vdisk'.($i+1).'.qcow2')) {
 									// hide all the disks because the auto disk already has been created
 									$boolShowAllDisks = false;
 								}
@@ -1886,7 +1887,8 @@ $(function() {
 			var $disk_serial = $table.find('.disk_serial');
 			var $disk_driver = $table.find('.disk_driver').val();
 			var $disk_ext = "img";
-			//if ($disk_driver == "raw") $disk_ext = "img"; else $disk_ext = $disk_driver;
+			if ($disk_driver == "raw") $disk_ext = "img"; 
+				else if(disk_select != 'manual') $disk_ext = $disk_driver;
 
 			if (disk_select == 'manual') {
 


### PR DESCRIPTION
Fix to not set type to raw on update.

New vdisks with type qcow2 will be created as .qcow2

If a qcow2 disk is set with a .img file name it will show as manual in the gui.

![image](https://github.com/unraid/webgui/assets/39065407/efaecd11-a195-42c9-bb1e-07129d477c8d)
