### PR TITLE
fix: replace document write usages

### DIFF
--- a/emhttp/plugins/dynamix/include/.login.php
+++ b/emhttp/plugins/dynamix/include/.login.php
@@ -529,7 +529,12 @@ $theme_dark = in_array($display['theme'], ['black', 'gray']);
                         cookieEnabled = document.cookie.indexOf("cookietest=")!=-1;
                         document.cookie = "cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT";
                         if (!cookieEnabled) {
-                            document.write("<p class='error'><?=_('Browser cookie support required for Unraid OS webgui')?></p>");
+                            const errorElement = document.createElement('p');
+                            errorElement.classList.add('error');
+                            errorElement.textContent = "<?=_('Browser cookie support required for Unraid OS webgui')?>";
+
+                            document.body.textContent = '';
+                            document.body.appendChild(errorElement);
                         }
                     </script>
                 </form>

--- a/emhttp/plugins/dynamix/include/.set-password.php
+++ b/emhttp/plugins/dynamix/include/.set-password.php
@@ -347,7 +347,14 @@ $THEME_DARK = in_array($display['theme'],['black','gray']);
         document.cookie = "cookietest=1";
         cookieEnabled = document.cookie.indexOf("cookietest=")!=-1;
         document.cookie = "cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT";
-        if (!cookieEnabled) document.write("<p class='error'><?=_('Browser cookie support required for Unraid OS webgui')?></p>");
+        if (!cookieEnabled) {
+            const errorElement = document.createElement('p');
+            errorElement.classList.add('error');
+            errorElement.textContent = "<?=_('Browser cookie support required for Unraid OS webgui')?>";
+
+            document.body.textContent = '';
+            document.body.appendChild(errorElement);
+        }
         // Password toggling
         const $passToggle = document.querySelector('.js-pass-toggle');
         const $passToggleHideSvg = $passToggle.querySelector('.js-pass-toggle-hide');


### PR DESCRIPTION
This replaces the two uses of document.write with a more modern solution. First we create the content needed in the body. Then wipe the body content out and finally append the desired content to it.

This does NOT fix the [3rd referenced use](https://github.com/limetech/webgui/blob/d7982ce3e072d5c86d5f4ce79e5da29e5f7838db/plugins/dynamix.vm.manager/novnc/app/error-handler.js#L58) in the app code. Since it is from the VNC module, we'd be diverging from upstream which would make updating the VNC client more difficult in the future unless we rember to always go patch that again. To fix that, we should work upstream to have a solution in their system. There are also a few more findings of `document.write` elsewhere in the app code that is tracked. Same situation as this one for all of them, being upstream code that we shouldn't touch.

Fixes: #1175 
