### PR TITLE
Change state directory logic & add `root` check

### DIFF
--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -2448,7 +2448,7 @@ For more details see the <a href="https://tailscale.com/kb/1080/cli#up" target="
 :end
 
 :docker_tailscale_statedir_help:
-If state directory detection fails on startup, you can specify a persistent directory in the container to override automatic detection, i.e. `/config/.tailscale_state`
+If state directory detection fails on startup, you can specify a persistent directory in the container to override automatic detection, i.e. `/container-path/.tailscale_state`
 :end
 
 :docker_tailscale_troubleshooting_packages_help:

--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -2448,7 +2448,7 @@ For more details see the <a href="https://tailscale.com/kb/1080/cli#up" target="
 :end
 
 :docker_tailscale_statedir_help:
-If state directory detection fails on startup, you can specify a persistent directory in the container to override automatic detection.
+If state directory detection fails on startup, you can specify a persistent directory in the container to override automatic detection, i.e. `/config/.tailscale_state`
 :end
 
 :docker_tailscale_troubleshooting_packages_help:

--- a/share/docker/tailscale_container_hook
+++ b/share/docker/tailscale_container_hook
@@ -131,20 +131,20 @@ unset TS_PARAMS
 
 if [ ! -z "${SERVER_DIR}" ]; then
   TSD_STATE_DIR="${SERVER_DIR}/.tailscale_state"
-  echo "Settings Tailscale state dir to: ${TSD_STATE_DIR}"
 elif [ ! -z "${DATA_DIR}" ]; then
   TSD_STATE_DIR="${DATA_DIR}/.tailscale_state"
-  echo "Settings Tailscale state dir to: ${TSD_STATE_DIR}"
 elif [ ! -z "${USER_HOME}" ]; then
   TSD_STATE_DIR="${USER_HOME}/.tailscale_state"
-  echo "Settings Tailscale state dir to: ${TSD_STATE_DIR}"
+elif [ -d "/config" ]; then
+  TSD_STATE_DIR="/config/.tailscale_state"
 else
   if [ -z "${TAILSCALE_STATE_DIR}" ]; then
     TAILSCALE_STATE_DIR="/config/.tailscale_state"
+    echo "WARNING: Couldn't detect persistent directory for .tailscale_state files! Enable Tailscale Advanced Settings and set the Tailscale State Directory!"
   fi
   TSD_STATE_DIR="${TAILSCALE_STATE_DIR}"
-  echo "Settings Tailscale state dir to: ${TSD_STATE_DIR}"
 fi
+echo "Settings Tailscale state dir to: ${TSD_STATE_DIR}"
 
 if [ ! -d "${TSD_STATE_DIR}" ]; then
   mkdir -p ${TSD_STATE_DIR}

--- a/share/docker/tailscale_container_hook
+++ b/share/docker/tailscale_container_hook
@@ -29,6 +29,11 @@ echo
 echo "Executing Unraid Docker Hook for Tailscale"
 echo
 
+if [ "$(id -u)" != "0" ]; then
+  echo "ERROR: No root privileges!"
+  error_handler
+fi
+
 if [ ! -f /usr/bin/tailscale ] || [ ! -f /usr/bin/tailscaled ]; then
   if [ ! -z "${TAILSCALE_EXIT_NODE_IP}" ]; then
     if [ ! -c /dev/net/tun ]; then

--- a/share/docker/tailscale_container_hook
+++ b/share/docker/tailscale_container_hook
@@ -140,7 +140,8 @@ elif [ -d "/config" ]; then
 else
   if [ -z "${TAILSCALE_STATE_DIR}" ]; then
     TAILSCALE_STATE_DIR="/config/.tailscale_state"
-    echo "WARNING: Couldn't detect persistent directory for .tailscale_state files! Enable Tailscale Advanced Settings and set the Tailscale State Directory!"
+    echo "ERROR: Couldn't detect persistent Docker directory for .tailscale_state! Enable Tailscale Advanced Settings in the Docker template and set the Tailscale State Directory!"
+    sleep infinity
   fi
   TSD_STATE_DIR="${TAILSCALE_STATE_DIR}"
 fi


### PR DESCRIPTION
- add check if `/config` exists
- display warning if detection was not successful
- make helptext more clear for state directory
- add check if script runs as `root`