### PR TITLE
Parity check wrong again.

### DIFF
--- a/emhttp/plugins/dynamix/nchan/parity_list
+++ b/emhttp/plugins/dynamix/nchan/parity_list
@@ -51,13 +51,13 @@ function update_translation($locale) {
     $text = "$docroot/languages/$locale/translations.txt";
     if (file_exists($text)) {
       $store = "$docroot/languages/$locale/translations.dot";
-      if (!file_exists($store)) file_put_contents_atomic($store,serialize(parse_lang_file($text)));
+      if (!file_exists($store)) file_put_contents($store,serialize(parse_lang_file($text)));
       $language = unserialize(file_get_contents($store));
     }
     $text = "$docroot/languages/$locale/main.txt";
     if (file_exists($text)) {
       $store = "$docroot/languages/$locale/main.dot";
-      if (!file_exists($store)) file_put_contents_atomic($store,serialize(parse_lang_file($text)));
+      if (!file_exists($store)) file_put_contents($store,serialize(parse_lang_file($text)));
       $language = array_merge($language,unserialize(file_get_contents($store)));
     }
   }
@@ -66,7 +66,7 @@ function create_sync($file) {
   return file_exists($file) ? explode(',',file_get_contents($file)) : [];
 }
 function create_file($file,...$data) {
-  if (!file_exists($file)) file_put_contents_atomic($file,implode(',',$data));
+  if (!file_exists($file)) file_put_contents($file,implode(',',$data));
 }
 
 while (true) {

--- a/emhttp/plugins/dynamix/nchan/parity_list
+++ b/emhttp/plugins/dynamix/nchan/parity_list
@@ -18,6 +18,7 @@ $log      = '/boot/config/parity-checks.log';
 $stamps   = '/var/tmp/stamps.ini';
 $resync   = '/var/tmp/resync.ini';
 $md5_old  = $spot_old = $fs_old = $proc_old = -1;
+$remove_resync_files = false;
 
 require_once "$docroot/webGui/include/Helpers.php";
 require_once "$docroot/webGui/include/publish.php";
@@ -50,13 +51,13 @@ function update_translation($locale) {
     $text = "$docroot/languages/$locale/translations.txt";
     if (file_exists($text)) {
       $store = "$docroot/languages/$locale/translations.dot";
-      if (!file_exists($store)) file_put_contents($store,serialize(parse_lang_file($text)));
+      if (!file_exists($store)) file_put_contents_atomic($store,serialize(parse_lang_file($text)));
       $language = unserialize(file_get_contents($store));
     }
     $text = "$docroot/languages/$locale/main.txt";
     if (file_exists($text)) {
       $store = "$docroot/languages/$locale/main.dot";
-      if (!file_exists($store)) file_put_contents($store,serialize(parse_lang_file($text)));
+      if (!file_exists($store)) file_put_contents_atomic($store,serialize(parse_lang_file($text)));
       $language = array_merge($language,unserialize(file_get_contents($store)));
     }
   }
@@ -65,7 +66,7 @@ function create_sync($file) {
   return file_exists($file) ? explode(',',file_get_contents($file)) : [];
 }
 function create_file($file,...$data) {
-  if (!file_exists($file)) file_put_contents($file,implode(',',$data));
+  if (!file_exists($file)) file_put_contents_atomic($file,implode(',',$data));
 }
 
 while (true) {
@@ -106,10 +107,15 @@ while (true) {
 			/* Save the result in the parity history log. */
 			file_put_contents($log, "$timestamp|$duration|$speed|$status|$error|$action|$size\n", FILE_APPEND);
 
-			delete_file($stamps, $resync);
+			/* Remove the resync files after the history file has been updated. */
+			$remove_resync_files = true;
 
 			/* Parity check is completed. */
 			$echo = "";
+		} elseif ($remove_resync_files) {
+			delete_file($stamps, $resync);
+
+			$remove_resync_files = false;
 		}
 	}
 
@@ -155,6 +161,6 @@ while (true) {
 		$proc_old = publish('mymonitor', $process) !== false ? $process : -1;
 	}
 
-	sleep(1);
+	sleep(3);
 }
 ?>


### PR DESCRIPTION
- Change poll inrterval to 3 seconds.  There is no reason to poll every second.
- Remove latest parity check files on the next poll after the parity history is updated.  I believe there was a race condition here with the 'monitor' task that sends the notify message.  It was picking up the previous parity history entry and not the current parity check.
- Change 'file_put_contents()' to 'file_put_contents_atomic()' wrapper.  Cannot do this for a file_put_contents file append though.