### PR TITLE
Only kill sshd from host

### DIFF
--- a/etc/rc.d/rc.sshd
+++ b/etc/rc.d/rc.sshd
@@ -27,10 +27,10 @@ sshd_running(){
   for pid in $(pgrep -f $SSHD); do
     # check if a sshd is running on host system
     if ! grep -qE '/docker/|/lxc/' /proc/$pid/cgroup; then
-      return 1
+      return 0
     fi
   done
-  return 0
+  return 1
 }
 
 sshd_build(){
@@ -48,7 +48,7 @@ sshd_build(){
 sshd_start(){
   log "Starting $DAEMON..."
   local REPLY
-  if ! sshd_running; then
+  if sshd_running; then
     REPLY="Already started"
   else
     # make sure ssh dir exists on flash
@@ -63,14 +63,14 @@ sshd_start(){
     sshd_build
     # start daemon
     run $SSHD
-    if ! sshd_running; then REPLY="Started"; else REPLY="Failed"; fi
+    if sshd_running; then REPLY="Started"; else REPLY="Failed"; fi
   fi
   log "$DAEMON...  $REPLY."
 }
 
 sshd_stop(){
   local REPLY
-  if sshd_running; then
+  if ! sshd_running; then
     REPLY="Already stopped"
   else
     log "Stopping $DAEMON..."
@@ -81,7 +81,7 @@ sshd_stop(){
         kill $pid
       fi
     done
-    if sshd_running; then
+    if ! sshd_running; then
       REPLY="Stopped"
     else
       REPLY="Failed"
@@ -125,7 +125,7 @@ sshd_update(){
 }
 
 sshd_status(){
-  if ! sshd_running; then
+  if sshd_running; then
     echo "$DAEMON is currently running."
   else
     echo "$DAEMON is not running."

--- a/etc/rc.d/rc.sshd
+++ b/etc/rc.d/rc.sshd
@@ -23,7 +23,14 @@ SSH_ETC="/etc/ssh"
 
 sshd_running(){
   sleep 0.1
-  [[ $(pgrep -cf $SSHD) -gt 0 ]]
+  # get all pids from sshd
+  for pid in $(pgrep -f $SSHD); do
+    # check if a sshd is running on host system
+    if ! grep -qE '/docker/|/lxc/' /proc/$pid/cgroup; then
+      return 1
+    fi
+  done
+  return 0
 }
 
 sshd_build(){
@@ -41,7 +48,7 @@ sshd_build(){
 sshd_start(){
   log "Starting $DAEMON..."
   local REPLY
-  if sshd_running; then
+  if ! sshd_running; then
     REPLY="Already started"
   else
     # make sure ssh dir exists on flash
@@ -56,19 +63,29 @@ sshd_start(){
     sshd_build
     # start daemon
     run $SSHD
-    if sshd_running; then REPLY="Started"; else REPLY="Failed"; fi
+    if ! sshd_running; then REPLY="Started"; else REPLY="Failed"; fi
   fi
   log "$DAEMON...  $REPLY."
 }
 
 sshd_stop(){
   local REPLY
-  if ! sshd_running; then
+  if sshd_running; then
     REPLY="Already stopped"
   else
     log "Stopping $DAEMON..."
-    killall sshd
-    if ! sshd_running; then REPLY="Stopped"; else REPLY="Failed"; fi
+    # get all pids from sshd
+    for pid in $(pgrep -f $SSHD); do
+      # make sure to kill only sshd from host system
+      if ! grep -qE '/docker/|/lxc/' /proc/$pid/cgroup; then
+        kill $pid
+      fi
+    done
+    if sshd_running; then
+      REPLY="Stopped"
+    else
+      REPLY="Failed"
+    fi
   fi
   log "$DAEMON...  $REPLY."
 }
@@ -103,12 +120,12 @@ sshd_reload(){
 
 sshd_update(){
   # 0 = update needed, 1 = no action
-  if ! sshd_running; then exit 1; fi
+  if sshd_running; then exit 1; fi
   if check && [[ "$(this ListenAddress)" == "${BIND[@]}" ]]; then exit 1; else exit 0; fi
 }
 
 sshd_status(){
-  if sshd_running; then
+  if ! sshd_running; then
     echo "$DAEMON is currently running."
   else
     echo "$DAEMON is not running."

--- a/etc/rc.d/rc.sshd
+++ b/etc/rc.d/rc.sshd
@@ -120,7 +120,7 @@ sshd_reload(){
 
 sshd_update(){
   # 0 = update needed, 1 = no action
-  if sshd_running; then exit 1; fi
+  if ! sshd_running; then exit 1; fi
   if check && [[ "$(this ListenAddress)" == "${BIND[@]}" ]]; then exit 1; else exit 0; fi
 }
 


### PR DESCRIPTION
This ensures that only the sshd PIDs from the host are terminated, and it also resolves an issue where an sshd service inside a container might automatically restart if it gets killed, which would prevent sshd on the host from starting. 

The current implementation kills all sshd daemons regardless of whether they are running in a Docker container or an LXC container.