### PR TITLE
Backport: Allow CA to override the "DONE" button appearing during multi installs / updates

### DIFF
--- a/emhttp/plugins/dynamix/include/DefaultPageLayout.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout.php
@@ -383,6 +383,12 @@ function openDone(data) {
   if (data == '_DONE_') {
     $('div.spinner.fixed').hide();
     $('button.confirm').text("<?=_('Done')?>").prop('disabled',false).show();
+    if ( typeof ca_done_override !== 'undefined' ) {
+      if (ca_done_override == true) {
+        $("button.confirm").trigger("click");
+        ca_done_override = false;
+      }
+    }
     return true;
   }
   return false;


### PR DESCRIPTION
Override it (ie: automatically close the window) so that CA can carry on with installing / updating plugins without waiting for user intervention