### PR TITLE
Correctly identify/show non dockerman Managed containers

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -929,6 +929,9 @@ class DockerClient {
 			$c['Created']     = $this->humanTiming($ct['Created']);
 			$c['NetworkMode'] = $ct['HostConfig']['NetworkMode'];
 			$c['Manager'] 	  = $info['Config']['Labels']['net.unraid.docker.managed'] ?? false;
+			if ($c['Manager'] == 'composeman') {
+				$c['ComposeProject'] = $info['Config']['Labels']['com.docker.compose.project'];
+			}
 			[$net, $id]       = array_pad(explode(':',$c['NetworkMode']),2,'');
 			$c['CPUset']      = $info['HostConfig']['CpusetCpus'];
 			$c['BaseImage']   = $ct['Labels']['BASEIMAGE'] ?? false;


### PR DESCRIPTION
Show containers which are created not by Unraid (either via the Compose plugin, Portainer running on Unraid, directly via `docker run`, or any other 3rd party method) and which are not labeled to be managed through dockerman.

- Hide Autostart switch from 3rd party containers
- Show that an update is available but don't allow updates (due to 3rd party software)
- Show the Stack name if the containers are created by the Docker Compose plugin

The following are just pictures to demonstrate how that will look like:
The first container is created by Portainer
The second container is created by the Docker Compose plugin
The other containers are created by Unraid through the CA App or through the `Add Container` button
![1](https://github.com/user-attachments/assets/8f0a592b-ae50-4a2c-b6ba-db6c53a58762)


![2](https://github.com/user-attachments/assets/84fd0658-d034-47b8-9ab3-52b52aa1c3e5)


![3](https://github.com/user-attachments/assets/6cbf64b9-3517-4a4c-8fe7-5d032f688f21)
