### PR TITLE
update.php: release file pointer after usage

### DIFF
--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -102,6 +102,7 @@ if (isset($_POST['#command'])) {
     while (!feof($proc)) {
       write_log(fgets($proc));
     }
+    @pclose($proc);
   }
 }
 ?>


### PR DESCRIPTION
When execution is done (EOF), might be good practice to attempt releasing the now unused file pointer back to the system.
Just checked the rest of the repository and it seems to be done everywhere else like this, was probably just forgotten here.

-- Rysz