### PR TITLE
Fix Error 500 on login / fix read file on empty files

### DIFF
--- a/emhttp/plugins/dynamix/include/.login.php
+++ b/emhttp/plugins/dynamix/include/.login.php
@@ -17,7 +17,7 @@ if (!empty($_COOKIE['unraid_'.md5($server_name)])) {
 
 function readFromFile($file): string {
     $text = "";
-    if (file_exists($file)) {
+    if (file_exists($file) && filesize($file) > 0) {
         $fp = fopen($file,"r");
         if (flock($fp, LOCK_EX)) {
             $text = fread($fp, filesize($file));


### PR DESCRIPTION
Login fails if files in `/var/log/pwfail/` exist but are empty. I got this error in my `/var/log/phplog`

```
[07-May-2024 20:28:25 Europe/Berlin] PHP Fatal error:  Uncaught ValueError: fread(): Argument #2 ($length) must be greater than 0 in /usr/local/emhttp/plugins/dynamix/include/.login.php:23
Stack trace:
#0 /usr/local/emhttp/plugins/dynamix/include/.login.php(23): fread(Resource id #22, 0)
#1 /usr/local/emhttp/plugins/dynamix/include/.login.php(64): readFromFile('/var/log/pwfail...')
#2 /usr/local/emhttp/plugins/dynamix/include/.login.php(198): cleanupFails('/var/log/pwfail...', 1715106505)
#3 /usr/local/emhttp/login.php(37): include('/usr/local/emht...')
#4 {main}
  thrown in /usr/local/emhttp/plugins/dynamix/include/.login.php on line 23
```

I added an additional check to only open and read the file if the size is greater than 0.