### PR TITLE
fix table order breaking when cookie is left malformed

### DIFF
--- a/emhttp/plugins/dynamix/DashStats.page
+++ b/emhttp/plugins/dynamix/DashStats.page
@@ -1188,6 +1188,7 @@ function SleepNow() {
 function sortTables() {
   $('table.dashboard').each(function(){
     var table = $(this);
+    sanitizeMultiCookie(table.prop('id'), ';', true);
     var index = $.cookie(table.prop('id'));
     // sorting list exists
     if (index != null) {


### PR DESCRIPTION
same as #1472 and #1776 just now for sanitizing the tile ordering cookies as well
if the browser leaves cookies in a malformed state (with null, empty or duplicate md5s) the tile ordering is not remembered
this PR cleans up the cookies (as already done with the hidden & inactive tile cookies) so tile sorting does not fail in such cases
--Rysz