### PR TITLE
Remove debug from share edit used for subpools removed from primary and secondary drop downs; fix incorrect commit.

### DIFF
--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -50,9 +50,6 @@ $pools = array_filter($pools, function($pool) {
 	return !isSubpool($pool);
 });
 
-@file_put_contents("/tmp/pools", json_encode($pools, JSON_PRETTY_PRINT));
-
-
 /* Check for non existent pool device. */
 if ($share['cachePool'] && !in_array($share['cachePool'], $pools)) {
 	$poolDefined = false;

--- a/emhttp/plugins/dynamix/scripts/xfs_check
+++ b/emhttp/plugins/dynamix/scripts/xfs_check
@@ -21,11 +21,13 @@ case "$1" in
 	/sbin/xfs_repair $4 $2 &> /var/lib/xfs/check.status.$3 &
 	pid=$!
 	echo $pid > /var/lib/xfs/check.pid.$3
-	# Capture the exit code once xfs_repair completes
-	{
-		wait $pid
-		echo $? > /var/lib/xfs/check.status.$3.exit
-	} &
+
+    # Wait for xfs_repair to complete synchronously
+    wait "$pid"
+
+    # Capture the exit code of xfs_repair
+	echo $? > /var/lib/xfs/check.status.$3.exit
+
 	exit 0
 ;;
 'status')


### PR DESCRIPTION
- Remove debug line left in code.
- Fix incorrect commit of xfs_repair script.  The original concept did not return the proper exit code.