### PR TITLE
Fix share floor calculation when the share is array only; fix detection of no mountable devices when adding shares

### DIFF
--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -457,30 +457,64 @@ function unite(field) {
   for (var i=0,item; item=field.options[i]; i++) if (item.selected) list.push(item.value);
   return list.join(',');
 }
+
+function parseDiskSize(sizeStr) {
+    const units = {
+        B: 1 / 1000,
+        KB: 1,
+        MB: 1000,
+        GB: 1000 * 1000,
+        TB: 1000 * 1000 * 1000,
+        PB: 1000 * 1000 * 1000 * 1000,
+        EB: 1000 * 1000 * 1000 * 1000 * 1000,
+        ZB: 1000 * 1000 * 1000 * 1000 * 1000 * 1000,
+        YB: 1000 * 1000 * 1000 * 1000 * 1000 * 1000 * 1000
+    };
+
+    // Check if the input is numeric only (assumed to be kilobytes)
+    if (/^\d+$/.test(sizeStr)) {
+        return parseInt(sizeStr, 10);
+    }
+
+    // Extract the numeric part and the unit
+    const result = sizeStr.match(/(\d+(\.\d+)?)\s*(B|KB|MB|GB|TB|PB|EB|ZB|YB)?/i);
+    if (!result) {
+        console.error("Invalid size format");
+        return null;
+    }
+
+    const value = parseFloat(result[1]); // The numeric part
+    const unit = (result[3] || "KB").toUpperCase(); // The unit part, default to KB
+
+    // Calculate total kilobytes
+    if (unit in units) {
+        return Math.round(value * units[unit]);
+    } else {
+        console.error("Unknown unit");
+        return null;
+    }
+}
+
 function setFloor(val) {
-  const fsSize = {<?=fsSize()?>};
-  const units = ['K','M','G','T','P','E','Z','Y'];
+  const fsSize = {<?=fsSize()?>};  // Make sure PHP outputs JSON here
   var full = fsSize[$('#primary').val()];
   var size = parseInt(full * 0.1); // 10% of available size
-  var number = val.replace(/[A-Z%\s]/gi,'').replace(',','.').split('.');
-  var last = number.pop();
-  number = number.length ? number.join('')+'.'+last : last;
-  if (number==0 && size>0) {
-    size = size.toString()
-    $.cookie('autosize-'+$('#shareName').val(),'1',{expires:365});
+  var parsedVal = parseDiskSize(val);  // Parse the input string to get numeric bytes
+
+  if (!parsedVal && size > 0) {
+    size = size.toString();
+    $.cookie('autosize-'+$('#shareName').val(), '1', {expires: 365});
   } else {
-   size = val;
+    // Correct comparison: check if parsedVal is less than full size, not just the 10% (size)
+    if (parsedVal < full) {
+      size = parsedVal;
+    }
     $.removeCookie('autosize-'+$('#shareName').val());
   }
-  var unit = size.replace(/[0-9.,\s]/g,'');
-  if (unit=='%') {
-    number = (number > 0 && number <= 100) ? parseInt(full * number / 100) : '';
-  } else {
-    var base = unit.length==2 ? 1000 : (unit.length==1 ? 1024 : 0);
-    number = base>0 ? number * Math.pow(base,(units.indexOf(unit.toUpperCase().replace('B',''))||0)) : size;
-  }
-  return isNaN(number) ? '' : number;
+
+  return size; // Return the possibly adjusted size
 }
+
 // Compose input fields
 function prepareEdit() {
 // Test share name validity

--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -56,7 +56,7 @@ function presetSpace($val) {
   if (!$val or strcasecmp($val,'NaN')==0) return;
   sanitize($val);
   $small = [];
-  foreach (data_filter($disks) as $disk) $small[] = _var($disk,'fsSize');
+  foreach (data_filter($disks) as $disk) $small[] = _var($disk,'fsFree');
   $fsSize[""] = min(array_filter($small));
   foreach ($pools as $pool) $fsSize[$pool] = _var($disks[$pool],'fsSize',0);
   $pool = _var($shares[$name],'cachePool');
@@ -72,7 +72,7 @@ function presetSpace($val) {
 function fsSize() {
   global $disks,$pools;
   $fsSize = $small = [];
-  foreach (data_filter($disks) as $disk) $small[] = _var($disk,'fsSize');
+  foreach (data_filter($disks) as $disk) $small[] = _var($disk,'fsFree');
   $fsSize[] = '"":"'.min(array_filter($small)).'"';
   foreach ($pools as $pool) $fsSize[] = '"'.$pool.'":"'._var($disks[$pool],'fsSize',0).'"';
   return implode(',',$fsSize);
@@ -469,7 +469,7 @@ function setFloor(val) {
     size = size.toString()
     $.cookie('autosize-'+$('#shareName').val(),'1',{expires:365});
   } else {
-    size = val;
+   size = val;
     $.removeCookie('autosize-'+$('#shareName').val());
   }
   var unit = size.replace(/[0-9.,\s]/g,'');

--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -18,7 +18,7 @@ Tag="share-alt-square"
 $width = [123,300];
 
 if ($name == "") {
-  // default values when adding new share
+  /* default values when adding new share. */
   $share = ["nameOrig"   => "",
             "name"       => "",
             "comment"    => "",
@@ -32,70 +32,194 @@ if ($name == "") {
             "cow"        => "auto"
            ];
 } elseif (array_key_exists($name, $shares)) {
-  // edit existing share
+  /* edit existing share. */
   $share = $shares[$name];
 } else {
-  // handle share deleted case
+  /* handle share deleted case. */
   echo "<p class='notice'>"._('Share')." '".htmlspecialchars($name)."' "._('has been deleted').".</p><input type='button' value=\""._('Done')."\" onclick='done()'>";
   return;
 }
-// Check for non existent pool device
+
+/* Check for non existent pool device. */
 if ($share['cachePool'] && !in_array($share['cachePool'],$pools)) $share['useCache'] = "no";
 
 function globalInclude($name) {
   global $var;
   return substr($name,0,4)=='disk' && (!$var['shareUserInclude'] || in_array($name,explode(',',$var['shareUserInclude'])));
 }
+
 function sanitize(&$val) {
   $data = explode('.',str_replace([' ',','],['','.'],$val));
   $last = array_pop($data);
   $val = count($data) ? implode($data).".$last" : $last;
 }
+
+/**
+ * Preset space calculation and formatting.
+ *
+ * @param float|string $val Value to calculate preset space for.
+ * @return string|null Formatted space string or null.
+ */
 function presetSpace($val) {
-  global $disks,$shares,$name,$pools,$display;
-  if (!$val or strcasecmp($val,'NaN')==0) return;
-  sanitize($val);
-  $small = [];
-  foreach (data_filter($disks) as $disk) $small[] = _var($disk,'fsFree');
-  $fsSize[""] = min(array_filter($small));
-  foreach ($pools as $pool) $fsSize[$pool] = _var($disks[$pool],'fsFree',0);
-  $pool = _var($shares[$name],'cachePool');
-  $size = _var($fsSize,$pool,0);
-  $size = $size>0 ? round(100*$val/$size,1) : 0;
-  $units = ['KB','MB','GB','TB','PB','EB','ZB','YB'];
-  $base = $val>0 ? floor(log($val,1000)) : 0;
-  $size = round($val/pow(1000,$base),1);
-  $unit = _var($units,$base);
-  [$dot,$comma] = str_split(_var($display,'number','.,'));
-  return $size>0 ? number_format($size,$size-floor($size)?1:0,$dot,$comma).' '.$unit : '';
+	global $disks, $shares, $name, $pools, $display;
+
+	/* Return if the value is invalid or NaN */
+	if (!$val || strcasecmp($val, 'NaN') == 0) return null;
+
+	/* Sanitize the value */
+	sanitize($val);
+
+	/* Prepare the largest array disk */
+	$large = [];
+	foreach (data_filter($disks) as $disk) {
+		$large[] = _var($disk, 'fsSize');
+	}
+
+	/* Get the maximum value from the large array, filtering out non-numeric values */
+	$fsSize[""] = max(array_filter($large, 'is_numeric'));
+
+	/* Prepare the fsSize array for each pool */
+	foreach ($pools as $pool) {
+		$fsSize[$pool] = _var($disks[$pool], 'fsSize', 0);
+	}
+
+	/* Get the cache pool size */
+	$pool = _var($shares[$name], 'cachePool');
+	$size = _var($fsSize, $pool, 0);
+
+	/* Calculate the size */
+	$size = $size > 0 ? round(100 * $val / $size, 1) : 0;
+
+	/* Units for size formatting */
+	$units = ['KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+	$base = $val > 0 ? floor(log($val, 1000)) : 0;
+	$formattedSize = round($val / pow(1000, $base), 1);
+	$unit = _var($units, $base);
+
+	/* Get number format settings */
+	[$dot, $comma] = str_split(_var($display, 'number', '.,'));
+
+	/* Return the formatted size */
+	return $formattedSize > 0 ? number_format($formattedSize, $formattedSize - floor($formattedSize) ? 1 : 0, $dot, $comma) . ' ' . $unit : '';
 }
+
+/**
+ * Function to get enabled disks based on include and exclude rules.
+ *
+ * @global array $disks Array of disk names to check.
+ * @global array $share Array containing include and exclude rules.
+ *
+ * @return array Array of keys for enabled disk names.
+ */
+function enabledDisks() {
+	global $disks, $share;
+
+	/* Prepare the resultant array */
+	$trueKeys = [];
+
+	/* Process each disk in the array */
+	foreach ($disks as $key => $disk) {
+		$include = true; /* Default to true */
+
+		/* Check the include field */
+		if (!empty($share['include'])) {
+			$includedDisks = explode(',', $share['include']);
+			if (!in_array($key, $includedDisks)) {
+				$include = false;
+			}
+		}
+
+		/* Check the exclude field */
+		if (!empty($share['exclude'])) {
+			$excludedDisks = explode(',', $share['exclude']);
+			if (in_array($key, $excludedDisks)) {
+				$include = false;
+			}
+		}
+
+		/* Add to trueKeys array if the disk should be included */
+		if ($include) {
+			$trueKeys[] = $key;
+		}
+	}
+
+	return $trueKeys;
+}
+
 function fsSize() {
-  global $disks,$pools;
-  $fsSize = $small = [];
-  foreach (data_filter($disks) as $disk) $small[] = _var($disk,'fsFree');
-  $fsSize[] = '"":"'.min(array_filter($small)).'"';
-  foreach ($pools as $pool) $fsSize[] = '"'.$pool.'":"'._var($disks[$pool],'fsFree',0).'"';
-  return implode(',',$fsSize);
+	global $disks, $pools, $share;
+	
+	$fsSize = [];
+	$small = [];
+
+	$enabledDisks	= enabledDisks();
+
+	foreach (data_filter($disks) as $key => $disk) {
+		if (in_array($key, $enabledDisks)) {
+			$small[] = _var($disk, 'fsSize');
+		}
+	}
+
+	$fsSize[''] = min(array_filter($small));
+
+	foreach ($pools as $pool) {
+		$fsSize[$pool] = _var($disks[$pool], 'fsSize', 0);
+	}
+
+	return json_encode($fsSize);
 }
+
+function fsFree() {
+	global $disks, $pools;
+
+	$fsFree = [];
+	$large = [];
+
+	$enabledDisks	= enabledDisks();
+
+	foreach (data_filter($disks) as $key => $disk) {
+		if (in_array($key, $enabledDisks)) {
+			$large[] = _var($disk, 'fsFree');
+		}
+	}
+
+	$fsFree[''] = max(array_filter($large));
+
+	foreach ($pools as $pool) {
+		$fsFree[$pool] = _var($disks[$pool], 'fsFree', 0);
+	}
+
+	return json_encode($fsFree);
+}
+
 function fsType() {
   global $disks,$pools;
+
   $fsType = [];
-  foreach ($pools as $pool) $fsType[] = '"'.$pool.'":"'.str_replace('luks:','',_var($disks[$pool],'fsType')).'"';
+
+  foreach ($pools as $pool) {
+    $fsType[] = '"'.$pool.'":"'.str_replace('luks:','',_var($disks[$pool],'fsType')).'"';
+  }
+
   return implode(',',$fsType);
 }
+
 function primary() {
   global $share;
   return $share['useCache']=='no' ? '' : $share['cachePool'];
 }
+
 function secondary() {
   global $share;
   return in_array($share['useCache'],['no','only']) ? '0' : '1';
 }
+
 function direction() {
   global $share;
   return $share['useCache']=='prefer' ? '1' : '0';
 }
-// global shares include/exclude
+
+/* global shares include/exclude. */
 $myDisks = array_filter(array_diff(array_keys(array_filter($disks,'my_disks')), explode(',',$var['shareUserExclude'])), 'globalInclude');
 ?>
 :share_edit_global1_help:
@@ -351,6 +475,7 @@ $(function() {
   if ($.cookie('autosize-'+$('#shareName').val())) $('#autosize').show();
   checkName($('#shareName').val());
 });
+
 function initDropdown(remove,create) {
   if (remove) {
     $('#s1').dropdownchecklist('destroy');
@@ -371,6 +496,7 @@ function initDropdown(remove,create) {
 <?endif;?>
   }
 }
+
 function z(i) {
   switch (i) {
     case 0: return $('#primary').prop('selectedIndex');
@@ -380,10 +506,12 @@ function z(i) {
     case 4: return z(0)==0 ? 'no' : (z(1)==0 ? 'only' : z(3));
   }
 }
+
 function updateCOW(i,slow) {
   const fsType = {<?=fsType()?>};
   if (fsType[i]=='btrfs') $('#cow-setting').show(slow); else $('#cow-setting').hide(slow);
 }
+
 function updateScreen(cache,slow) {
   switch (cache) {
   case 'no':
@@ -452,112 +580,177 @@ function updateScreen(cache,slow) {
     break;
   }
 }
+
 function unite(field) {
   var list = [];
   for (var i=0,item; item=field.options[i]; i++) if (item.selected) list.push(item.value);
   return list.join(',');
 }
 
-function parseDiskSize(sizeStr) {
-    const units = {
-        B: 1 / 1000,
-        KB: 1,
-        MB: 1000,
-        GB: 1000 * 1000,
-        TB: 1000 * 1000 * 1000,
-        PB: 1000 * 1000 * 1000 * 1000,
-        EB: 1000 * 1000 * 1000 * 1000 * 1000,
-        ZB: 1000 * 1000 * 1000 * 1000 * 1000 * 1000,
-        YB: 1000 * 1000 * 1000 * 1000 * 1000 * 1000 * 1000
-    };
-
-    // Check if the input is numeric only (assumed to be kilobytes)
-    if (/^\d+$/.test(sizeStr)) {
-        return parseInt(sizeStr, 10);
-    }
-
-    // Extract the numeric part and the unit
-    const result = sizeStr.match(/(\d+(\.\d+)?)\s*(B|KB|MB|GB|TB|PB|EB|ZB|YB)?/i);
-    if (!result) {
-        console.error("Invalid size format");
-        return null;
-    }
-
-    const value = parseFloat(result[1]); // The numeric part
-    const unit = (result[3] || "KB").toUpperCase(); // The unit part, default to KB
-
-    // Calculate total kilobytes
-    if (unit in units) {
-        return Math.round(value * units[unit]);
-    } else {
-        console.error("Unknown unit");
-        return null;
-    }
-}
-
+/* Set the share floor by trying to set the floor at 10% of a pool, or 10% of the largest disk in the array. */
 function setFloor(val) {
-  const fsSize = {<?=fsSize()?>};  // Make sure PHP outputs JSON here
-  var full = fsSize[$('#primary').val()];
-  var size = parseInt(full * 0.1); // 10% of available size
-  var parsedVal = parseDiskSize(val);  // Parse the input string to get numeric bytes
+	const fsSize = JSON.parse('<?= fsSize() ?>');
+	const fsFree = JSON.parse('<?= fsFree() ?>');
 
-  if (!parsedVal && size > 0) {
-    size = size.toString();
-    $.cookie('autosize-'+$('#shareName').val(), '1', {expires: 365});
-  } else {
-    // Correct comparison: check if parsedVal is less than full size, not just the 10% (size)
-    if (parsedVal < full) {
-      size = parsedVal;
-    }
-    $.removeCookie('autosize-'+$('#shareName').val());
-  }
+	/* Retrieve size and free space based on selected primary value */
+	var full = fsSize[$('#primary').val()];
+	var free = fsFree[$('#primary').val()];
 
-  return size; // Return the possibly adjusted size
+	/* This is the disk with the largest free space. */
+	var array_free = fsFree[''];
+
+	/* Calculate 10% of available size as default */
+	var size = parseInt(full * 0.1);
+
+	/* Parse the input string to get numeric bytes */
+	var parsedVal = parseDiskSize(val);
+
+	/* Check if parsedVal is a valid number and less than free */
+	if (parsedVal && parsedVal < free) {
+		size = parsedVal;
+		$.removeCookie('autosize-' + $('#shareName').val());
+	} else {
+		/* If parsedVal is not set or invalid */
+		if (!parsedVal && size < free) {
+			$.cookie('autosize-' + $('#shareName').val(), '1', { expires: 365 });
+		} else {
+			/* If parsedVal is greater than or equal to free, set size to 90% of free */
+			size = free * 0.9;
+			$.removeCookie('autosize-' + $('#shareName').val());
+		}
+	}
+
+	/* Is the primary device selection. */
+	var primarySelectElement = document.getElementById('primary');
+	var primarySelectedOption = primarySelectElement.options[primarySelectElement.selectedIndex];
+	var primaryText = primarySelectedOption.text;
+
+	/* Is the secondary device selection. */
+	var secondarySelectElement = document.getElementById('secondary');
+	var secondarySelectedOption = secondarySelectElement.options[secondarySelectElement.selectedIndex];
+	var secondaryText = secondarySelectedOption.text;
+
+	/* See if either primary or secondary is an array device. */
+	if (primaryText === "Array" || secondaryText === "Array") {
+		/* Check that after all calculations to see if the size is still less than the largest array free. */
+		if (size > array_free) {
+			size = array_free * 0.9;
+		}
+	}
+
+	/* Return the possibly adjusted size as a string */
+	return size.toString();
 }
 
-// Compose input fields
+/* Converts human readable size strings to numeric bytes */
+function parseDiskSize(sizeStr) {
+	const units = {
+		B: 1 / 1000,
+		KB: 1,
+		MB: 1000,
+		GB: 1000 * 1000,
+		TB: 1000 * 1000 * 1000,
+		PB: 1000 * 1000 * 1000 * 1000,
+		EB: 1000 * 1000 * 1000 * 1000 * 1000,
+		ZB: 1000 * 1000 * 1000 * 1000 * 1000 * 1000,
+		YB: 1000 * 1000 * 1000 * 1000 * 1000 * 1000 * 1000
+	};
+
+	/* Check if the input is numeric only (assumed to be kilobytes). */
+	if (/^\d+$/.test(sizeStr)) {
+		return parseInt(sizeStr, 10);
+	}
+
+	/* Extract the numeric part and the unit. */
+	const result = sizeStr.match(/(\d+(\.\d+)?)\s*(B|KB|MB|GB|TB|PB|EB|ZB|YB)?/i);
+	if (!result) {
+		return null;
+	}
+
+	/* The numeric part. */
+	const value = parseFloat(result[1]);
+
+	/* The unit part, default to KB. */
+	const unit = (result[3] || "KB").toUpperCase();
+
+	/* Calculate total kilobytes. */
+	if (unit in units) {
+		return Math.round(value * units[unit]);
+	} else {
+		return null;
+	}
+}
+
+/* Compose input fields. */
 function prepareEdit() {
-// Test share name validity
-  var share = form.shareName.value.trim();
-  if (share.length==0) {
-    swal({title:"_(Missing share name)_",text:"_(Enter a name for the share)_",type:'error',html:true,confirmButtonText:"_(Ok)_"});
-    return false;
-  }
-  var reserved = [<?=implode(',',array_map('escapestring',explode(',',$var['reservedNames'])))?>];
-  if (reserved.includes(share)) {
-    swal({title:"_(Invalid share name)_",text:"_(Do not use reserved names)_",type:'error',html:true,confirmButtonText:"_(Ok)_"});
-    return false;
-  }
-  var pools = [<?=implode(',',array_map('escapestring',$pools))?>];
-  if (pools.includes(share)) {
-    swal({title:"_(Invalid share name)_",text:"_(Do not use pool names)_",type:'error',html:true,confirmButtonText:"_(Ok)_"});
-    return false;
-  }
-  if (share.match('[:\\\/*<>|"?]')) {
-    swal({title:"_(Invalid Characters)_",text:"_(You cannot use the following within share names)_"+'<b> \\ / : * < > | " ?</b>',type:'error',html:true,confirmButtonText:"_(Ok)_"});
-    return false;
-  }
-// Update settings
-  form.shareName.value = share;
-  form.shareUseCache.value = z(4);
-  form.shareFloor.value = setFloor(form.shareFloor.value);
-  switch (form.shareUseCache.value) {
-  case 'no':
-    form.shareAllocator.value = form.shareAllocator1.value;
-    form.shareSplitLevel.value = form.shareSplitLevel1.value;
-    form.shareInclude.value = unite(form.shareInclude1);
-    form.shareExclude.value = unite(form.shareExclude1);
-    break;
-  case 'yes':
-  case 'prefer':
-    form.shareAllocator.value = form.shareAllocator2.value;
-    form.shareSplitLevel.value = form.shareSplitLevel2.value;
-    form.shareInclude.value = unite(form.shareInclude2);
-    form.shareExclude.value = unite(form.shareExclude2);
-    break;
-  }
-  return true;
+	/* Test share name validity. */
+	var share = form.shareName.value.trim();
+	if (share.length == 0) {
+		swal({
+			title: "_(Missing share name)_",
+			text: "_(Enter a name for the share)_",
+			type: 'error',
+			html: true,
+			confirmButtonText: "_(Ok)_"
+		});
+		return false;
+	}
+
+	var reserved = [<?= implode(',', array_map('escapestring', explode(',', $var['reservedNames']))) ?>];
+	if (reserved.includes(share)) {
+		swal({
+			title: "_(Invalid share name)_",
+			text: "_(Do not use reserved names)_",
+			type: 'error',
+			html: true,
+			confirmButtonText: "_(Ok)_"
+		});
+		return false;
+	}
+
+	var pools = [<?= implode(',', array_map('escapestring', $pools)) ?>];
+	if (pools.includes(share)) {
+		swal({
+			title: "_(Invalid share name)_",
+			text: "_(Do not use pool names)_",
+			type: 'error',
+			html: true,
+			confirmButtonText: "_(Ok)_"
+		});
+		return false;
+	}
+
+	if (share.match('[:\\\/*<>|"?]')) {
+		swal({
+			title: "_(Invalid Characters)_",
+			text: "_(You cannot use the following within share names)_" + '<b> \\ / : * < > | " ?</b>',
+			type: 'error',
+			html: true,
+			confirmButtonText: "_(Ok)_"
+		});
+		return false;
+	}
+
+	/* Update settings. */
+	form.shareName.value = share;
+	form.shareUseCache.value = z(4);
+	form.shareFloor.value = setFloor(form.shareFloor.value);
+	switch (form.shareUseCache.value) {
+		case 'no':
+			form.shareAllocator.value = form.shareAllocator1.value;
+			form.shareSplitLevel.value = form.shareSplitLevel1.value;
+			break;
+		case 'yes':
+		case 'prefer':
+			form.shareAllocator.value = form.shareAllocator2.value;
+			form.shareSplitLevel.value = form.shareSplitLevel2.value;
+			form.shareInclude.value = unite(form.shareInclude2);
+			form.shareExclude.value = unite(form.shareExclude2);
+			break;
+	}
+	return true;
 }
+
 function readShare() {
   var name = $('select[name="readshare"]').val();
   initDropdown(true,false);
@@ -576,6 +769,7 @@ function readShare() {
   });
   $(form).find('select').trigger('change');
 }
+
 function writeShare(data,n,i) {
   if (data) {
     if (n<i) {
@@ -606,6 +800,7 @@ function writeShare(data,n,i) {
     writeShare(data,0,i);
   }
 }
+
 function checkName(name) {
   if (/^[A-Za-z0-9-_.: ]*$/.test(name)) $('#zfs-name').hide(); else $('#zfs-name').show();
 }

--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -458,6 +458,7 @@ _(Delete)_<input type="checkbox" name="confirmDelete" onchange="chkDelete(this.f
 </div>
 <?endif;?>
 </form>
+
 <script>
 var form = document.share_edit;
 
@@ -620,19 +621,19 @@ function setFloor(val) {
 		}
 	}
 
-	/* Is the primary device selection. */
+	/* Is the secondary device array. */
 	var primarySelectElement = document.getElementById('primary');
 	var primarySelectedOption = primarySelectElement.options[primarySelectElement.selectedIndex];
 	var primaryText = primarySelectedOption.text;
 
-	/* Is the secondary device selection. */
+	/* Is the secondary device array. */
 	var secondarySelectElement = document.getElementById('secondary');
 	var secondarySelectedOption = secondarySelectElement.options[secondarySelectElement.selectedIndex];
 	var secondaryText = secondarySelectedOption.text;
 
 	/* See if either primary or secondary is an array device. */
 	if (primaryText === "Array" || secondaryText === "Array") {
-		/* Check that after all calculations to see if the size is still less than the largest array free. */
+		/* Check that after all calculations to set the size it is still less than the largest array free. */
 		if (size > array_free) {
 			size = array_free * 0.9;
 		}
@@ -683,72 +684,53 @@ function parseDiskSize(sizeStr) {
 
 /* Compose input fields. */
 function prepareEdit() {
-	/* Test share name validity. */
-	var share = form.shareName.value.trim();
-	if (share.length == 0) {
-		swal({
-			title: "_(Missing share name)_",
-			text: "_(Enter a name for the share)_",
-			type: 'error',
-			html: true,
-			confirmButtonText: "_(Ok)_"
-		});
-		return false;
-	}
+  /* Test share name validity. */
+  var share = form.shareName.value.trim();
 
-	var reserved = [<?= implode(',', array_map('escapestring', explode(',', $var['reservedNames']))) ?>];
-	if (reserved.includes(share)) {
-		swal({
-			title: "_(Invalid share name)_",
-			text: "_(Do not use reserved names)_",
-			type: 'error',
-			html: true,
-			confirmButtonText: "_(Ok)_"
-		});
-		return false;
-	}
+  /* Clean up the share name. */
+  share = safeName(share);
+  if (share.length==0) {
+    swal({title:"_(Missing share name)_",text:"_(Enter a name for the share)_",type:'error',html:true,confirmButtonText:"_(Ok)_"});
+    return false;
+  }
 
-	var pools = [<?= implode(',', array_map('escapestring', $pools)) ?>];
-	if (pools.includes(share)) {
-		swal({
-			title: "_(Invalid share name)_",
-			text: "_(Do not use pool names)_",
-			type: 'error',
-			html: true,
-			confirmButtonText: "_(Ok)_"
-		});
-		return false;
-	}
+  var reserved = [<?=implode(',',array_map('escapestring',explode(',',$var['reservedNames'])))?>];
+  if (reserved.includes(share)) {
+    swal({title:"_(Invalid share name)_",text:"_(Do not use reserved names)_",type:'error',html:true,confirmButtonText:"_(Ok)_"});
+    return false;
+  }
 
-	if (share.match('[:\\\/*<>|"?]')) {
-		swal({
-			title: "_(Invalid Characters)_",
-			text: "_(You cannot use the following within share names)_" + '<b> \\ / : * < > | " ?</b>',
-			type: 'error',
-			html: true,
-			confirmButtonText: "_(Ok)_"
-		});
-		return false;
-	}
+  var pools = [<?=implode(',',array_map('escapestring',$pools))?>];
+  if (pools.includes(share)) {
+    swal({title:"_(Invalid share name)_",text:"_(Do not use pool names)_",type:'error',html:true,confirmButtonText:"_(Ok)_"});
+    return false;
+  }
 
-	/* Update settings. */
-	form.shareName.value = share;
-	form.shareUseCache.value = z(4);
-	form.shareFloor.value = setFloor(form.shareFloor.value);
-	switch (form.shareUseCache.value) {
-		case 'no':
-			form.shareAllocator.value = form.shareAllocator1.value;
-			form.shareSplitLevel.value = form.shareSplitLevel1.value;
-			break;
-		case 'yes':
-		case 'prefer':
-			form.shareAllocator.value = form.shareAllocator2.value;
-			form.shareSplitLevel.value = form.shareSplitLevel2.value;
-			form.shareInclude.value = unite(form.shareInclude2);
-			form.shareExclude.value = unite(form.shareExclude2);
-			break;
-	}
-	return true;
+  if (share.match('[:\\\/*<>|"?]')) {
+    swal({title:"_(Invalid Characters)_",text:"_(You cannot use the following within share names)_"+'<b> \\ / : * < > | " ?</b>',type:'error',html:true,confirmButtonText:"_(Ok)_"});
+    return false;
+  }
+
+  /* Update settings. */
+  form.shareName.value = share;
+  form.shareUseCache.value = z(4);
+  form.shareFloor.value = setFloor(form.shareFloor.value);
+  switch (form.shareUseCache.value) {
+  case 'no':
+    form.shareAllocator.value = form.shareAllocator1.value;
+    form.shareSplitLevel.value = form.shareSplitLevel1.value;
+    form.shareInclude.value = unite(form.shareInclude1);
+    form.shareExclude.value = unite(form.shareExclude1);
+    break;
+  case 'yes':
+  case 'prefer':
+    form.shareAllocator.value = form.shareAllocator2.value;
+    form.shareSplitLevel.value = form.shareSplitLevel2.value;
+    form.shareInclude.value = unite(form.shareInclude2);
+    form.shareExclude.value = unite(form.shareExclude2);
+    break;
+  }
+  return true;
 }
 
 function readShare() {
@@ -799,6 +781,30 @@ function writeShare(data,n,i) {
     $('div.spinner.fixed').show('slow');
     writeShare(data,0,i);
   }
+}
+
+function safeName(name) {
+	/* Define the allowed characters regex */
+	var validChars = /^[A-Za-z0-9-_.: ]*$/;
+	
+	/* Check if the name contains only valid characters */
+	var isValidName = validChars.test(name);
+	
+	/* If valid, return the name as it is */
+	if (isValidName) {
+		return name;
+	}
+	
+	/* If not valid, sanitize the name by removing invalid characters */
+	var sanitizedString = '';
+	for (var i = 0; i < name.length; i++) {
+		if (validChars.test(name[i])) {
+			sanitizedString += name[i];
+		}
+	}
+	
+	/* Return the sanitized string */
+	return sanitizedString;
 }
 
 function checkName(name) {

--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -508,9 +508,15 @@ function z(i) {
   }
 }
 
-function updateCOW(i,slow) {
-  const fsType = {<?=fsType()?>};
-  if (fsType[i]=='btrfs') $('#cow-setting').show(slow); else $('#cow-setting').hide(slow);
+
+/* Update the Copy-on-Write (COW) setting visibility based on the filesystem type */
+function updateCOW(i, slow) {
+	const fsType = {<?=fsType()?>};
+	if (fsType[i] === 'btrfs') {
+		$('#cow-setting').show(slow);
+	} else {
+		$('#cow-setting').hide(slow);
+	}
 }
 
 function updateScreen(cache,slow) {
@@ -582,10 +588,16 @@ function updateScreen(cache,slow) {
   }
 }
 
+/* Unite selected options into a comma-separated string */
 function unite(field) {
-  var list = [];
-  for (var i=0,item; item=field.options[i]; i++) if (item.selected) list.push(item.value);
-  return list.join(',');
+	const list = [];
+	for (let i = 0; i < field.options.length; i++) {
+		const item = field.options[i];
+		if (item.selected) {
+			list.push(item.value);
+		}
+	}
+	return list.join(',');
 }
 
 /* Set the share floor by trying to set the floor at 10% of a pool, or 10% of the largest disk in the array. */
@@ -594,17 +606,18 @@ function setFloor(val) {
 	const fsFree = JSON.parse('<?= fsFree() ?>');
 
 	/* Retrieve size and free space based on selected primary value */
-	var full = fsSize[$('#primary').val()];
-	var free = fsFree[$('#primary').val()];
+	const primaryValue = $('#primary').val();
+	const full = fsSize[primaryValue];
+	const free = fsFree[primaryValue];
 
 	/* This is the disk with the largest free space. */
-	var array_free = fsFree[''];
+	const arrayFree = fsFree[''];
 
 	/* Calculate 10% of available size as default */
-	var size = parseInt(full * 0.1);
+	let size = parseInt(full * 0.1);
 
 	/* Parse the input string to get numeric bytes */
-	var parsedVal = parseDiskSize(val);
+	const parsedVal = parseDiskSize(val);
 
 	/* Check if parsedVal is a valid number and less than free */
 	if (parsedVal && parsedVal < free) {
@@ -622,20 +635,20 @@ function setFloor(val) {
 	}
 
 	/* Is the secondary device array. */
-	var primarySelectElement = document.getElementById('primary');
-	var primarySelectedOption = primarySelectElement.options[primarySelectElement.selectedIndex];
-	var primaryText = primarySelectedOption.text;
+	const primarySelectElement = document.getElementById('primary');
+	const primarySelectedOption = primarySelectElement.options[primarySelectElement.selectedIndex];
+	const primaryText = primarySelectedOption.text;
 
 	/* Is the secondary device array. */
-	var secondarySelectElement = document.getElementById('secondary');
-	var secondarySelectedOption = secondarySelectElement.options[secondarySelectElement.selectedIndex];
-	var secondaryText = secondarySelectedOption.text;
+	const secondarySelectElement = document.getElementById('secondary');
+	const secondarySelectedOption = secondarySelectElement.options[secondarySelectElement.selectedIndex];
+	const secondaryText = secondarySelectedOption.text;
 
 	/* See if either primary or secondary is an array device. */
 	if (primaryText === "Array" || secondaryText === "Array") {
 		/* Check that after all calculations to set the size it is still less than the largest array free. */
-		if (size > array_free) {
-			size = array_free * 0.9;
+		if (size > arrayFree) {
+			size = arrayFree * 0.9;
 		}
 	}
 
@@ -684,53 +697,69 @@ function parseDiskSize(sizeStr) {
 
 /* Compose input fields. */
 function prepareEdit() {
-  /* Test share name validity. */
-  var share = form.shareName.value.trim();
+	/* Test share name validity. */
+	var share = form.shareName.value.trim();
 
-  /* Clean up the share name. */
-  share = safeName(share);
-  if (share.length==0) {
-    swal({title:"_(Missing share name)_",text:"_(Enter a name for the share)_",type:'error',html:true,confirmButtonText:"_(Ok)_"});
-    return false;
-  }
+	if (share.length == 0) {
+		swal({
+			title: "Missing share name",
+			text: "Enter a name for the share",
+			type: 'error',
+			html: true,
+			confirmButtonText: "Ok"
+		});
+		return false;
+	}
 
-  var reserved = [<?=implode(',',array_map('escapestring',explode(',',$var['reservedNames'])))?>];
-  if (reserved.includes(share)) {
-    swal({title:"_(Invalid share name)_",text:"_(Do not use reserved names)_",type:'error',html:true,confirmButtonText:"_(Ok)_"});
-    return false;
-  }
+	var reserved = [<?=implode(',',array_map('escapestring',explode(',',$var['reservedNames'])))?>];
+	if (reserved.includes(share)) {
+		swal({
+			title: "Invalid share name",
+			text: "Do not use reserved names",
+			type: 'error',
+			html: true,
+			confirmButtonText: "Ok"
+		});
+		return false;
+	}
 
-  var pools = [<?=implode(',',array_map('escapestring',$pools))?>];
-  if (pools.includes(share)) {
-    swal({title:"_(Invalid share name)_",text:"_(Do not use pool names)_",type:'error',html:true,confirmButtonText:"_(Ok)_"});
-    return false;
-  }
+	var pools = [<?=implode(',',array_map('escapestring',$pools))?>];
+	if (pools.includes(share)) {
+		swal({
+			title: "Invalid share name",
+			text: "Do not use pool names",
+			type: 'error',
+			html: true,
+			confirmButtonText: "Ok"
+		});
+		return false;
+	}
 
-  if (share.match('[:\\\/*<>|"?]')) {
-    swal({title:"_(Invalid Characters)_",text:"_(You cannot use the following within share names)_"+'<b> \\ / : * < > | " ?</b>',type:'error',html:true,confirmButtonText:"_(Ok)_"});
-    return false;
-  }
+	/* Clean up the share name. */
+	share = safeName(share);
 
-  /* Update settings. */
-  form.shareName.value = share;
-  form.shareUseCache.value = z(4);
-  form.shareFloor.value = setFloor(form.shareFloor.value);
-  switch (form.shareUseCache.value) {
-  case 'no':
-    form.shareAllocator.value = form.shareAllocator1.value;
-    form.shareSplitLevel.value = form.shareSplitLevel1.value;
-    form.shareInclude.value = unite(form.shareInclude1);
-    form.shareExclude.value = unite(form.shareExclude1);
-    break;
-  case 'yes':
-  case 'prefer':
-    form.shareAllocator.value = form.shareAllocator2.value;
-    form.shareSplitLevel.value = form.shareSplitLevel2.value;
-    form.shareInclude.value = unite(form.shareInclude2);
-    form.shareExclude.value = unite(form.shareExclude2);
-    break;
-  }
-  return true;
+	/* Update settings. */
+	form.shareName.value = share;
+	form.shareUseCache.value = z(4);
+	form.shareFloor.value = setFloor(form.shareFloor.value);
+
+	switch (form.shareUseCache.value) {
+		case 'no':
+			form.shareAllocator.value = form.shareAllocator1.value;
+			form.shareSplitLevel.value = form.shareSplitLevel1.value;
+			form.shareInclude.value = unite(form.shareInclude1);
+			form.shareExclude.value = unite(form.shareExclude1);
+			break;
+		case 'yes':
+		case 'prefer':
+			form.shareAllocator.value = form.shareAllocator2.value;
+			form.shareSplitLevel.value = form.shareSplitLevel2.value;
+			form.shareInclude.value = unite(form.shareInclude2);
+			form.shareExclude.value = unite(form.shareExclude2);
+			break;
+	}
+
+	return true;
 }
 
 function readShare() {
@@ -783,12 +812,13 @@ function writeShare(data,n,i) {
   }
 }
 
+/* Clean up the share name by removing invalid characters. */
 function safeName(name) {
 	/* Define the allowed characters regex */
-	var validChars = /^[A-Za-z0-9-_.: ]*$/;
+	const validChars = /^[A-Za-z0-9-_.: ]*$/;
 	
 	/* Check if the name contains only valid characters */
-	var isValidName = validChars.test(name);
+	const isValidName = validChars.test(name);
 	
 	/* If valid, return the name as it is */
 	if (isValidName) {
@@ -796,8 +826,8 @@ function safeName(name) {
 	}
 	
 	/* If not valid, sanitize the name by removing invalid characters */
-	var sanitizedString = '';
-	for (var i = 0; i < name.length; i++) {
+	let sanitizedString = '';
+	for (let i = 0; i < name.length; i++) {
 		if (validChars.test(name[i])) {
 			sanitizedString += name[i];
 		}
@@ -808,6 +838,11 @@ function safeName(name) {
 }
 
 function checkName(name) {
-  if (/^[A-Za-z0-9-_.: ]*$/.test(name)) $('#zfs-name').hide(); else $('#zfs-name').show();
+	var isValidName = /^[A-Za-z0-9-_.: ]*$/.test(name);
+	if (isValidName) {
+		$('#zfs-name').hide();
+	} else {
+		$('#zfs-name').show();
+	}
 }
 </script>

--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -58,7 +58,7 @@ function presetSpace($val) {
   $small = [];
   foreach (data_filter($disks) as $disk) $small[] = _var($disk,'fsFree');
   $fsSize[""] = min(array_filter($small));
-  foreach ($pools as $pool) $fsSize[$pool] = _var($disks[$pool],'fsSize',0);
+  foreach ($pools as $pool) $fsSize[$pool] = _var($disks[$pool],'fsFree',0);
   $pool = _var($shares[$name],'cachePool');
   $size = _var($fsSize,$pool,0);
   $size = $size>0 ? round(100*$val/$size,1) : 0;
@@ -74,7 +74,7 @@ function fsSize() {
   $fsSize = $small = [];
   foreach (data_filter($disks) as $disk) $small[] = _var($disk,'fsFree');
   $fsSize[] = '"":"'.min(array_filter($small)).'"';
-  foreach ($pools as $pool) $fsSize[] = '"'.$pool.'":"'._var($disks[$pool],'fsSize',0).'"';
+  foreach ($pools as $pool) $fsSize[] = '"'.$pool.'":"'._var($disks[$pool],'fsFree',0).'"';
   return implode(',',$fsSize);
 }
 function fsType() {

--- a/emhttp/plugins/dynamix/ShareList.page
+++ b/emhttp/plugins/dynamix/ShareList.page
@@ -16,12 +16,12 @@ Cond="_var($var,'fsState')!='Stopped' && _var($var,'shareUser')=='e'"
  */
 ?>
 <?
-// Function to filter out unwanted disks and check if any valid disks exist.
+// Function to filter out unwanted disks, check if any valid disks exist, and ignore disks with a blank device.
 function checkDisks($disks) {
   foreach ($disks as $disk) {
-    // Check the disk type and fsStatus.
-    if (!in_array($disk['name'], ['flash', 'parity', 'parity2']) && $disk['fsStatus'] !== "Unmountable: unsupported or no file system") {
-      // A valid disk is found, return true.
+    // Check the disk type, fsStatus, and ensure the device is not blank.
+    if (!in_array($disk['name'], ['flash', 'parity', 'parity2']) && $disk['fsStatus'] !== "Unmountable: unsupported or no file system" && !empty($disk['device'])) {
+      // A valid disk with a non-blank device is found, return true.
       return true;
     }
   }

--- a/emhttp/plugins/dynamix/include/DiskList.php
+++ b/emhttp/plugins/dynamix/include/DiskList.php
@@ -38,12 +38,12 @@ $nodisks = "<tr><td class='empty' colspan='7'><i class='fa fa-folder-open-o icon
 // GUI settings
 extract(parse_plugin_cfg('dynamix',true));
 
-// Function to filter out unwanted disks and check if any valid disks exist.
+// Function to filter out unwanted disks, check if any valid disks exist, and ignore disks with a blank device.
 function checkDisks($disks) {
   foreach ($disks as $disk) {
-    // Check the disk type and fsStatus.
-    if (!in_array($disk['name'], ['flash', 'parity', 'parity2']) && $disk['fsStatus'] !== "Unmountable: unsupported or no file system") {
-      // A valid disk is found, return true.
+    // Check the disk type, fsStatus, and ensure the device is not blank.
+    if (!in_array($disk['name'], ['flash', 'parity', 'parity2']) && $disk['fsStatus'] !== "Unmountable: unsupported or no file system" && !empty($disk['device'])) {
+      // A valid disk with a non-blank device is found, return true.
       return true;
     }
   }

--- a/emhttp/plugins/dynamix/include/ShareList.php
+++ b/emhttp/plugins/dynamix/include/ShareList.php
@@ -63,12 +63,12 @@ $pools = implode(',', $pools_check);
 // Natural sorting of share names
 uksort($shares,'strnatcasecmp');
 
-// Function to filter out unwanted disks and check if any valid disks exist.
+// Function to filter out unwanted disks, check if any valid disks exist, and ignore disks with a blank device.
 function checkDisks($disks) {
   foreach ($disks as $disk) {
-    // Check the disk type and fsStatus.
-    if (!in_array($disk['name'], ['flash', 'parity', 'parity2']) && $disk['fsStatus'] !== "Unmountable: unsupported or no file system") {
-      // A valid disk is found, return true.
+    // Check the disk type, fsStatus, and ensure the device is not blank.
+    if (!in_array($disk['name'], ['flash', 'parity', 'parity2']) && $disk['fsStatus'] !== "Unmountable: unsupported or no file system" && !empty($disk['device'])) {
+      // A valid disk with a non-blank device is found, return true.
       return true;
     }
   }


### PR DESCRIPTION
The total array free space was used, instead of the smallest array disk device free space.  A validity check added to limit the manually entered share floor to less than the free space of the disk with the least free space.  This preents the situation where a share is added and the auto calculated share floor or manually entered share floor does not cause failures in adding shares.

The detection of the situation where no unmountable disks are available when adding shares has been modified to account for unassigned disk slots.