### PR TITLE
TS Mullvad VPN changes

### DIFF
--- a/share/docker/tailscale_container_hook
+++ b/share/docker/tailscale_container_hook
@@ -145,7 +145,8 @@ elif [ -d "/config" ]; then
 else
   if [ -z "${TAILSCALE_STATE_DIR}" ]; then
     TAILSCALE_STATE_DIR="/config/.tailscale_state"
-    echo "ERROR: Couldn't detect persistent Docker directory for .tailscale_state! Enable Tailscale Advanced Settings in the Docker template and set the Tailscale State Directory!"
+    echo "ERROR: Couldn't detect persistent Docker directory for .tailscale_state!"
+    echo "       Please enable Tailscale Advanced Settings in the Docker template and set the Tailscale State Directory manually!"
     sleep infinity
   fi
   TSD_STATE_DIR="${TAILSCALE_STATE_DIR}"

--- a/share/docker/tailscale_container_hook
+++ b/share/docker/tailscale_container_hook
@@ -134,7 +134,9 @@ fi
 unset TSD_PARAMS
 unset TS_PARAMS
 
-if [ ! -z "${SERVER_DIR}" ]; then
+if [ ! -z "${TAILSCALE_STATE_DIR}" ]; then
+  TSD_STATE_DIR="${TAILSCALE_STATE_DIR}"
+elif [ ! -z "${SERVER_DIR}" ]; then
   TSD_STATE_DIR="${SERVER_DIR}/.tailscale_state"
 elif [ ! -z "${DATA_DIR}" ]; then
   TSD_STATE_DIR="${DATA_DIR}/.tailscale_state"
@@ -142,14 +144,12 @@ elif [ ! -z "${USER_HOME}" ]; then
   TSD_STATE_DIR="${USER_HOME}/.tailscale_state"
 elif [ -d "/config" ]; then
   TSD_STATE_DIR="/config/.tailscale_state"
+elif [ -d "/data" ]; then
+  TSD_STATE_DIR="/data/.tailscale_state"
 else
-  if [ -z "${TAILSCALE_STATE_DIR}" ]; then
-    TAILSCALE_STATE_DIR="/config/.tailscale_state"
-    echo "ERROR: Couldn't detect persistent Docker directory for .tailscale_state!"
-    echo "       Please enable Tailscale Advanced Settings in the Docker template and set the Tailscale State Directory manually!"
-    sleep infinity
-  fi
-  TSD_STATE_DIR="${TAILSCALE_STATE_DIR}"
+  echo "ERROR: Couldn't detect persistent Docker directory for .tailscale_state!"
+  echo "       Please enable Tailscale Advanced Settings in the Docker template and set the Tailscale State Directory manually!"
+  sleep infinity
 fi
 echo "Settings Tailscale state dir to: ${TSD_STATE_DIR}"
 


### PR DESCRIPTION
- Prioritize searching for Exit Nodes through the container before using the Tailscale plugin if installed. This is necessary to display Exit Nodes from Mullvad for specific containers.