### PR TITLE
update.php: add two optional methods to define defaults

### DIFF
--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -31,10 +31,12 @@
  *                  instead of the regular 'default.cfg' file. If pathname is relative (no leading '/'),
  *                  the given configuration file will be searched for under '/usr/local/emhttp/plugins/'.
  * 
- * #defaultvalues : If present in combination with #default, no defaults file but an associative array
- *                  passed through POST in format of 'defaultvalues[key]=value' will be restored instead.
- *                  e.g. <input type="hidden" name="#defaultvalues[SERVICE]" value="enable">
- *                  e.g. <input type="hidden" name="#defaultvalues[INTERVAL]" value="25">
+ * #defaults      : If present in combination with #default, no defaults file but an associative array
+ *                  passed through POST in format of '#defaults[key]=value' will be restored instead.
+ *                  e.g. <input type="hidden" name="#defaults[SERVICE]" value="enable">
+ *                  e.g. <input type="hidden" name="#defaults[INTERVAL]" value="25">
+ *                  Beware: Browsers generally do not send empty values, if your default values include
+ *                  any empty strings, you should preferably use a default configuration file instead.
  * 
  * #include       : Specifies name of an include file to read and execute in before saving the file contents.
  * #cleanup       : If present then parameters with empty strings are omitted from being written to the file.
@@ -69,8 +71,8 @@ if (isset($_POST['#file'])) {
       $defaultfile = $_POST['#defaultfile'];
       if ($defaultfile && $defaultfile[0]!='/') $defaultfile = "$docroot/plugins/$defaultfile";
       $default = @parse_ini_file($defaultfile, $section) ?: [];
-    } elseif(isset($_POST['#defaultvalues'])) {
-      $default = is_array($_POST['#defaultvalues']) ? ($_POST['#defaultvalues'] ?: []) : [];
+    } elseif(isset($_POST['#defaults'])) {
+      $default = is_array($_POST['#defaults']) ? ($_POST['#defaults'] ?: []) : [];
     } else {
       $default = @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/default.cfg", $section) ?: [];
     }

--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -26,8 +26,8 @@
  *                If omitted, then it's just a flat ini file without sections.
  * 
  * #default     : If present, then the default values will be restored instead (from 'default.cfg').
- * #defaultfile : If present in combination with #default, a custom defaults file
- *                relative to the document root is read (instead of 'default.cfg').
+ * #defaultfile : If present in combination with #default, a custom defaults file relative to the
+ *                plugin's document root will be restored instead (and not that 'default.cfg' file).
  * 
  * #include     : Specifies name of an include file to read and execute in before saving the file contents.
  * #cleanup     : If present then parameters with empty strings are omitted from being written to the file.

--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -70,11 +70,11 @@ if (isset($_POST['#file'])) {
     if(isset($_POST['#defaultfile'])) {
       $defaultfile = $_POST['#defaultfile'];
       if ($defaultfile && $defaultfile[0]!='/') $defaultfile = "$docroot/plugins/$defaultfile";
-      $default = @parse_ini_file($defaultfile, $section) ?: [];
+      $default = parse_ini_file($defaultfile, $section) ?: [];
     } elseif(isset($_POST['#defaults'])) {
       $default = is_array($_POST['#defaults']) ? ($_POST['#defaults'] ?: []) : [];
     } else {
-      $default = @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/default.cfg", $section) ?: [];
+      $default = parse_ini_file("$docroot/plugins/".basename(dirname($file))."/default.cfg", $section) ?: [];
     }
   }
 

--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -70,7 +70,7 @@ if (isset($_POST['#file'])) {
       if ($defaultfile && $defaultfile[0]!='/') $defaultfile = "$docroot/plugins/$defaultfile";
       $default = @parse_ini_file($defaultfile, $section) ?: [];
     } elseif(isset($_POST['#defaultvalues'])) {
-        $default = $_POST['#defaultvalues'] ?: [];
+        $default = is_array($_POST['#defaultvalues']) ? ($_POST['#defaultvalues'] ?: []) : [];
     } else {
       $default = @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/default.cfg", $section) ?: [];
     }

--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -18,7 +18,7 @@
  *
  * #file        : The pathname of the file to be updated. It does not need to previously exist.
  *                If pathname is relative (no leading '/'), the configuration file will placed
