### PR TITLE
Mover status button on 'Array Operation' page.

### DIFF
--- a/emhttp/plugins/dynamix/nchan/parity_list
+++ b/emhttp/plugins/dynamix/nchan/parity_list
@@ -126,7 +126,7 @@ while (true) {
 		$process = -1;
 	} elseif ($spot > 0 && $bytes > 0) {
 		$process = 1;
-	} elseif (file_exists('/var/run/mover.pid')) {
+	} elseif (_var($var, 'shareMoverActive') == "yes") {
 		$process = 2;
 	} elseif (exec('ps -C btrfs -o cmd=|grep -cv show') > 0) {
 		$process = 3;


### PR DESCRIPTION
- Monitor the var 'shareMoverActive' instead of the 'mover.pid' file for mover status.