### PR TITLE
(backport) (bugfix) /etc/rc.d/rc.rsyslogd: OS-native PID for decisions

### DIFF
--- a/etc/rc.d/rc.rsyslogd
+++ b/etc/rc.d/rc.rsyslogd
@@ -7,8 +7,8 @@
 # rsyslogd_reload added by Christophe Trussardi <chris@teria.org> Sept 2011
 #
 
-pidfile1=/var/run/rsyslogd.pid	# native rsyslogd pid file
-pidfile2=/var/run/syslogd.pid	# spoof the "old" syslogd file
+pidfile1="/var/run/rsyslogd.pid"  # native rsyslogd pid file
+pidfile2="/var/run/syslogd.pid" # spoof the "old" syslogd file
 
 create_xconsole()
 {
@@ -25,14 +25,14 @@ rsyslogd_start() {
     echo "Starting rsyslogd daemon: "
     echo "/usr/sbin/rsyslogd -i $pidfile1"
     /usr/sbin/rsyslogd -i "$pidfile1"
-    cp "$pidfile1" "$pidfile2"
+    ln -sf "$pidfile1" "$pidfile2"
   fi
 }
 
 rsyslogd_stop() {
-  killall rsyslogd 2> /dev/null
-  /usr/bin/rm $pidfile1 2> /dev/null
-  /usr/bin/rm $pidfile2 2> /dev/null
+  [ -f "$pidfile1" ] && /bin/kill "$(cat "$pidfile1")"
+  /usr/bin/rm -f "$pidfile1" 2> /dev/null
+  /usr/bin/rm -f "$pidfile2" 2> /dev/null
 }
 
 rsyslogd_restart() {
@@ -43,7 +43,7 @@ rsyslogd_restart() {
 
 rsyslogd_reload() {
   echo "Reloading rsyslogd daemon: "
-  [ -f "$pidfile1" ] && /bin/kill -HUP $(cat $pidfile1)
+  [ -f "$pidfile1" ] && /bin/kill -HUP "$(cat "$pidfile1")"
 }
 
 case "$1" in

--- a/etc/rc.d/rc.rsyslogd
+++ b/etc/rc.d/rc.rsyslogd
@@ -30,9 +30,9 @@ rsyslogd_start() {
 }
 
 rsyslogd_stop() {
-  [ -f "$pidfile1" ] && /bin/kill "$(cat "$pidfile1")"
-  /usr/bin/rm -f "$pidfile1" 2> /dev/null
-  /usr/bin/rm -f "$pidfile2" 2> /dev/null
+  /bin/killall --ns $$ rsyslogd 2>/dev/null
+  /usr/bin/rm -f "$pidfile1" 2>/dev/null
+  /usr/bin/rm -f "$pidfile2" 2>/dev/null
 }
 
 rsyslogd_restart() {
@@ -43,7 +43,7 @@ rsyslogd_restart() {
 
 rsyslogd_reload() {
   echo "Reloading rsyslogd daemon: "
-  [ -f "$pidfile1" ] && /bin/kill -HUP "$(cat "$pidfile1")"
+  /bin/killall -HUP --ns $$ rsyslogd 2>/dev/null
 }
 
 case "$1" in


### PR DESCRIPTION
backport of #1882 

bugfix: multiple running _rsyslogd_ processes (e.g. spawned by Docker containers) caused the _rc.d_ script to think that the OS-native process was already running, resulting in startup or restart failure of the OSes daemon. the proposed changes make the script act on the OS-native PID file and not other unrelated processes by name.

-- Rysz (credits to Discord user _Brendann_ for noticing this issue)