### PR TITLE
fix: prevent deleting containers that are assigned as a network

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -824,6 +824,13 @@ class DockerClient {
 		global $docroot, $dockerManPaths;
 		$id = $id ?: $name;
 		$info = DockerUtil::loadJSON($dockerManPaths['webui-info']);
+
+		// Check to see if the container is linked to other containers
+		$networks = array_map(function ($n) { return $n['NetworkMode']; }, $this->getDockerContainers());
+		if (in_array("container:{$name}", $networks)) {
+				return "Container currently assigned as network for another container.";
+		}
+
 		// Attempt to remove container
 		$this->getDockerJSON("/containers/$id?force=1", 'DELETE', $code);
 		if (isset($info[$name])) {


### PR DESCRIPTION
If a container has been assigned as a network via #1857 , deleting that container breaks the connected container:

- The container gets stuck in "rebuilding" state in an infinite loop of being recreated (see attached recording).
- Due to the loop, the Docker page in the UI gets stuck "loading" infinitely, and cannot be interacted with.
- Remove the container from CLI can succeed, but requires multiple attempts.

This change adds a check to the removal that prevents a container from being removed if it is assigned as the network for another container.

https://github.com/user-attachments/assets/46fb2efc-6974-49bd-89ec-4bd0eec00b32

