### PR TITLE
Add Unmap Support

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt.php
@@ -699,7 +699,7 @@
 						if ($strDevType == 'file' || $strDevType == 'block') {
 							$strSourceType = ($strDevType == 'file' ? 'file' : 'dev');
 
-							if ($strDevType == "file" && ($disk['bus'] == "virtio" || $disk['bus'] == "scsi" || $disk['bus'] == "sata")) $strDevUnmap = ' discard="unmap" '; else $strDevUnmap ="";
+							if (isset($disk['discard'])) $strDevUnmap = " discard=\"{$disk['discard']}\" "; else $strDevUnmap = " discard=\"ignore\" ";
 
 							$diskstr .= "<disk type='" . $strDevType . "' device='disk'>
 											<driver name='qemu' type='" . $disk['driver'] . "' cache='writeback'".$strDevUnmap."/>
@@ -1341,6 +1341,7 @@
 				if ($tmp) {
 					$tmp['bus'] = $disk->target->attributes()->bus->__toString();
 					$tmp["boot order"] = $disk->boot->attributes()->order ?? "";
+					$tmp["discard"] = $disk->driver->attributes()->discard ?? "ignore";
 					$tmp["rotation"] = $disk->target->attributes()->rotation_rate ?? "0";
 					$tmp['serial'] = $disk->serial ;
 
@@ -1371,7 +1372,8 @@
 						'bus' =>  $disk->target->attributes()->bus->__toString(),
 						'boot order' => $disk->boot->attributes()->order ,
 						'rotation' => $disk->target->attributes()->rotation_rate ?? "0",
-						'serial' => $disk->serial
+						'serial' => $disk->serial,
+						'discard' => $disk->driver->attributes()->discard ?? "ignore"
 					];
 				}
 			}

--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt.php
@@ -699,8 +699,10 @@
 						if ($strDevType == 'file' || $strDevType == 'block') {
 							$strSourceType = ($strDevType == 'file' ? 'file' : 'dev');
 
+							if ($strDevType == "file" && ($disk['bus'] == "virtio" || $disk['bus'] == "scsi" || $disk['bus'] == "sata")) $strDevUnmap = ' discard="unmap" '; else $strDevUnmap ="";
+
 							$diskstr .= "<disk type='" . $strDevType . "' device='disk'>
-											<driver name='qemu' type='" . $disk['driver'] . "' cache='writeback'/>
+											<driver name='qemu' type='" . $disk['driver'] . "' cache='writeback'".$strDevUnmap."/>
 											<source " . $strSourceType . "='" . htmlspecialchars($disk['image'], ENT_QUOTES | ENT_XML1) . "'/>
 											<target bus='" . $disk['bus'] . "' dev='" . $disk['dev'] . "' $rotation_rate />
 											$bootorder

--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -1091,6 +1091,15 @@ private static $encoding = 'UTF-8';
 		return $arrValidDiskBuses;
 	}
 
+	function getValidDiskDiscard() {
+		$arrValidDiskDiscard = [
+			'ignore' => 'Ignore(No Trim)',
+			'unmap' => 'Unmap(Trim)',
+		];
+
+		return $arrValidDiskDiscard;
+	}
+
 	function getValidCdromBuses() {
 		$arrValidCdromBuses = [
 			'scsi' => 'SCSI',
@@ -1316,6 +1325,7 @@ private static $encoding = 'UTF-8';
 				'driver' => $disk['type'],
 				'dev' => $disk['device'],
 				'bus' => $disk['bus'],
+				'discard' => $disk['discard'],
 				'boot' => $disk['boot order'],
 				'rotation' => $disk['rotation'],
 				'serial' => $disk['serial'],
@@ -1330,6 +1340,7 @@ private static $encoding = 'UTF-8';
 				'dev' => 'hda',
 				'select' => '',
 				'bus' => 'virtio',
+				'discard' => 'ignore',
 				'rotation' => "0"
 			];
 		}

--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -1457,7 +1457,12 @@ private static $encoding = 'UTF-8';
 		// preserve existing disk driver settings
 		foreach ($new['devices']['disk'] as $key => $disk) {
 			$source = $disk['source']['@attributes']['file'];
-			foreach ($old['devices']['disk'] as $k => $d) if ($source==$d['source']['@attributes']['file']) $new['devices']['disk'][$key]['driver']['@attributes'] = $d['driver']['@attributes'];
+			if (isset($disk['driver']['@attributes']['discard'])) $discard = $disk['driver']['@attributes']['discard']; else $discard = null;
+			foreach ($old['devices']['disk'] as $k => $d) 
+				if ($source==$d['source']['@attributes']['file']) { 
+					if (isset($discard)) $d['driver']['@attributes']['discard'] = $discard;
+					$new['devices']['disk'][$key]['driver']['@attributes'] = $d['driver']['@attributes'];
+				}
 		}
 		// settings not in the GUI, but maybe customized
 		unset($old['clock']);

