### PR TITLE
feat: show routes from all routing tables, not just default

### DIFF
--- a/emhttp/plugins/dynamix/include/RoutingTable.php
+++ b/emhttp/plugins/dynamix/include/RoutingTable.php
@@ -26,8 +26,8 @@ case 'Add Route':
   if ($gateway && $route) exec("/etc/rc.d/rc.inet1 ".escapeshellarg("{$gateway}_{$route}_{$metric}_add"));
   break;
 default:
-  exec("ip -4 route show|grep -v '^127.0.0.0'",$ipv4);
-  exec("ip -6 route show|grep -Pv '^([am:]|(f[ef][0-9][0-9])::)|expires'",$ipv6);
+  exec("ip -4 route show table all|grep -Pv '^(127\\.0\\.0\\.0)|table local'",$ipv4);
+  exec("ip -6 route show table all|grep -Pv '^([am:]|(f[ef][0-9][0-9])::)|expires|table local'",$ipv6);
   foreach ($ipv4 as $info) {
     $cell = explode(' ',$info);
     $route = $cell[0];


### PR DESCRIPTION
This change allows the Network Settings page to display routes from all routing tables, not just the default one.

In particular, Tailscale does not use the default routing table when adding routes. Instead, it adds routes to a separate table (route table 52) and then creates a network rule to process that table in addition to the default table. The existing Network Settings logic only polls for routes on the default table. and as a result routes added by Tailscale do not appear.

This change specifically excludes items in the local routing table, which is maintained by the kernel and contains routes for the local system. Displaying these routes would create unnecessary noise in the route display. 