### PR TITLE
Set NTP to use interfaces.

### DIFF
--- a/etc/rc.d/rc.ntpd
+++ b/etc/rc.d/rc.ntpd
@@ -35,7 +35,7 @@ ntpd_build(){
     [[ $IPV6 == no ]] && echo "interface ignore ipv6" >>$CONF
     # add listen interfaces
     for NET in $BIND; do
-      echo "interface listen $NET # $(show $NET)" >>$CONF
+      echo "interface listen $(show $NET) # $NET" >>$CONF
     done
   fi
   # add configured NTP servers


### PR DESCRIPTION
Change to use interface rather than IP.

From

# Generated entries follow:
interface ignore wildcard
interface ignore ipv6
interface listen 192.168.1.225 # br0
server time1.google.com iburst
server time2.google.com iburst
server time3.google.com iburst
server time4.google.com iburst

to

# Generated entries follow:
interface ignore wildcard
interface ignore ipv6
interface listen br0 # 192.168.1.225
server time1.google.com iburst
server time2.google.com iburst
server time3.google.com iburst
server time4.google.com iburst