### PR TITLE
Network info display improvements (part 2)

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -952,6 +952,8 @@ class DockerClient {
 				$c['NetworkMode'] = DockerUtil::ctMap($c['NetworkMode']);
 				$ports = &$info['Config']['ExposedPorts'];
 			}
+			$ip = $c['NetworkMode']=='host' ? $host : $ct['NetworkSettings']['Networks'][$c['NetworkMode']]['IPAddress'] ?? null;
+			$c['Networks'][$c['NetworkMode']] = [ 'IPAddress' => $ip ];
 			foreach($ct['NetworkSettings']['Networks'] as $netName => $netVals) {
 				$i = $c['NetworkMode']=='host' ? $host : $netVals['IPAddress'];
 				$c['Networks'][$netName] = [ 'IPAddress' => $i ];

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -951,13 +951,11 @@ class DockerClient {
 			} else if (!$id) {
 				$c['NetworkMode'] = DockerUtil::ctMap($c['NetworkMode']);
 				$ports = &$info['Config']['ExposedPorts'];
-				foreach($ct['NetworkSettings']['Networks'] as $netName => $netVals) {
-					$i = $c['NetworkMode']=='host' ? $host : $netVals['IPAddress'];
-					$c['Networks'][$netName] = [ 'IPAddress' => $i ];
-				}
 			}
-			$ip = $c['NetworkMode']=='host' ? $host : $ct['NetworkSettings']['Networks'][$c['NetworkMode']]['IPAddress'] ?? null;
-			$c['Networks'][$c['NetworkMode']] = [ 'IPAddress' => $ip ];
+			foreach($ct['NetworkSettings']['Networks'] as $netName => $netVals) {
+				$i = $c['NetworkMode']=='host' ? $host : $netVals['IPAddress'];
+				$c['Networks'][$netName] = [ 'IPAddress' => $i ];
+			}
 			$ports = (isset($ports) && is_array($ports)) ? $ports : [];
 			foreach ($ports as $port => $value) {
 				if (!isset($info['HostConfig']['PortBindings'][$port])) {

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -89,29 +89,29 @@ foreach ($containers as $ct) {
   $wait = var_split($autostart[array_search($name,$names)]??'',1);
   $networks = [];
   $network_ips = [];
+  $ports_internal = [];
+  $ports_external = [];
   foreach($ct['Networks'] as $netName => $netVals) {
     $networks[] = $netName;
     $network_ips[] = $netVals['IPAddress'];
-  }
-  $ports_internal = [];
-  $ports_external = [];
-  foreach ($ct['Ports'] as $port) {
-    if (strpos($ct['NetworkMode'], 'container:') === 0)
-      break;
-    if (_var($port,'PublicPort') && _var($port,'Driver') == 'bridge')
-      $ports_external[] = sprintf('%s:%s', $host, strtoupper(_var($port,'PublicPort')));
-    if (isset($ct['Networks']['host'])) {
-      $ports_external[] = sprintf('%s', $netVals['IPAddress']);
-      $ports_internal[] = sprintf('%s', 'all');
-      break;
-    }
-    if (isset($ct['Ports']['vlan'])) {
-      $ports_external[] = sprintf('%s', $netVals['IPAddress']);
-      $ports_internal[] = sprintf('%s', 'all');
-      break;
-    }
-    if ((!isset($ct['Networks']['host'])) || (!isset($ct['Networks']['vlan']))) {
-      $ports_internal[] = sprintf('%s:%s', _var($port,'PrivatePort'), strtoupper(_var($port,'Type')));
+    foreach ($ct['Ports'] as $port) {
+      if (strpos($ct['NetworkMode'], 'container:') === 0)
+        break;
+      if (_var($port,'PublicPort') && _var($port,'Driver') == 'bridge')
+        $ports_external[] = sprintf('%s:%s', $host, strtoupper(_var($port,'PublicPort')));
+      if (isset($ct['Networks']['host'])) {
+        $ports_external[] = sprintf('%s', $netVals['IPAddress']);
+        $ports_internal[0] = sprintf('%s', 'all');
+        break;
+      }
+      if (isset($ct['Ports']['vlan'])) {
+        $ports_external[] = sprintf('%s', $netVals['IPAddress']);
+        $ports_internal[0] = sprintf('%s', 'all');
+        break;
+      }
+      if ((!isset($ct['Networks']['host'])) || (!isset($ct['Networks']['vlan']))) {
+        $ports_internal[] = sprintf('%s:%s', _var($port,'PrivatePort'), strtoupper(_var($port,'Type')));
+      }
     }
   }
   $paths = [];

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -91,26 +91,24 @@ foreach ($containers as $ct) {
   $network_ips = [];
   $ports_internal = [];
   $ports_external = [];
+  if (isset($ct['Ports']['vlan'])) {
+    foreach ($ct['Ports']['vlan'] as $i)
+      $ports_external[] = sprintf('%s', $i);
+    $ports_internal[0] = sprintf('%s', 'all');
+  }
   foreach($ct['Networks'] as $netName => $netVals) {
     $networks[] = $netName;
     $network_ips[] = $netVals['IPAddress'];
-    foreach ($ct['Ports'] as $port) {
-      if (strpos($ct['NetworkMode'], 'container:') === 0)
-        break;
-      if (_var($port,'PublicPort') && _var($port,'Driver') == 'bridge')
-        $ports_external[] = sprintf('%s:%s', $host, strtoupper(_var($port,'PublicPort')));
-      if (isset($ct['Networks']['host'])) {
-        $ports_external[] = sprintf('%s', $netVals['IPAddress']);
-        $ports_internal[0] = sprintf('%s', 'all');
-        break;
-      }
-      if (isset($ct['Ports']['vlan'])) {
-        $ports_external[] = sprintf('%s', $netVals['IPAddress']);
-        $ports_internal[0] = sprintf('%s', 'all');
-        break;
-      }
-      if ((!isset($ct['Networks']['host'])) || (!isset($ct['Networks']['vlan']))) {
-        $ports_internal[] = sprintf('%s:%s', _var($port,'PrivatePort'), strtoupper(_var($port,'Type')));
+
+    if (isset($ct['Networks']['host'])) {
+      $ports_external[] = sprintf('%s', $netVals['IPAddress']);
+      $ports_internal[0] = sprintf('%s', 'all');
+    } else if (!isset($ct['Ports']['vlan']) || strpos($ct['NetworkMode'], 'container:') != 0) {
+      foreach ($ct['Ports'] as $port) {
+        if (_var($port,'PublicPort') && _var($port,'Driver') == 'bridge')
+          $ports_external[] = sprintf('%s:%s', $host, strtoupper(_var($port,'PublicPort')));
+        if ((!isset($ct['Networks']['host'])) || (!isset($ct['Networks']['vlan'])))
+          $ports_internal[] = sprintf('%s:%s', _var($port,'PrivatePort'), strtoupper(_var($port,'Type')));
       }
     }
   }


### PR DESCRIPTION
This commit ensures containers with multiple networks are always displayed. Previously, networks connected to containers (docker network connect...) don't show
This is an improvement on #1616 