### PR TITLE
Update vm_dashusage

### DIFF
--- a/emhttp/plugins/dynamix/nchan/vm_dashusage
+++ b/emhttp/plugins/dynamix/nchan/vm_dashusage
@@ -41,10 +41,12 @@ if ($var['fsState'] == "Started" || $var['fsState'] == "Starting") {
     sleep(10);
   } elseif ($domain_cfg['SERVICE'] != "enable") { 
     #Add remove_nchan_pid_entry("webGui/nchan/vm_dashusage");
+    exec("sed -i '/webGui\/nchan\/vm_dashusage/d' /var/run/nchan.pid");
     return;
   }
 } else {
   #Add remove_nchan_pid_entry("webGui/nchan/vm_dashusage");
+  exec("sed -i '/webGui\/nchan\/vm_dashusage/d' /var/run/nchan.pid");
   return;
 }
 


### PR DESCRIPTION
Fix vm_dashusage processing when array not started.

Is the array is manual start and you open dashboard before starting pid entry is not removed for nchan process.
Fix: remove pid entry.