### PR TITLE
fix inconsistent PHP error reporting defaults (PHPSettings.page)

### DIFF
--- a/emhttp/plugins/dynamix/PHPsettings.page
+++ b/emhttp/plugins/dynamix/PHPsettings.page
@@ -47,11 +47,11 @@ under normal running conditions.
 _(Error reporting level)_:
 : <select name="error_reporting" onchange="toggleScreen(this.selectedIndex)">
   <?=mk_option(_var($conf,'error_reporting'), strval(E_ALL & ~E_NOTICE & ~E_WARNING & ~E_DEPRECATED), "_(Default)_");?>
-  <?=mk_option(_var($conf,'error_reporting'), "32767", "_(All Categories)_");?>
-  <?=mk_option(_var($conf,'error_reporting'), "1", "_(Errors Only)_");?>
-  <?=mk_option(_var($conf,'error_reporting'), "2", "_(Warnings Only)_");?>
-  <?=mk_option(_var($conf,'error_reporting'), "8", "_(Notices Only)_");?>
-  <?=mk_option(_var($conf,'error_reporting'), "8192", "_(Deprecated Only)_");?>
+  <?=mk_option(_var($conf,'error_reporting'), strval(E_ALL), "_(All Categories)_");?>
+  <?=mk_option(_var($conf,'error_reporting'), strval(E_ERROR), "_(Errors Only)_");?>
+  <?=mk_option(_var($conf,'error_reporting'), strval(E_WARNING), "_(Warnings Only)_");?>
+  <?=mk_option(_var($conf,'error_reporting'), strval(E_NOTICE), "_(Notices Only)_");?>
+  <?=mk_option(_var($conf,'error_reporting'), strval(E_DEPRECATED), "_(Deprecated Only)_");?>
   </select>
 
 &nbsp;

--- a/emhttp/plugins/dynamix/PHPsettings.page
+++ b/emhttp/plugins/dynamix/PHPsettings.page
@@ -46,7 +46,7 @@ under normal running conditions.
 <input type="hidden" name="log_errors" value="1">
 _(Error reporting level)_:
 : <select name="error_reporting" onchange="toggleScreen(this.selectedIndex)">
-  <?=mk_option(_var($conf,'error_reporting'), "E_ALL & ~E_NOTICE & ~E_WARNING & ~E_DEPRECATED", "_(Default)_");?>
+  <?=mk_option(_var($conf,'error_reporting'), strval(E_ALL & ~E_NOTICE & ~E_WARNING & ~E_DEPRECATED), "_(Default)_");?>
   <?=mk_option(_var($conf,'error_reporting'), "32767", "_(All Categories)_");?>
   <?=mk_option(_var($conf,'error_reporting'), "1", "_(Errors Only)_");?>
   <?=mk_option(_var($conf,'error_reporting'), "2", "_(Warnings Only)_");?>

--- a/emhttp/plugins/dynamix/PHPsettings.page
+++ b/emhttp/plugins/dynamix/PHPsettings.page
@@ -28,7 +28,7 @@ if (!file_exists($log)) touch($log);
 :php_settings_plug:
 This utility is used for development purposes only and allows Plugin Authors to verify their PHP code by enabling different levels of PHP error reporting.
 
-By default error logging is minimum and any errors are shown on screen. Changing the **Error reporting level** will capture the selected level of errors
+By default error logging is minimum and errors are not shown on screen. Changing the **Error reporting level** will capture the selected level of errors
 into a LOG file, which can be opened in a separate window to monitor in real-time the events when visiting various GUI pages or executing background
 processes on the server.
 
@@ -46,7 +46,7 @@ under normal running conditions.
 <input type="hidden" name="log_errors" value="1">
 _(Error reporting level)_:
 : <select name="error_reporting" onchange="toggleScreen(this.selectedIndex)">
-  <?=mk_option(_var($conf,'error_reporting'), "", "_(Default)_");?>
+  <?=mk_option(_var($conf,'error_reporting'), "E_ALL & ~E_NOTICE & ~E_WARNING & ~E_DEPRECATED", "_(Default)_");?>
   <?=mk_option(_var($conf,'error_reporting'), "32767", "_(All Categories)_");?>
   <?=mk_option(_var($conf,'error_reporting'), "1", "_(Errors Only)_");?>
   <?=mk_option(_var($conf,'error_reporting'), "2", "_(Warnings Only)_");?>
@@ -147,11 +147,12 @@ function PHPinfo() {
 }
 function preset(form) {
   // reset to default settings
+  // derived from default .ini file installed at boot
   if (form.error_reporting.selectedIndex==0) {
-    form.error_log.value = "";
-    form.display_startup_errors.value = "";
-    form.display_errors.value = "";
-    form.log_errors.value = "";
+    form.error_log.value = "<?=$log?>";
+    form.display_startup_errors.value = "0";
+    form.display_errors.value = "0";
+    form.log_errors.value = "1";
   }
   $.cookie('reload_php',1);
 }


### PR DESCRIPTION
**TLDR:** Setting the PHP error reporting level to "Default" in the GUI does not restore the respective boot-time default state, but deletes the configuration file, which causes any PHP events to be shown on screen and GUI elements/plugins to break. This PR fixes that bug and makes the GUI "Default" for PHP error reporting level consistent with that of the OS boot-time defaults.

### Current inconsistency between "Default" setting in _Tools->PHP Settings_ and OS defaults:
**At boot-time the OS installs the following sane PHP error reporting level defaults**:
```
root@TowerOLD:~# cat /etc/php.d/errors-php.ini
error_log="/var/log/phplog"
display_startup_errors="0"
display_errors="0"
log_errors="1"
error_reporting=E_ALL & ~E_NOTICE & ~E_WARNING & ~E_DEPRECATED
```
**Setting a different PHP error reporting level through the GUI and then setting it back to "Default" (in the GUI):**
```
root@TowerOLD:~# cat /etc/php.d/errors-php.ini
cat: /etc/php.d/errors-php.ini: No such file or Directory
```
We can see that the sane OS defaults are not restored but the settings file is completely deleted instead. This results in any PHP events (even extremely verbose ones, such as function deprecation notices) being shown on screen, which is breaking GUI elements relying on the responses of (backend) PHP scripts - as shown PHP warnings will corrupt the expected response.

See here (for such experienced problems from when I had not figured out this issue yet):
https://forums.unraid.net/topic/89453-plugin-gpu-statistics/?do=findComment&comment=1453748
https://forums.unraid.net/topic/38582-plug-in-community-applications/?do=findComment&comment=1451469

### Proposed PR makes "Default" setting in _Tools->PHP Settings_ consistent with OS defaults:

Boot-Time Defaults:
```
root@TowerOLD:~# cat /etc/php.d/errors-php.ini
error_log="/var/log/phplog"
display_startup_errors="0"
display_errors="0"
log_errors="1"
error_reporting=E_ALL & ~E_NOTICE & ~E_WARNING & ~E_DEPRECATED
```
Setting to "Default" in _Tools->PHP Settings_ (with proposed changes of this PR applied):
```
root@TowerOLD:~# cat /etc/php.d/errors-php.ini 
error_log="/var/log/phplog"
display_startup_errors="0"
display_errors="0"
log_errors="1"
error_reporting="24565"
```
`24565` = `E_ALL & ~E_NOTICE & ~E_WARNING & ~E_DEPRECATED` (for practical reasons, see 31f81349a890c74c65355b29d167e6418cfcf2ca & 8d9e2a04c0a33cb13f8edf622ac0ee6852e8f196)

-- Rysz
