### PR TITLE
Add fastcgi_path_info to default nginx configuration

### DIFF
--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -386,7 +386,9 @@ build_locations(){
 	#
 	# pass PHP scripts to FastCGI server listening on unix:/var/run/php-fpm.sock
 	#
-	location ~ \.php$ {
+	location ~ ^(.+\.php)(.*)$ {
+	    fastcgi_split_path_info  ^(.+\.php)(.*)$;
+	    fastcgi_param PATH_INFO  $fastcgi_path_info;
 	    include fastcgi_params;
 	}
 	#


### PR DESCRIPTION
This change updates rc.nginx to pass path info to CGI scripts.

This change was initially considered via #1421. Instead of applying the change globally, the change was implemented via the Tailscale plugin patching rc.nginx during Tailscale startup (dkaser/unraid-tailscale-utils@d572961). Per #1421, we planned to evaluate making this a global change after ensuring that it does not have any harmful side effects.

The Tailscale plugin has been applying this change since release 2023.09.14 and is currently in use by at least 11,500 Unraid servers. In this time, there have been no reports of any issues that have been related to the addition of fastcgi_path_info.