### PR TITLE
(bugfix) /etc/rc.d/rc.rsyslogd: OS-native PID for decisions

### DIFF
--- a/etc/rc.d/rc.rsyslogd
+++ b/etc/rc.d/rc.rsyslogd
@@ -29,15 +29,12 @@ create_xconsole(){
 
 rsyslogd_running(){
   sleep 0.1
-  [[ ! -f $PIDFILE ]] && return 1
-  local RSPID
-  RSPID=$(cat "$PIDFILE")
-  if kill -0 "$RSPID" &>/dev/null; then
-    # PID is alive
+  if pgrep --ns $$ -x rsyslogd &>/dev/null; then
+    # Daemon is alive
     return 0
   else
-    # PID is dead (remove stale PID file)
-    rm -f "$PIDFILE"
+    # Daemon is dead (remove stale PID file)
+    [[ -f $PIDFILE ]] && rm -f "$PIDFILE"
     return 1
   fi
 }
@@ -60,7 +57,7 @@ rsyslogd_stop(){
   if ! rsyslogd_running; then
     REPLY="Already stopped"
   else
-    run kill "$(cat "$PIDFILE")"
+    run killall --ns $$ rsyslogd
     sleep 2
     if ! rsyslogd_running; then REPLY="Stopped"; else REPLY="Failed"; fi
   fi
@@ -78,7 +75,7 @@ rsyslogd_reload(){
   log "Reloading $DAEMON..."
   local REPLY
   REPLY="Reloaded"
-  [[ -f $PIDFILE ]] && run kill -HUP "$(cat "$PIDFILE")" || REPLY="Failed"
+  run killall -HUP --ns $$ rsyslogd || REPLY="Failed"
   log "$DAEMON...  $REPLY."
 }
 

--- a/etc/rc.d/rc.rsyslogd
+++ b/etc/rc.d/rc.rsyslogd
@@ -74,8 +74,12 @@ rsyslogd_restart(){
 rsyslogd_reload(){
   log "Reloading $DAEMON..."
   local REPLY
-  REPLY="Reloaded"
-  run killall -HUP --ns $$ rsyslogd || REPLY="Failed"
+  if ! rsyslogd_running; then
+    REPLY="Not running"
+  else
+    REPLY="Reloaded"
+    run killall -HUP --ns $$ rsyslogd || REPLY="Failed"
+  fi
   log "$DAEMON...  $REPLY."
 }
 

--- a/etc/rc.d/rc.rsyslogd
+++ b/etc/rc.d/rc.rsyslogd
@@ -13,7 +13,7 @@
 # Bergware - modified for Unraid OS, October 2023
 
 DAEMON="Syslog server daemon"
-PIDFILE=/var/run/rsyslogd.pid  # native rsyslogd pid file
+PIDFILE="/var/run/rsyslogd.pid"  # native rsyslogd pid file
 
 # run & log functions
 . /etc/rc.d/rc.runlog
@@ -29,7 +29,17 @@ create_xconsole(){
 
 rsyslogd_running(){
   sleep 0.1
-  ps axc | grep -q ' rsyslogd'
+  [[ ! -f $PIDFILE ]] && return 1
+  local RSPID
+  RSPID=$(cat "$PIDFILE")
+  if kill -0 "$RSPID" &>/dev/null; then
+    # PID is alive
+    return 0
+  else
+    # PID is dead (remove stale PID file)
+    rm -f "$PIDFILE"
+    return 1
+  fi
 }
 
 rsyslogd_start(){
@@ -38,7 +48,7 @@ rsyslogd_start(){
   if rsyslogd_running; then
     REPLY="Already started"
   else
-    run /usr/sbin/rsyslogd -i $PIDFILE
+    run /usr/sbin/rsyslogd -i "$PIDFILE"
     if rsyslogd_running; then REPLY="Started"; else REPLY="Failed"; fi
   fi
   log "$DAEMON...  $REPLY."
@@ -50,8 +60,8 @@ rsyslogd_stop(){
   if ! rsyslogd_running; then
     REPLY="Already stopped"
   else
-    run killall rsyslogd
-    rm -f $PIDFILE
+    run kill "$(cat "$PIDFILE")"
+    sleep 2
     if ! rsyslogd_running; then REPLY="Stopped"; else REPLY="Failed"; fi
   fi
   log "$DAEMON...  $REPLY."
@@ -68,7 +78,7 @@ rsyslogd_reload(){
   log "Reloading $DAEMON..."
   local REPLY
   REPLY="Reloaded"
-  [[ -f $PIDFILE ]] && run kill -HUP $(cat $PIDFILE) || REPLY="Failed"
+  [[ -f $PIDFILE ]] && run kill -HUP "$(cat "$PIDFILE")" || REPLY="Failed"
   log "$DAEMON...  $REPLY."
 }
 


### PR DESCRIPTION
bugfix: multiple running _rsyslogd_ processes (e.g. spawned by Docker containers) caused the _rc.d_ script to think that the OS-native process was already running, resulting in startup or restart failure of the OSes daemon. the proposed changes make the script act on the OS-native PID file and not other unrelated processes by name.

-- Rysz (credits to Discord user _Brendann_ for noticing this issue)