### PR TITLE
Make sure to not show internal IP from stopped containers

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -98,7 +98,7 @@ foreach ($containers as $ct) {
   }
   foreach($ct['Networks'] as $netName => $netVals) {
     $networks[] = $netName;
-    $network_ips[] = $netVals['IPAddress'];
+    $network_ips[] = $running ? $netVals['IPAddress'] : null;
 
     if (isset($ct['Networks']['host'])) {
       $ports_external[] = sprintf('%s', $netVals['IPAddress']);


### PR DESCRIPTION
This is just a small fix to make sure internal IPs from stopped containers are not displayed.

Before:
![before](https://github.com/user-attachments/assets/204309a0-c892-4781-926c-bc80fed85198)


After:
![after](https://github.com/user-attachments/assets/25702220-a3ab-4eef-afac-bb63e5a1c8a8)
