### PR TITLE
Show autostart button on 3rd party containers

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -188,11 +188,7 @@ foreach ($containers as $ct) {
   echo "<td class='advanced'><span class='cpu-$id'>0%</span><div class='usage-disk mm'><span id='cpu-$id' style='width:0'></span><span></span></div>";
   echo "<br><span class='mem-$id'>0 / 0</span></td>";
   if (empty($composestack)) {
-    if ($ct['Manager'] == "dockerman") {
-      echo "<td><input type='checkbox' id='$id-auto' class='autostart' container='".htmlspecialchars($name)."'".($info['autostart'] ? ' checked':'').">";
-    } else {
-      echo "<td><i class='fa fa-docker fa-fw'/></i> 3rd Party";
-    }
+    echo "<td><input type='checkbox' id='$id-auto' class='autostart' container='".htmlspecialchars($name)."'".($info['autostart'] ? ' checked':'').">";
   } else {
     echo "<td><i class='fa fa-docker'/></i> Compose";
   }


### PR DESCRIPTION
This rolls back to hide the Autostart button on 3rd party containers since a user made me aware that there are some containers out there which indeed need the Autostart function from Unraid to fully work because they lack support in their WebUI for Autostart.

I marked this as draft since I want to try this myself first.