### PR TITLE
Fix issue with plugin icons

### DIFF
--- a/emhttp/plugins/dynamix/include/PageBuilder.php
+++ b/emhttp/plugins/dynamix/include/PageBuilder.php
@@ -78,7 +78,7 @@ function tab_title($title,$path,$tag) {
   if (!$tag || substr($tag,-4)=='.png') {
     $file = "$path/icons/".($tag ?: strtolower(str_replace(' ','',$title)).".png");
     if (file_exists("$docroot/$file")) {
-      return "<img src='/$file' class='icon'>$title";
+      return "<img src='/$file' class='icon' style='max-width: 18px; max-height: 18px; width: auto; height: auto; object-fit: contain;'>$title";
     } else {
       return "<i class='fa fa-th title'></i>$title";
     }


### PR DESCRIPTION
- make sure the maximum icon size for a plugin is 18x18px

This PR fixes an issue when a plugin maintainer uses a .png as icon file instead of the default Font Awesome ones.

Current implementation with a 500x500px png:
![not working](https://github.com/user-attachments/assets/8047c95b-0c3b-4746-8061-240bb9a65937)

With the changes from the PR:
![working](https://github.com/user-attachments/assets/caf19c67-2c19-44d3-ae96-6d3fec9e4457)
