### PR TITLE
Feature Request: Use user's actual shell in OpenTerminal.php #1832

### DIFF
--- a/emhttp/plugins/dynamix/include/OpenTerminal.php
+++ b/emhttp/plugins/dynamix/include/OpenTerminal.php
@@ -51,7 +51,9 @@ case 'ttyd':
     // no child processes, restart ttyd to pick up possible font size change
     if ($retval != 0) exec("kill ".$ttyd_pid[0]);
   }
-  if ($retval != 0) exec("ttyd-exec -i '$sock' " . basename(posix_getpwuid(0)['shell']) . " --login");
+  $userShell = basename(posix_getpwuid(0)['shell']);
+  $shell = in_array($userShell, ['bash', 'sh', 'zsh', 'fish', 'ksh', 'tcsh', 'dash']) ? $userShell : 'bash';
+  if ($retval != 0) exec("ttyd-exec -i '$sock' $shell --login");
   break;
 case 'syslog':
   // read syslog file

--- a/emhttp/plugins/dynamix/include/OpenTerminal.php
+++ b/emhttp/plugins/dynamix/include/OpenTerminal.php
@@ -73,7 +73,7 @@ case 'ttyd':
     // no child processes, restart ttyd to pick up possible font size change
     if ($retval != 0) exec("kill ".$ttyd_pid[0]);
   }
-  if ($retval != 0) exec("ttyd-exec -i '$sock' " . getUserShell() . " --login");
+  if ($retval != 0) exec("ttyd-exec -i '$sock' " . escapeshellarg(getUserShell()) . " --login");
   break;
 case 'syslog':
   // read syslog file

--- a/emhttp/plugins/dynamix/include/OpenTerminal.php
+++ b/emhttp/plugins/dynamix/include/OpenTerminal.php
@@ -51,8 +51,7 @@ case 'ttyd':
     // no child processes, restart ttyd to pick up possible font size change
     if ($retval != 0) exec("kill ".$ttyd_pid[0]);
   }
-  $shell = posix_getpwuid(0)['shell'] === '/bin/zsh' ? 'zsh' : 'bash';
-  if ($retval != 0) exec("ttyd-exec -i '$sock' '$shell' --login");
+  if ($retval != 0) exec("ttyd-exec -i '$sock' '" . posix_getpwuid(0)['shell'] . "' --login");
   break;
 case 'syslog':
   // read syslog file

--- a/emhttp/plugins/dynamix/include/OpenTerminal.php
+++ b/emhttp/plugins/dynamix/include/OpenTerminal.php
@@ -45,10 +45,10 @@ function getUserShell() {
     }
   } catch (Throwable $t) {
     syslog(LOG_ERR, 'Error determining user shell: ' . $t->getMessage());
-    return defaultShell;
+    return $defaultShell;
   }
   
-  return defaultShell;
+  return $defaultShell;
 }
 
 function wait($name,$cmd) {

--- a/emhttp/plugins/dynamix/include/OpenTerminal.php
+++ b/emhttp/plugins/dynamix/include/OpenTerminal.php
@@ -30,26 +30,25 @@ $run  = "$docroot/webGui/scripts/run_cmd";
 if (!empty($display['tty'])) exec("sed -ri 's/fontSize=[0-9]+/fontSize={$display['tty']}/' /etc/default/ttyd");
 
 function getUserShell() {
-  $shell = 'bash';
+  $defaultShell = 'bash';
+  
   try {
     $username = posix_getpwuid(posix_geteuid())['name'];
     $passwd = file_get_contents('/etc/passwd');
     $lines = explode("\n", $passwd);
     foreach ($lines as $line) {
-        $parts = explode(':', $line);
-        if ($parts[0] === $username) {
-            $fullShellPath = end($parts);
-            $shell = basename(trim($fullShellPath));
-            break;
-        }
+      $parts = explode(':', $line);
+      if ($parts[0] === $username) {
+          $fullShellPath = end($parts);
+          return basename(trim($fullShellPath));
+      }
     }
-  } catch (Exception $e) {
-      syslog(LOG_ERR, "Error determining user shell: " . $e->getMessage());
+  } catch (Throwable $t) {
+    syslog(LOG_ERR, 'Error determining user shell: ' . $t->getMessage());
+    return defaultShell;
   }
   
-  syslog(LOG_INFO, sprintf("User shell determined: %s %s", $username, $shell));
-  
-  return $shell;
+  return defaultShell;
 }
 
 function wait($name,$cmd) {

--- a/emhttp/plugins/dynamix/include/OpenTerminal.php
+++ b/emhttp/plugins/dynamix/include/OpenTerminal.php
@@ -51,9 +51,8 @@ case 'ttyd':
     // no child processes, restart ttyd to pick up possible font size change
     if ($retval != 0) exec("kill ".$ttyd_pid[0]);
   }
-  $userShell = basename(posix_getpwuid(0)['shell']);
-  $shell = in_array($userShell, ['bash', 'sh', 'zsh', 'fish', 'ksh', 'tcsh', 'dash']) ? $userShell : 'bash';
-  if ($retval != 0) exec("ttyd-exec -i '$sock' $shell --login");
+  $shell = posix_getpwuid(0)['shell'] === '/bin/zsh' ? 'zsh' : 'bash';
+  if ($retval != 0) exec("ttyd-exec -i '$sock' '$shell' --login");
   break;
 case 'syslog':
   // read syslog file

--- a/emhttp/plugins/dynamix/include/OpenTerminal.php
+++ b/emhttp/plugins/dynamix/include/OpenTerminal.php
@@ -32,20 +32,23 @@ if (!empty($display['tty'])) exec("sed -ri 's/fontSize=[0-9]+/fontSize={$display
 function getUserShell() {
   $shell = 'bash';
   try {
-      $username = posix_getpwuid(posix_geteuid())['name'];
-      $passwd = file_get_contents('/etc/passwd');
-      $lines = explode("\n", $passwd);
-      foreach ($lines as $line) {
-          if (strpos($line, $username) === 0) {
-              $parts = explode(':', $line);
-              $fullShellPath = end($parts);
-              $shell = basename(trim($fullShellPath));
-              break;
-          }
-      }
+    $username = posix_getpwuid(posix_geteuid())['name'];
+    $passwd = file_get_contents('/etc/passwd');
+    $lines = explode("\n", $passwd);
+    foreach ($lines as $line) {
+        $parts = explode(':', $line);
+        if ($parts[0] === $username) {
+            $fullShellPath = end($parts);
+            $shell = basename(trim($fullShellPath));
+            break;
+        }
+    }
   } catch (Exception $e) {
-      syslog(LOG_ERR, "Fehler beim Ermitteln der User-Shell: " . $e->getMessage());
+      syslog(LOG_ERR, "Error determining user shell: " . $e->getMessage());
   }
+  
+  syslog(LOG_INFO, sprintf("User shell determined: %s %s", $username, $shell));
+  
   return $shell;
 }
 


### PR DESCRIPTION
Added function getUserShell() to OpenTerminal.php and use it for the execution