### PR TITLE
Fix UPS settings page when config contains empty values

### DIFF
--- a/emhttp/plugins/dynamix.apcupsd/UPSdetails.page
+++ b/emhttp/plugins/dynamix.apcupsd/UPSdetails.page
@@ -14,11 +14,13 @@ Tag="battery-3"
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  */
+$docroot = $docroot ?? $_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp';
+require_once "$docroot/webGui/include/Wrappers.php";
 ?>
 <script>
 function getUPSstatus() {
-  var batteryLevel = "<?= !empty($cfg['BATTERYLEVEL']) ? $cfg['BATTERYLEVEL'] : 0 ?>";
-  var batteryRuntime = "<?= !empty($cfg['MINUTES']) ? $cfg['MINUTES'] : 0 ?>";
+  var batteryLevel = "<?= _var($cfg,'BATTERYLEVEL',0) ?>";
+  var batteryRuntime = "<?= _var($cfg,'MINUTES',0) ?>";
 
   $.post('/plugins/dynamix.apcupsd/include/UPSstatus.php',{level:batteryLevel,runtime:batteryRuntime},function(data) {
     data = data.split('\n');

--- a/emhttp/plugins/dynamix.apcupsd/UPSdetails.page
+++ b/emhttp/plugins/dynamix.apcupsd/UPSdetails.page
@@ -17,7 +17,10 @@ Tag="battery-3"
 ?>
 <script>
 function getUPSstatus() {
-  $.post('/plugins/dynamix.apcupsd/include/UPSstatus.php',{level:<?=$cfg['BATTERYLEVEL']?>,runtime:<?=$cfg['MINUTES']?>},function(data) {
+  var batteryLevel = "<?= !empty($cfg['BATTERYLEVEL']) ? $cfg['BATTERYLEVEL'] : 0 ?>";
+  var batteryRuntime = "<?= !empty($cfg['MINUTES']) ? $cfg['MINUTES'] : 0 ?>";
+
+  $.post('/plugins/dynamix.apcupsd/include/UPSstatus.php',{level:batteryLevel,runtime:batteryRuntime},function(data) {
     data = data.split('\n');
     $('#ups_summary').html(data[0]);
     $('#ups_status').html(data[1]);


### PR DESCRIPTION
## Issue:

When either of the UPS config options `Battery level to initiate shutdown (%)` or `Runtime left to initiate shutdown (minutes)` are set to empty, the UPS details section breaks. This is due to the `getUPSstatus` function passing values directly from the config, which results in an error if either value is empty.

<img width="2716" alt="UPSsettings 2024-07-16 19-38-05" src="https://github.com/user-attachments/assets/6275390a-a7df-4912-942e-6577c6c2fffa">


## Solution:

The fix sets and passes variables to the `getUPSstatus` function for each of the config options. The variables are either set to the value contained in the config file, or `0` if the config has no value set.

Tested the fix locally and confirmed it functions as expected.