### PR TITLE
Don't save state of help button from page to page

### DIFF
--- a/emhttp/plugins/dynamix/HelpButton.page
+++ b/emhttp/plugins/dynamix/HelpButton.page
@@ -19,10 +19,8 @@ Code="e934"
 function HelpButton() {
   if ($('.nav-item.HelpButton').toggleClass('active').hasClass('active')) {
     $('.inline_help').show('slow');
-    $.cookie('help','help');
   } else {
     $('.inline_help').hide('slow');
-    $.removeCookie('help');
   }
 }
 </script>

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout.php
@@ -581,7 +581,6 @@ function flashReport() {
 $(function() {
   var tab = $.cookie('one')||$.cookie('tab')||'tab1';
   if (tab=='tab0') tab = 'tab'+$('input[name$="tabs"]').length; else if ($('#'+tab).length==0) {initab(); tab = 'tab1';}
-  if ($.cookie('help')=='help') {$('.inline_help').show(); $('.nav-item.HelpButton').addClass('active');}
   $('#'+tab).attr('checked', true);
   updateTime();
   $.jGrowl.defaults.closeTemplate = '<i class="fa fa-close"></i>';


### PR DESCRIPTION
Pet peeve that if a user clicks help then it stays selected from page to page.  Make the user instead reselect help as they navigate

We still get users posting "How do I get rid of the blue boxes" ~ once per month

Up to Larry 