### PR TITLE
Fix a situation where the secondary pool device is missing.

### DIFF
--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -644,6 +644,7 @@ function updateScreen(cache, slow) {
 				secondaryDropdown.options[i].disabled = true;
 			}
 			secondaryDropdown.selectedIndex = 0;
+			checkRequiredSecondary = false;
 
 			if (poolsOnly) {
 				$('#moverDirection2').hide();


### PR DESCRIPTION
When a secondary pool device is missing and the Array is chosen for the primary device, the configuration would fail because the secondary device is still believed to be a missing pool device.