### PR TITLE
Add SSD flag for vdisks.

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt.php
@@ -261,6 +261,9 @@
 					if (!empty($disk['boot'])) {
 						$arrReturn['boot'] = $disk['boot'];
 					}
+					if (!empty($disk['rotation'])) {
+						$arrReturn['rotation'] = $disk['rotation'];
+					}
 					if (!empty($disk['serial'])) {
 						$arrReturn['serial'] = $disk['serial'];
 					}
@@ -687,13 +690,18 @@
 
 						if ($disk["serial"] != "") $serial = "<serial>".$disk["serial"]."</serial>" ; else $serial = "" ;
 
+						$rotation_rate = "";
+						if ($disk['bus'] == "scsi" || $disk['bus'] == "sata" || $disk['bus'] == "ide" ) {
+							if ($disk['rotation']) $rotation_rate = " rotation_rate='1' ";
+						}
+
 						if ($strDevType == 'file' || $strDevType == 'block') {
 							$strSourceType = ($strDevType == 'file' ? 'file' : 'dev');
 
 							$diskstr .= "<disk type='" . $strDevType . "' device='disk'>
 											<driver name='qemu' type='" . $disk['driver'] . "' cache='writeback'/>
 											<source " . $strSourceType . "='" . htmlspecialchars($disk['image'], ENT_QUOTES | ENT_XML1) . "'/>
-											<target bus='" . $disk['bus'] . "' dev='" . $disk['dev'] . "'/>
+											<target bus='" . $disk['bus'] . "' dev='" . $disk['dev'] . "' $rotation_rate />
 											$bootorder
 											$readonly
 											$serial
@@ -1307,6 +1315,7 @@
 				if ($tmp) {
 					$tmp['bus'] = $disk->target->attributes()->bus->__toString();
 					$tmp["boot order"] = $disk->boot->attributes()->order ?? "";
+					$tmp["rotation"] = $disk->target->attributes()->rotation_rate ?? "0";
 					$tmp['serial'] = $disk->serial ;
 
 					// Libvirt reports 0 bytes for raw disk images that haven't been
@@ -1335,6 +1344,7 @@
 						'physical' => '-',
 						'bus' =>  $disk->target->attributes()->bus->__toString(),
 						'boot order' => $disk->boot->attributes()->order ,
+						'rotation' => $disk->target->attributes()->rotation_rate ?? "0",
 						'serial' => $disk->serial
 					];
 				}
@@ -2365,6 +2375,7 @@
 				foreach ($objNodes as $objNode) {
 					$dom  = $xpath->query('source/address/@domain', $objNode)->Item(0)->nodeValue;
 					$bus  = $xpath->query('source/address/@bus', $objNode)->Item(0)->nodeValue;
+					$rotation  = $xpath->query('target/address/@rotation_rate', $objNode)->Item(0)->nodeValue;
 					$slot = $xpath->query('source/address/@slot', $objNode)->Item(0)->nodeValue;
 					$func = $xpath->query('source/address/@function', $objNode)->Item(0)->nodeValue;
 					$rom = $xpath->query('rom/@file', $objNode);
@@ -2388,6 +2399,7 @@
 						'product' => $tmp2['product_name'],
 						'product_id' => $tmp2['product_id'],
 						'boot' => $boot,
+						'rotation' => $rotation,
 						'rom' => $rom,
 						'guest' => $guest
 					];

--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -1289,6 +1289,7 @@ private static $encoding = 'UTF-8';
 				'dev' => $disk['device'],
 				'bus' => $disk['bus'],
 				'boot' => $disk['boot order'],
+				'rotation' => $disk['rotation'],
 				'serial' => $disk['serial'],
 				'select' => $default_option
 			];
@@ -1300,7 +1301,8 @@ private static $encoding = 'UTF-8';
 				'driver' => 'raw',
 				'dev' => 'hda',
 				'select' => '',
-				'bus' => 'virtio'
+				'bus' => 'virtio',
+				'rotation' => "0"
 			];
 		}
 
@@ -2521,11 +2523,7 @@ function addtemplatexml($post) {
 			'overrides' => $usertemplate
 		];
 		file_put_contents($templateslocation,json_encode($savedtemplates,JSON_PRETTY_PRINT));
-			// Fire off the vnc/spice popup if available
-			$reply = ['success' => true];
-
-		#} else {
-		#	$reply = ['error' => $lv->get_last_error()];
+		$reply = ['success' => true];
 		
 	return $reply;
 }

--- a/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -303,7 +303,6 @@
 	}
 
 	if (strpos($arrConfig['template']['name'],"User-") !== false) $arrConfig['template']['name'] = str_replace("User-","",$arrConfig['template']['name']);
-	#var_dump($arrConfig);
 ?>
 
 <link rel="stylesheet" href="<?autov('/plugins/dynamix.vm.manager/scripts/codemirror/lib/codemirror.css')?>">
@@ -805,11 +804,14 @@
 			<tr class="advanced disk_bus_options">
 				<td>_(vDisk Bus)_:</td>
 				<td>
