### PR TITLE
Fix `getDockerJSON`

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -721,7 +721,7 @@ class DockerClient {
 		$fp = stream_socket_client('unix:///var/run/docker.sock', $errno, $errstr);
 		if ($fp === false) {
 			echo "Couldn't create socket: [$errno] $errstr";
-			return null;
+			return [];
 		}
 		$protocol = $unchunk ? 'HTTP/1.0' : 'HTTP/1.1';
 		$out = "$method {$api}{$url} $protocol\r\nHost:127.0.0.1\r\nConnection:Close\r\n";


### PR DESCRIPTION
If docker comms fail, return (empty) array (as expected by everyone) instead of null. Fixes `foreach() argument must be of type array|object, null given`