### PR TITLE
Grub VM settings fix

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/VMSettings.page
+++ b/emhttp/plugins/dynamix.vm.manager/VMSettings.page
@@ -30,30 +30,68 @@ if (!$hardware) {
 function scan($area, $text) {
   return strpos($area,$text)!==false;
 }
-function detect(&$syslinux, $key) {
-  $size = count($syslinux);
-  $menu = $i = 0;
-  $value = '';
-  // find the default section
-  while ($i < $size) {
-    if (scan($syslinux[$i],'label ')) {
-      $n = $i + 1;
-      // find the current requested setting
-      while (!scan($syslinux[$n],'label ') && $n < $size) {
-        if (scan($syslinux[$n],'menu default')) $menu = 1;
-        if (scan($syslinux[$n],'append')) foreach (explode(' ',$syslinux[$n]) as $cmd) if (scan($cmd,$key)) {$value = explode('=',$cmd)[1]; break;}
-        $n++;
+function detect(&$bootcfg, $bootenv, $key) {
+  if ($bootenv === 'syslinux') {
+    $size = count($bootcfg);
+    $menu = $i = 0;
+    $value = '';
+    // find the default section
+    while ($i < $size) {
+      if (scan($bootcfg[$i],'label ')) {
+        $n = $i + 1;
+        // find the current requested setting
+        while (!scan($bootcfg[$n],'label ') && $n < $size) {
+          if (scan($bootcfg[$n],'menu default')) $menu = 1;
+          if (scan($bootcfg[$n],'append')) foreach (explode(' ',$bootcfg[$n]) as $cmd) if (scan($cmd,$key)) {$value = explode('=',$cmd)[1]; break;}
+          $n++;
+        }
+        if ($menu) break; else $i = $n - 1;
       }
-      if ($menu) break; else $i = $n - 1;
+      $i++;
     }
-    $i++;
+  } elseif ($bootenv === 'grub') {
+    $menu_entries = [];
+    // find the current boot entry
+    foreach ($bootcfg as $line) {
+      if (preg_match('/set default=(\d+)/', $line, $match)) {
+        $bootentry = (int)$match[1];
+        break;
+      }
+    }
+    // split boot entries
+    foreach ($bootcfg as $line) {
+      if (strpos($line, 'menuentry ') === 0) {
+        $in_menuentry = true;
+        $current_entry = $line . "\n";
+      } elseif ($in_menuentry) {
+        $current_entry .= $line . "\n";
+        if (trim($line) === "}") {
+          $menu_entries[] = $current_entry;
+          $in_menuentry = false;
+        }
+      }
+    }
+    // search in selected menuentry
+    $menuentry = explode("\n", $menu_entries[$bootentry]);
+    foreach (explode(' ', $menu_entries[$bootentry]) as $cmd) {
+      if (scan($cmd,$key)) {
+        $value = explode('=',$cmd)[1];
+        break;
+      }
+     }
   }
-  return $value;
+  return trim($value);
 }
-$syslinux          = file('/boot/syslinux/syslinux.cfg',FILE_IGNORE_NEW_LINES+FILE_SKIP_EMPTY_LINES);
+if (is_file('/boot/syslinux/syslinux.cfg')) {
+  $bootcfg           = file('/boot/syslinux/syslinux.cfg',FILE_IGNORE_NEW_LINES+FILE_SKIP_EMPTY_LINES);
+  $bootenv           = 'syslinux';
+} elseif (is_file('/boot/grub/grub.cfg')) {
+  $bootcfg           = file('/boot/grub/grub.cfg',FILE_IGNORE_NEW_LINES+FILE_SKIP_EMPTY_LINES);
+  $bootenv           = 'grub';
+}
 $arrValidNetworks  = getValidNetworks();
-$pcie_acs_override = detect($syslinux, 'pcie_acs_override');
-$vfio_allow_unsafe = detect($syslinux, 'allow_unsafe_interrupts');
+$pcie_acs_override = detect($bootcfg, $bootenv, 'pcie_acs_override');
+$vfio_allow_unsafe = detect($bootcfg, $bootenv, 'allow_unsafe_interrupts');
 $bgcolor           = strstr('white,azure',$display['theme']) ? '#f2f2f2' : '#1c1c1c';
 $started           = $var['fsState']=='Started';
 $libvirt_up        = $libvirt_running=='yes';
@@ -321,7 +359,7 @@ $(function(){
 <?if ($safemode):?>
     if (run) $("#settingsForm").submit();
 <?else:?>
-    if (run) $.post("/plugins/dynamix.vm.manager/include/VMajax.php", {action:'syslinux',pcie:$('#pcie_acs_override').val(),vfio:$('#vfio_allow_unsafe').val()}, function(data){
+    if (run) $.post("/plugins/dynamix.vm.manager/include/VMajax.php", {action:'cmdlineoverride',pcie:$('#pcie_acs_override').val(),vfio:$('#vfio_allow_unsafe').val()}, function(data){
       $("#settingsForm").submit();
     });
 <?endif;?>


### PR DESCRIPTION
- Make VM Settings work again when using GRUB
- Make sure to properly inject/remove `PCIe ACS override`/`VFIO allow unsafe interrupts` to `grub.cfg`