### PR TITLE
Add warning about server signing to SMB Security page; update helptext.

### DIFF
--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -269,7 +269,14 @@ For more complete documentation, please refer to the btrfs-balance [Manpage](htt
 **Scrub** runs the *btrfs scrub* program which will read all data and metadata blocks from all
 devices and verify checksums.
 
-If *Repair corrupted blocks* is checked, *btrfs scrub* will repair corrupted blocks if there’s a correct copy available.
+*btrfs scrub* will repair corrupted blocks if there is a correct copy available.
+:end
+
+:info_zfs_scrub_help:
+**Scrub** runs the *zfs scrub* program which will read all data and metadata blocks from all
+devices and verify checksums.
+
+Click the **Upgrade Pool** button to upgrade the ZFS pool to enable the latest ZFS features.
 :end
 
 :info_scrub_cancel_help:
@@ -281,6 +288,10 @@ If *Repair corrupted blocks* is checked, *btrfs scrub* will repair corrupted blo
 
 The *Options* field is initialized with *--readonly* which specifies check-only.  If repair is needed, you should run
 a second Check pass, setting the *Options* to *--repair*; this will permit *btrfs check* to fix the file system.
+
+WARNING: **Do not use** *--repair* unless you are advised to do so by a developer or an experienced user,
+and then only after having accepted that no fsck successfully repair all types of filesystem corruption.
+E.g. some other software or hardware bugs can fatally damage a volume.
 
 After starting a Check, you should Refresh to monitor progress and status.  Depending on
 how large the file system is, and what errors might be present, the operation can take **a long time** to finish (hours).
@@ -695,6 +706,12 @@ Summary of security modes:
 **Secure** All users including guests have read access, you select which of your users have write access.
 
 **Private** No guest access at all, you select which of your users have read/write, read-only access or no access.
+
+Windows Server Signing:
+
+If you are unable to browse SMB shares with Windows 11 version 24H2 or newer, you need to make some changes to accomodate a new feature called Server Signing.  Server Signing is enabled in Unraid and you need to make changes to access Public shares.
+You can <u><a href='https://techcommunity.microsoft.com/t5/storage-at-microsoft/accessing-a-third-party-nas-with-smb-in-windows-11-24h2-may-fail/ba-p/4154300', target='_blank'>disable it in Windows</a></u>, or to work with Unraid with Server Signing enabled, the easiest way is to create a user (with a password set) in Unraid with the same name as the Windows account you are using, Windows should then ask you for the credentials.
+If you are using a Microsoft account, it may be better to just create a user in Unraid with a simple username and set a password, then in Windows go to Control Panel -> Credential Manager -> Windows credentials -> Add a Windows Credential and add the correct Unraid server name and credentials.
 :end
 
 :smb_secure_access_help:

--- a/emhttp/plugins/dynamix/SecuritySMB.page
+++ b/emhttp/plugins/dynamix/SecuritySMB.page
@@ -100,11 +100,11 @@ _(Case-sensitive names)_:
 
 <?endif;?>
 _(Security)_:
-: <select name="shareSecurity">
+: <select name="shareSecurity" onchange="checkPublicSelection(this);">
   <?=mk_option($sec[$name]['security'], "public", _('Public'))?>
   <?=mk_option($sec[$name]['security'], "secure", _('Secure'))?>
   <?=mk_option($sec[$name]['security'], "private", _('Private'))?>
-  </select>
+  </select><span id="warningMessage" style="display:none; color: red;">_(Warning)_:  _(Windows may require a valid User to be defined even for Public shares)_.  _(See Help)_.</span>
 
 :smb_security_modes_help:
 
@@ -315,4 +315,25 @@ function writeUserSMB(data,n,i) {
     writeUserSMB(data,0,i);
   }
 }
+
+function checkPublicSelection(select) {
+	/* Get reference to the warning message span */
+	let warningMessage = document.getElementById("warningMessage");
+
+	/* Check if 'Public' is selected */
+	if (select.value === "public") {
+		/* Display warning for 'Public' option */
+		warningMessage.style.display = "inline";
+	} else {
+		/* Hide warning for other options */
+		warningMessage.style.display = "none";
+	}
+}
+
+/* Call checkPublicSelection with the initial selection on page load */
+document.addEventListener("DOMContentLoaded", function() {
+	let smbSecuritySelect = document.querySelector('[name="shareSecurity"]');
+	checkPublicSelection(smbSecuritySelect);
+});
+
 </script>


### PR DESCRIPTION
- Add warning to SMB security setting on shares about Windows Security Signing.
- Add help text to SMB security setting on shares about Windows Security Signing.
- Add help text abuot upgrading ZFS pools to device info page.
- Add help text for zfs scrub to device info page.