### PR TITLE
Fix invalid situation where useCache is 'no' when array is enabled.

### DIFF
--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -56,6 +56,11 @@ if ((! $share['cachePool']) && ($share['cachePool2'])) {
 	$share['cachePool2']	= "";
 }
 
+/* If useCache is "no" with an array, this is invalid and useCache has to be 'only'. */
+if ((! $poolsOnly) && ($share['useCache'] == "no")) {
+	$share['useCache'] = 'only';
+}
+
 /* Check for non existent pool device. */
 if ($share['cachePool'] && !in_array($share['cachePool'], $pools)) {
 	$poolDefined = false;

--- a/emhttp/plugins/dynamix/include/ShareList.php
+++ b/emhttp/plugins/dynamix/include/ShareList.php
@@ -214,8 +214,8 @@ foreach ($shares as $name => $share) {
 		$share_valid	= true;
 	}
 
-	/* When there is no array, all pools are treated as 'only' cache. */
-	if (($poolsOnly) && (! $share['cachePool2'])) {
+	/* When there is no array, all pools are treated as 'only' cache. If useCache is "no" with an array, this is invalid and useCache has to be 'only'. */
+	if ((($poolsOnly) && (! $share['cachePool2'])) || ((! $poolsOnly) && ($share['useCache'] == "no"))) {
 		$share['useCache'] = 'only';
 	}
 


### PR DESCRIPTION
When a share is setup on a pool with no array, and then the array is enabled, the share list shows 'Array' instead of pool only and share edit does not recognize this as a pool with secondary selections enabled.