### PR TITLE
Fix php warning when saving text to a file.

### DIFF
--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -60,8 +60,8 @@ if (isset($_POST['#file'])) {
   }
   if ($save) {
     $text = "";
+    $keys = is_file($file) ? (parse_ini_file($file, $section) ?: []) : [];
     if ($section) {
-      $keys = is_file($file) ? (parse_ini_file($file, $section) ?: []) : [];
       foreach ($_POST as $key => $value) if ($key[0]!='#') $keys[$section][$key] = $default[$section][$key] ?? $value;
       foreach ($keys as $section => $block) {
         $text .= "[$section]\n";

--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -49,7 +49,6 @@ if (isset($_POST['#file'])) {
   $cleanup = isset($_POST['#cleanup']);
   $default = ($file && isset($_POST['#default'])) ? @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/default.cfg", $section) : [];
 
-  $keys = is_file($file) ? (parse_ini_file($file, $section) ?: []) : [];
   // the 'save' switch can be reset by the include file to disallow settings saving
   $save = true;
   if (isset($_POST['#include'])) {
@@ -62,6 +61,7 @@ if (isset($_POST['#file'])) {
   if ($save) {
     $text = "";
     if ($section) {
+      $keys = is_file($file) ? (parse_ini_file($file, $section) ?: []) : [];
       foreach ($_POST as $key => $value) if ($key[0]!='#') $keys[$section][$key] = $default[$section][$key] ?? $value;
       foreach ($keys as $section => $block) {
         $text .= "[$section]\n";

--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -51,11 +51,7 @@ if (isset($_POST['#file'])) {
   $default = ($file && isset($_POST['#default'])) ? @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/default.cfg", $section) : [];
 
   // if the file is not a raw file, it can be parsed 
-  if (! $raw_file) {
-    $keys = is_file($file) ? (parse_ini_file($file, $section) ?: []) : [];
-  } else {
-    $keys = [];
-  }
+  $keys = (is_file($file) && !$raw_file) ? (parse_ini_file($file, $section) ?: []) : [];
 
   // the 'save' switch can be reset by the include file to disallow settings saving
   $save = true;

--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -43,11 +43,19 @@ flush();
 $docroot = $_SERVER['DOCUMENT_ROOT'];
 if (isset($_POST['#file'])) {
   $file = $_POST['#file'];
+  $raw_file = isset($_POST['#raw_file']) ? ($_POST['#raw_file'] === 'true') : false;
   // prepend with boot (flash) if path is relative
   if ($file && $file[0]!='/') $file = "/boot/config/plugins/$file";
   $section = $_POST['#section'] ?? false;
   $cleanup = isset($_POST['#cleanup']);
   $default = ($file && isset($_POST['#default'])) ? @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/default.cfg", $section) : [];
+
+  // if the file is not a raw file, it can be parsed 
+  if (! $raw_file) {
+    $keys = is_file($file) ? (parse_ini_file($file, $section) ?: []) : [];
+  } else {
+    $keys = [];
+  }
 
   // the 'save' switch can be reset by the include file to disallow settings saving
   $save = true;
@@ -60,7 +68,6 @@ if (isset($_POST['#file'])) {
   }
   if ($save) {
     $text = "";
-    $keys = is_file($file) ? (parse_ini_file($file, $section) ?: []) : [];
     if ($section) {
       foreach ($_POST as $key => $value) if ($key[0]!='#') $keys[$section][$key] = $default[$section][$key] ?? $value;
       foreach ($keys as $section => $block) {


### PR DESCRIPTION
A php warning occurs when a text area is to be saved to a file and it contains a reserved php character.  Update.php tries to parse the file and extract a specific section even if the file is only to be saved.  It is also trying to extract a section when the $section is not defined i.e. $section is set to false.