--- a/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -31,6 +31,7 @@
 	$arrValidUSBDevices = getValidUSBDevices();
 	$arrValidDiskDrivers = getValidDiskDrivers();
 	$arrValidDiskBuses = getValidDiskBuses();
+	$arrValidDiskDiscard = getValidDiskDiscard();
 	$arrValidCdromBuses = getValidCdromBuses();
 	$arrValidVNCModels = getValidVNCModels();
 	$arrValidProtocols = getValidVMRCProtocols();
@@ -88,7 +89,8 @@
 				'select' => $domain_cfg['VMSTORAGEMODE'],
 				'bus' => 'virtio' ,
 				'boot' => 1,
-				'serial' => 'vdisk1'
+				'serial' => 'vdisk1',
+				'discard' => 'ignore'
 			]
 		],
 		'gpu' => [
@@ -848,6 +850,10 @@
 					</select>
 				_(Boot Order)_:
 				<input type="number" size="5" maxlength="5" id="disk[<?=$i?>][boot]" class="narrow bootorder" style="width: 50px;" name="disk[<?=$i?>][boot]"   title="_(Boot order)_"  value="<?=$arrDisk['boot']?>" >
+				_(Discard)_:
+					<select name="disk[<?=$i?>][discard]" class="disk_driver narrow" title="_(Set discard option)_">
+					<?mk_dropdown_options($arrValidDiskDiscard, $arrDisk['discard']);?>
+					</select>
 				<? if ($arrDisk['bus'] == "virtio" || $arrDisk['bus'] == "usb") $ssddisabled = "hidden "; else $ssddisabled = " ";?>
 				<span id="disk[<?=$i?>][rotatetext]" <?=$ssddisabled?>>_(SSD)_:</span>
 				<input type="checkbox"  id="disk[<?=$i?>][rotation]" class="narrow rotation" onchange="updateSSDCheck(this)"style="width: 50px;" name="disk[<?=$i?>][rotation]"  <?=$ssddisabled ?> <?=$arrDisk['rotation'] ? "checked ":"";?>  title="_(Set SDD flag)_"  value="<?=$arrDisk['rotation']?>" >
@@ -896,6 +902,11 @@
 			<p class="advanced">
 				<b>vDisk Boot Order</b><br>
 				Specify the order the devices are used for booting.
+			</p>
+
+			<p class="advanced">
+				<b>vDisk Discard</b><br>
+				Specify if unmap(Trim) requests are sent to underlaying filesystem.
 			</p>
 
 			<p class="advanced">
@@ -1002,6 +1013,10 @@
 
 				_(Boot Order)_:
 				<input type="number" size="5" maxlength="5" id="disk[{{INDEX}}][boot]" class="narrow bootorder" style="width: 50px;" name="disk[{{INDEX}}][boot]"   title="_(Boot order)_"  value="" >
+				_(Discard)_:
+					<select name="disk[{{INDEX}}][discard]" class="disk_driver narrow" title="_(Set discard option)_">
+					<?mk_dropdown_options($arrValidDiskDiscard, "ignore");?>
+					</select>
 				<span id="disk[{{INDEX}}][rotatetext]" hidden>_(SSD)_:</span>
 				<input type="checkbox"  id="disk[{{INDEX}}][rotation]" class="narrow rotation" onchange="updateSSDCheck(this)"style="width: 50px;" name="disk[{{INDEX}}[rotation]" hidden title="_(Set SSD flag)_" value='0' >
 				</td>


### PR DESCRIPTION
Add support for unmap by adding discard='unmap' if type is file and either of these bus types. Virtio,SCSI or SATA

Example XML
`<disk type='file' device='disk'>
      <driver name='qemu' type='raw' cache='writeback' discard='unmap'/>
      <source file='/mnt/vmpoolzfs/domains2/Linuxxxy/vdisk1.img'/>
      <target dev='hdc' bus='virtio'/>
      <serial>vdisk1</serial>
      <boot order='1'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
    </disk>` 