-					<select name="disk[<?=$i?>][bus]" class="disk_bus narrow">
+					<select name="disk[<?=$i?>][bus]" class="disk_bus narrow" onchange="BusChange(this)">
 					<?mk_dropdown_options($arrValidDiskBuses, $arrDisk['bus']);?>
 					</select>
 				_(Boot Order)_:
 				<input type="number" size="5" maxlength="5" id="disk[<?=$i?>][boot]" class="narrow bootorder" style="width: 50px;" name="disk[<?=$i?>][boot]"   title="_(Boot order)_"  value="<?=$arrDisk['boot']?>" >
+				<? if ($arrDisk['bus'] == "virtio" || $arrDisk['bus'] == "usb") $ssddisabled = "hidden "; else $ssddisabled = " ";?>
+				<span id="disk[<?=$i?>][rotatetext]" <?=$ssddisabled?>>_(SSD)_:</span>
+				<input type="checkbox"  id="disk[<?=$i?>][rotation]" class="narrow rotation" onchange="updateSSDCheck(this)"style="width: 50px;" name="disk[<?=$i?>][rotation]"  <?=$ssddisabled ?> <?=$arrDisk['rotation'] ? "checked ":"";?>  title="_(Set SDD flag)_"  value="<?=$arrDisk['rotation']?>" >
 				</td>
 			</tr>
 			<tr class="advanced disk_bus_options">
@@ -855,6 +857,11 @@
 			<p class="advanced">
 				<b>vDisk Boot Order</b><br>
 				Specify the order the devices are used for booting.
+			</p>
+
+			<p class="advanced">
+				<b>vDisk SSD Flag</b><br>
+				Specify the vdisk shows as SSD within the guest, only supported on SCSI, SATA and IDE bus types.
 			</p>
 
 			<p class="advanced">
@@ -949,12 +956,14 @@
 			<tr class="advanced disk_bus_options">
 				<td>_(vDisk Bus)_:</td>
 				<td>
-					<select name="disk[{{INDEX}}][bus]" class="disk_bus narrow">
+					<select name="disk[{{INDEX}}][bus]" class="disk_bus narrow" onchange="BusChange(this)">
 					<?mk_dropdown_options($arrValidDiskBuses, '');?>
 					</select>
 
 				_(Boot Order)_:
 				<input type="number" size="5" maxlength="5" id="disk[{{INDEX}}][boot]" class="narrow bootorder" style="width: 50px;" name="disk[{{INDEX}}][boot]"   title="_(Boot order)_"  value="" >
+				<span id="disk[{{INDEX}}][rotatetext]" hidden>_(SSD)_:</span>
+				<input type="checkbox"  id="disk[{{INDEX}}][rotation]" class="narrow rotation" onchange="updateSSDCheck(this)"style="width: 50px;" name="disk[{{INDEX}}[rotation]" hidden title="_(Set SSD flag)_" value='0' >
 				</td>
 				<tr class="advanced disk_bus_options">
 				<td>_(Serial)_:</td>
@@ -1698,6 +1707,28 @@ function ShareChange(share) {
 			document.getElementById(name+"[target]").removeAttribute("disabled");
 			document.getElementById(name+"[source]").removeAttribute("disabled");
 		}
+}
+
+function BusChange(bus) {
+		var value = bus.value;
+		var index = bus.name.indexOf("]") + 1;
+		var name = bus.name.substr(0,index) ;
+		if (value == "virtio" || value == "usb" ) {
+		document.getElementById(name+"[rotatetext]").style.visibility="hidden";
+		document.getElementById(name+"[rotation]").style.visibility="hidden";
+		} else {
+			document.getElementById(name+"[rotation]").style.display="inline";
+			document.getElementById(name+"[rotation]").style.visibility="visible";
+			document.getElementById(name+"[rotatetext]").style.display="inline";
+			document.getElementById(name+"[rotatetext]").style.visibility="visible";
+		}
+}
+
+function updateSSDCheck(ssd) {
+		var value = ssd.value;
+		var index = ssd.name.indexOf("]") + 1;
+		var name = ssd.name.substr(0,index) ;
+		if (document.getElementById(name+"[rotation]").checked) ssd.value = "1"; else ssd.value = "0";
 }
 
 function BIOSChange(bios) {


### PR DESCRIPTION
Add flag to vdisks to allow disks to show in guest as ssd rather than a hdd.

![image](https://github.com/unraid/webgui/assets/39065407/3099ef1a-be4f-44bc-84da-9eb52008ab5a)
![image](https://github.com/unraid/webgui/assets/39065407/d39d3d96-4679-42f1-8546-0e1c5afc7b78)
![image](https://github.com/unraid/webgui/assets/39065407/b177585f-0753-451e-bc97-807761eb6d0f)

XML after setting flag.

![image](https://github.com/unraid/webgui/assets/39065407/cc3c005d-c361-4676-805a-85b07cf7cef6)
