### PR TITLE
Update rc.docker

### DIFF
--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -127,7 +127,7 @@ all_containers(){
 
 # Running containers
 running_containers(){
-  docker ps --format '{{.ID}} {{.Names}} {{.Labels}}' 2>/dev/null | grep 'net.unraid.docker.managed=' | awk '{print $2}'
+  docker ps --format='{{.Names}} {{.Labels}}' 2>/dev/null | grep 'net.unraid.docker.managed=' | awk '{print $1}'
 }
 
 # Network driver

--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -127,7 +127,7 @@ all_containers(){
 
 # Running containers
 running_containers(){
-  docker ps --filter "label=net.unraid.docker.managed=dockerman" --format='{{.Names}}' 2>/dev/null
+  docker ps --format '{{.ID}} {{.Names}} {{.Labels}}' 2>/dev/null | grep 'net.unraid.docker.managed=' | awk '{print $2}'
 }
 
 # Network driver
@@ -567,7 +567,7 @@ docker_service_stop(){
     # Try to stop dockerd gracefully
     kill $(docker_pid) 2>/dev/null
     # show waiting message
-    echo "Waiting 30 seconds for $DAEMON daemon to die."
+    echo "Waiting 30 seconds for $DAEMON to die."
     TIMER=30
     # must ensure daemon has exited
     while [[ $TIMER -gt 0 ]]; do

--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -127,7 +127,7 @@ all_containers(){
 
 # Running containers
 running_containers(){
-  docker ps --format='{{.Names}}' 2>/dev/null
+  docker ps --filter "label=net.unraid.docker.managed=dockerman" --format='{{.Names}}' 2>/dev/null
 }
 
 # Network driver
@@ -531,9 +531,7 @@ docker_container_stop(){
   log "Stopping containers..."
   if ! docker_running; then return 1; fi
   [[ -n $(running_containers) ]] && docker stop --time=${DOCKER_TIMEOUT:-10} $(running_containers) >/dev/null
-  # Kill containers if still running
-  docker kill $(docker ps -q) 2>/dev/null
-  log "Containers stopped."
+  log "Unraid managed containers stopped."
 }
 
 docker_service_start(){
@@ -568,7 +566,9 @@ docker_service_stop(){
   if [[ -r $DOCKER_PIDFILE ]]; then
     # Try to stop dockerd gracefully
     kill $(docker_pid) 2>/dev/null
-    TIMER=15
+    # show waiting message
+    echo "Waiting 30 seconds for $DAEMON daemon to die."
+    TIMER=30
     # must ensure daemon has exited
     while [[ $TIMER -gt 0 ]]; do
       sleep 1
@@ -583,8 +583,6 @@ docker_service_stop(){
         # signal successful stop
         TIMER=-1
       else
-        # show waiting message
-        echo "$DAEMON... Waiting to die."
         ((TIMER--))
       fi
     done


### PR DESCRIPTION
- Only stop Unraid managed containers
- Don't kill containers since Docker will kill them if they won't stop after the set timeout when the daemon is stopping
- Increase timeout for daemon to die to 30 seconds (seems a bit short if 3rd party containers are installed)
- Rephrase message for daemon to die and display it only once

This is a further improvement to Docker for third party containers to honor their restart policy.
Currently Unraid stops all container regardless if they are manged by Unraid or not, with that change it will only stop containers managed by Unraid (or Compose) and therefore honor the restart policy for 3rd party managed containers.

In the following animation you'll see the third party container named `affectionate_meninsky` with the restart policy `--restart=unless-stopped` will automatically start after docker is restarted, you'll also notice that it will take about 12 seconds for the daemon to die because the above mentioned container doesn't catch the exit signal and therefore Docker executes `docker kill` to kill the container after the set timeout from 10 seconds (you might have to click on the animation to actually see what's going on):
![Peek 2024-09-24 15-56](https://github.com/user-attachments/assets/48840319-3172-4b4e-8109-49a3e1cf167d)
