### PR TITLE
Xfs check not detecting file issues; remove subpools from share edit.

### DIFF
--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -45,6 +45,14 @@ if ($name == "") {
 /* If the configuration is pools only, then no array disks are available. */
 $poolsOnly	= ((int)$var['SYS_ARRAY_SLOTS'] <= 2) ? true : false;
 
+/* Remove subpools from the array of pools. */
+$pools = array_filter($pools, function($pool) {
+	return !isSubpool($pool);
+});
+
+@file_put_contents("/tmp/pools", json_encode($pools, JSON_PRETTY_PRINT));
+
+
 /* Check for non existent pool device. */
 if ($share['cachePool'] && !in_array($share['cachePool'], $pools)) {
 	$poolDefined = false;

--- a/emhttp/plugins/dynamix/scripts/xfs_check
+++ b/emhttp/plugins/dynamix/scripts/xfs_check
@@ -21,6 +21,11 @@ case "$1" in
 	/sbin/xfs_repair $4 $2 &> /var/lib/xfs/check.status.$3 &
 	pid=$!
 	echo $pid > /var/lib/xfs/check.pid.$3
+	# Capture the exit code once xfs_repair completes
+	{
+		wait $pid
+		echo $? > /var/lib/xfs/check.status.$3.exit
+	} &
 	exit 0
 ;;
 'status')


### PR DESCRIPTION
- xfs check does not show file issues from exit code.
- Remove subpools from the available pool devices in primary and secondary storage in share edit.