### PR TITLE
Behaviour fix for #1743 : "Add in the ability to set a manual UPS capacity override in `dynamix.apcupsd`"

### DIFF
--- a/emhttp/plugins/dynamix.apcupsd/include/UPSstatus.php
+++ b/emhttp/plugins/dynamix.apcupsd/include/UPSstatus.php
@@ -91,14 +91,17 @@ if (file_exists("/var/run/apcupsd.pid")) {
     if ($i%2==1) $result[] = "</tr>";
   }
   if (count($rows)%2==1) $result[] = "<td></td><td></td></tr>";
+
+  // If the override is defined, override the power value, using the same implementation as above.
+  // This is a better implementation, as it allows the existing Unraid code to work with the override.
+  if ($overrideUpsCapacity > 0) {
+    $power = $overrideUpsCapacity;
+    $status[4] = $power>0 ? "<td $green>$power W</td>" : "<td $red>$power W</td>";
+  }
+
   if ($power && isset($load)) $status[5] = ($load<90 ? "<td $green>" : "<td $red>").round($power*$load/100)." W (".$status[5].")</td>";
   elseif (isset($load)) $status[5] = ($load<90 ? "<td $green>" : "<td $red>").$status[5]."</td>";
   $status[6] = isset($output) ? ((!$volt || ($minv<$output && $output<$maxv) ? "<td $green>" : "<td $red>").$status[6].(isset($freq) ? " ~ $freq Hz" : "")."</td>") : $status[6];
-
-  if ($status[4] == $defaultCell && $overrideUpsCapacity > 0 && isset($load) && $load > 0) {
-    $nominalPower = round($load * 0.01 * $overrideUpsCapacity);
-    $status[4] = ($nominalPower > 0 ? "<td $green>" : "<td $red>") . "≈ $nominalPower W</td>";
-  }
 }
 if (empty($rows)) $result[] = "<tr><td colspan='4' style='text-align:center'>"._('No information available')."</td></tr>";
 

--- a/emhttp/plugins/dynamix/nchan/ups_status
+++ b/emhttp/plugins/dynamix/nchan/ups_status
@@ -119,14 +119,17 @@ while (true) {
         break;
       }
     }
+
+    // If the override is defined, override the power value, using the same implementation as above.
+    // This is a better implementation, as it allows the existing Unraid code to work with the override.
+    if ($overrideUpsCapacity > 0) {
+      $power = $overrideUpsCapacity;
+      $echo[4] = $power>0 ? "<span $green>$power W</span>" : "<span $red>$power W</span>";
+    }
+
     if (isset($power) && isset($load)) $echo[5] = ($load<90 ? "<span $green>" : "<span $red>").round($power*$load/100)." W (".$echo[5].")</span>";
     elseif (isset($load)) $echo[5] = ($load<90 ? "<span>" : "<span $red>").$echo[5]."</span>";
     $echo[6] = isset($output) ? ((empty($volt) || ($minv<$output && $output<$maxv) ? "<span $green>" : "<span $red>").$echo[6].(isset($freq) ? " ~ $freq Hz" : "")."</span>") : $echo[6];
-
-    if ($echo[4] == $defaultCell && $overrideUpsCapacity > 0 && isset($load) && $load > 0) {
-      $nominalPower = round($load * 0.01 * $overrideUpsCapacity);
-      $echo[4] = ($nominalPower > 0 ? "<span $green>" : "<span $red>") . "≈ $nominalPower W</span>";
-    }
   }
   $echo = json_encode($echo);
   $md5_new = md5($echo,true);


### PR DESCRIPTION
This is a behaviour fix for my prior merged PR, #1743.

My original intention was to try and mirror the default Unraid GUI behaviour on how it reports the UPS statistics, in which @johnnieblack-JorgeB kindly later shared how a traditional UPS that _does_ report `NOMPOWER` behaves and demonstrated how my implementation differs.

This PR is just to bring the behaviour inline with a UPS that _does_ report `NOMPOWER`, so that the GUI is consistent in what and how it reports UPS data, whether you have a UPS that reports `NOMPOWER` or you are using the nominal power override provided in #1743.

As the screenshot below demonstrates, the override nominal power value is now read directly into the Nominal Power `$power` field, mirroring the behaviour of a UPS that reports its `NOMPOWER` value. This then further allows the existing Unraid implementation of the load statistics to be generated, exactly the same as they would be for a `NOMPOWER` reporting UPS.

This re-implementation moves the nominal power override into overriding the `$power` value, instead of defining its own logic. It aligns the GUI with UPS' that report the `NOMPOWER` value by using Unraid's existing code and implementation, so they appear and behave the same, reducing complexity and making the implementation much more clean and robust.

---

1. Default Unraid `NOMPOWER` UPS behaviour, courtesy of @johnnieblack-JorgeB. The Nominal Power value is the maximum nominal power rating of the UPS, with the UPS load containing the %'age load and current wattage load estimated based on the `LOADPCT`:

![settings_nompower](https://github.com/unraid/webgui/assets/7256684/c9fda14d-8519-491d-8fcb-20be6feed0fc)

2. #1743 PR behaviour, incorrectly placing the load percentage and current power load in the nominal power field:

![settings_old](https://github.com/unraid/webgui/assets/7256684/013350d7-a464-4e1f-98ae-216989887f62)

3. New override behaviour in this PR, aligning the behaviour of the override value with the default Unraid behaviour of a UPS reporting `NOMPOWER`, as shown in screenshot `1`. Uses the same code as Unraid, just overriding the `$power` value:

![settings](https://github.com/unraid/webgui/assets/7256684/49737fee-e6fc-4f18-8396-a5288ba792e1)

---

1. Default Unraid `NOMPOWER` UPS behaviour, courtesy of @johnnieblack-JorgeB. The Nominal Power value is the maximum nominal power rating of the UPS, with the UPS load containing the %'age load and current wattage load estimated based on the `LOADPCT`:

![dashboard_nompower](https://github.com/unraid/webgui/assets/7256684/83c2911d-a211-44cb-8c32-500ce9f16248)

2. #1743 PR behaviour, incorrectly placing the load percentage and current power load in the nominal power field:

![dashboard_old](https://github.com/unraid/webgui/assets/7256684/b0da9645-bf2a-43d2-8e48-697621cee276)

3. New override behaviour in this PR, aligning the behaviour of the override value with the default Unraid behaviour of a UPS reporting `NOMPOWER`, as shown in screenshot `1`. Uses the same code as Unraid, just overriding the `$power` value:

![dashboard_old](https://github.com/unraid/webgui/assets/7256684/0f36de40-3df4-4286-b20e-3b78b0476108)