### PR TITLE
backport: Drop down not working properly.

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
@@ -156,10 +156,8 @@ _(Enable Docker)_:
 
 _(Enable container table readmore-js)_:
 : <select id="DOCKER_READMORE" name="DOCKER_READMORE">
-
   <?=mk_option(_var($dockercfg,'DOCKER_READMORE'), 'yes', _('Yes'))?>
   <?=mk_option(_var($dockercfg,'DOCKER_READMORE'), 'no', _('No'))?>
-
   </select>
 
 :docker_readmore_help:


### PR DESCRIPTION
The "Enable container table readmore-js" drop down is not working properly with some browsers.