### PR TITLE
[Backport] - Fix for rc.docker for interfaces with higher index than 0

### DIFF
--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -254,15 +254,19 @@ start_network(){
     USER_NETWORKS=$(docker inspect --format='{{range $key, $value := .NetworkSettings.Networks}}{{$key}};{{if $value.IPAMConfig}}{{if $value.IPAMConfig.IPv4Address}}{{$value.IPAMConfig.IPv4Address}}{{end}}{{if $value.IPAMConfig.IPv6Address}},{{$value.IPAMConfig.IPv6Address}}{{end}}{{end}} {{end}}' $CONTAINER)
     for ROW in $USER_NETWORKS; do
       ROW=(${ROW/;/ })
-      MY_NETWORK=${ROW[0]}
-      MY_IP=${ROW[1]/,/;}
-      if [[ -n $MY_NETWORK && $MY_NETWORK != $MY_NETWORK ]]; then
-        LABEL=${MY_NETWORK//[0-9.]/}
-        if [[ "br bond eth" =~ $LABEL && $LABEL != ${PORT:0:-1} ]]; then
-          MY_NETWORK=${MY_NETWORK/$LABEL/${PORT:0:-1}}
+      USER_NETWORK=${ROW[0]}
+      USER_IP=${ROW[1]/,/;}
+      if [[ -n $USER_NETWORK && $USER_NETWORK != $MY_NETWORK ]]; then
+        LABEL=${USER_NETWORK//[0-9.]/}
+        IF_NO_PARTS=${USER_NETWORK#"$LABEL"}
+        IF_NO=${IF_NO_PARTS%%.*}
+        if [[ "br bond eth" =~ $LABEL && $IF_NO -gt 0 ]]; then
+          USER_NETWORK=$USER_NETWORK
+        elif [[ "br bond eth" =~ $LABEL && $LABEL != ${PORT:0:-1} ]]; then
+          USER_NETWORK=${USER_NETWORK/$LABEL/${PORT:0:-1}}
         fi
-        logger -t $(basename $0) "container $CONTAINER has an additional network that will be restored: $MY_NETWORK"
-        NETRESTORE[$MY_NETWORK]="$CONTAINER,$MY_IP ${NETRESTORE[$MY_NETWORK]}"
+        logger -t $(basename $0) "container $CONTAINER has an additional network that will be restored: $USER_NETWORK"
+        NETRESTORE[$USER_NETWORK]="$CONTAINER,$USER_IP ${NETRESTORE[$USER_NETWORK]}"
       fi
     done
   done


### PR DESCRIPTION
- Fix error in first if condition which always returned `false`
- Change name from variables so that it a bit easier to read
- Make sure that custom interfaces with a higher index then 0 are properly rebuilt

This directly address [this](https://forums.unraid.net/bug-reports/stable-releases/6124-etcrcdrcdocker-ignores-additional-container-networks-and-cant-auto-start-affected-containers-again-r2694/) issue from the Forums.

~~Still needs to be tested by the user who reported it, I will remove the draft status when it's been tested.~~