- *                placed under '/boot/config/plugins'.
+ *                placed under '/boot/config/plugins/'.
  *                This parameter may be omitted to perform a command execution only (see #command).
  * 
  * #section     : If present, then the ini file consists of a set of named sections, and all of the
@@ -29,7 +29,7 @@
  * 
  * #defaultfile : If present in combination with #default, a custom defaults file will be restored
  *                instead of the regular 'default.cfg' file. If pathname is relative (no leading '/'),
- *                the given configuration file will be searched for under '/usr/local/emhttp/plugins'.
+ *                the given configuration file will be searched for under '/usr/local/emhttp/plugins/'.
  * 
  * #include     : Specifies name of an include file to read and execute in before saving the file contents.
  * #cleanup     : If present then parameters with empty strings are omitted from being written to the file.

--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -59,9 +59,9 @@ if (isset($_POST['#file'])) {
   $default = [];
   if($file && isset($_POST['#default'])) {
     if(isset($_POST['#defaultfile'])) {
-      $default = @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/".$_POST['#defaultfile'], $section) ?? [];
+      $default = @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/".$_POST['#defaultfile'], $section) ?: [];
     } else {
-      $default = @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/default.cfg", $section) ?? [];
+      $default = @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/default.cfg", $section) ?: [];
     }
   }
 

--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -70,7 +70,7 @@ if (isset($_POST['#file'])) {
       if ($defaultfile && $defaultfile[0]!='/') $defaultfile = "$docroot/plugins/$defaultfile";
       $default = @parse_ini_file($defaultfile, $section) ?: [];
     } elseif(isset($_POST['#defaultvalues'])) {
-        $default = is_array($_POST['#defaultvalues']) ? ($_POST['#defaultvalues'] ?: []) : [];
+      $default = is_array($_POST['#defaultvalues']) ? ($_POST['#defaultvalues'] ?: []) : [];
     } else {
       $default = @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/default.cfg", $section) ?: [];
     }

--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -16,25 +16,30 @@
  * The $_POST variable contains a list of key/value parameters to be updated in the file.
  * There are a number of special parameters prefixed with a hash '#' character:
  *
- * #file        : The pathname of the file to be updated. It does not need to previously exist.
- *                If pathname is relative (no leading '/'), the configuration file will placed
- *                placed under '/boot/config/plugins/'.
- *                This parameter may be omitted to perform a command execution only (see #command).
+ * #file          : The pathname of the file to be updated. It does not need to previously exist.
+ *                  If pathname is relative (no leading '/'), the configuration file will placed
+ *                  placed under '/boot/config/plugins/'.
+ *                  This parameter may be omitted to perform a command execution only (see #command).
  * 
- * #section     : If present, then the ini file consists of a set of named sections, and all of the
- *                configuration parameters apply to this one particular section.
- *                If omitted, then it's just a flat ini file without sections.
+ * #section       : If present, then the ini file consists of a set of named sections, and all of the
+ *                  configuration parameters apply to this one particular section.
+ *                  If omitted, then it's just a flat ini file without sections.
  * 
- * #default     : If present, then the default values will be restored instead (from 'default.cfg').
+ * #default       : If present, then the default values will be restored instead (from 'default.cfg').
  * 
- * #defaultfile : If present in combination with #default, a custom defaults file will be restored
- *                instead of the regular 'default.cfg' file. If pathname is relative (no leading '/'),
- *                the given configuration file will be searched for under '/usr/local/emhttp/plugins/'.
+ * #defaultfile   : If present in combination with #default, a custom defaults file will be restored
+ *                  instead of the regular 'default.cfg' file. If pathname is relative (no leading '/'),
+ *                  the given configuration file will be searched for under '/usr/local/emhttp/plugins/'.
  * 
- * #include     : Specifies name of an include file to read and execute in before saving the file contents.
- * #cleanup     : If present then parameters with empty strings are omitted from being written to the file.
- * #command     : A shell command to execute after updating the configuration file.
- * #arg         : An array of arguments for the shell command.
+ * #defaultvalues : If present in combination with #default, no defaults file but an associative array
+ *                  passed through POST in format of 'defaultvalues[key]=value' will be restored instead.
+ *                  e.g. <input type="hidden" name="#defaultvalues[SERVICE]" value="enable">
+ *                  e.g. <input type="hidden" name="#defaultvalues[INTERVAL]" value="25">
+ * 
+ * #include       : Specifies name of an include file to read and execute in before saving the file contents.
+ * #cleanup       : If present then parameters with empty strings are omitted from being written to the file.
+ * #command       : A shell command to execute after updating the configuration file.
+ * #arg           : An array of arguments for the shell command.
  */
 function write_log($string) {
   if (empty($string)) return;
@@ -64,6 +69,8 @@ if (isset($_POST['#file'])) {
       $defaultfile = $_POST['#defaultfile'];
       if ($defaultfile && $defaultfile[0]!='/') $defaultfile = "$docroot/plugins/$defaultfile";
       $default = @parse_ini_file($defaultfile, $section) ?: [];
+    } elseif(isset($_POST['#defaultvalues'])) {
+        $default = $_POST['#defaultvalues'] ?: [];
     } else {
       $default = @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/default.cfg", $section) ?: [];
     }

--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -26,8 +26,10 @@
  *                If omitted, then it's just a flat ini file without sections.
  * 
  * #default     : If present, then the default values will be restored instead (from 'default.cfg').
- * #defaultfile : If present in combination with #default, a custom defaults file relative to the
- *                plugin's document root will be restored instead (and not that 'default.cfg' file).
+ * 
+ * #defaultfile : If present in combination with #default, a custom defaults file will be restored
+ *                instead of the regular 'default.cfg' file. If pathname is relative (no leading '/'),
+ *                the given configuration file will be searched for under '/usr/local/emhttp/plugins'.
  * 
  * #include     : Specifies name of an include file to read and execute in before saving the file contents.
  * #cleanup     : If present then parameters with empty strings are omitted from being written to the file.
@@ -59,7 +61,9 @@ if (isset($_POST['#file'])) {
   $default = [];
   if($file && isset($_POST['#default'])) {
     if(isset($_POST['#defaultfile'])) {
-      $default = @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/".$_POST['#defaultfile'], $section) ?: [];
+      $defaultfile = $_POST['#defaultfile'];
+      if ($defaultfile && $defaultfile[0]!='/') $defaultfile = "$docroot/plugins/$defaultfile";
+      $default = @parse_ini_file($defaultfile, $section) ?: [];
     } else {
       $default = @parse_ini_file("$docroot/plugins/".basename(dirname($file))."/default.cfg", $section) ?: [];
     }


### PR DESCRIPTION
Right now there is only one method to define default values for a form with user settings within the WebGUI and plugins.
All default values need to be put into a single `default.cfg` file, which can get messy if a page or plugin has multiple forms.

This PR adds two more methods to define default values, so UI developers can be more flexible when using multiple forms.
**The default behaviour remains unchanged**, but two more options are added for better logical separation of defaults values.

I'm sure these optional additions (default behaviour remains unchanged), would be appreciated by our UI/plugin developers.
It should make it much easier to streamline defining default values for user setting forms, to avoid issues like #1829 .

### Documentation and Usage Examples:

- **Additional documentation added to _update.php_ header:**

```
 * #defaultfile   : If present in combination with #default, a custom defaults file will be restored
 *                  instead of the regular 'default.cfg' file. If pathname is relative (no leading '/'),
 *                  the given configuration file will be searched for under '/usr/local/emhttp/plugins/'.
 * 
 * #defaults      : If present in combination with #default, no defaults file but an associative array
 *                  passed through POST in format of '#defaults[key]=value' will be restored instead.
 *                  e.g. <input type="hidden" name="#defaults[SERVICE]" value="enable">
 *                  e.g. <input type="hidden" name="#defaults[INTERVAL]" value="25">
 *                  Beware: Browsers generally do not send empty values, if your default values include
 *                  any empty strings, you should preferably use a default configuration file instead.
```

- **Method 1 (no additional parameters, _equals current behaviour_):**

```
<input type="submit" name="#default" value="Default">
```
Upon submitting with `#default`, `default.cfg` file is loaded and default values are read from this file.
**_This is the current behaviour that remains unchanged for full backwards compatibility._**

- **Method 2 (with `#defaultfile` parameter)**
```
<input type="hidden" name="#defaultfile" value="/tmp/def.cfg">
<input type="submit" name="#default" value="Default">
```
Upon submitting with `#default`,  `/tmp/def.cfg` is loaded and default values are read from this file.

- **Method 3 (with `#defaults` parameter)**
```
<input type="hidden" name="#defaults[SERVICE]" value="enable">
<input type="hidden" name="#defaults[INTERVAL]" value="25">
<input type="submit" name="#default" value="Default">
```
Upon submitting with `#default`,  no file is loaded and default values are read from the `#defaults` associative array.

-- Rysz