### PR TITLE
Tabbed page mode not working properly.

### DIFF
--- a/emhttp/plugins/dynamix/include/DefaultPageLayout.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout.php
@@ -200,11 +200,11 @@ function settab(tab) {
   $.cookie('one','tab1');
 <?endif;?>
 <?break;?>
-<?case'Cache':case'Data':case'Flash':case'Parity':?>
+<?case'Cache':case'Data':case'Device':case'Flash':case'Parity':?>
   $.cookie('one',tab);
 <?break;?>
 <?default:?>
-  $.cookie(($.cookie('one')==null?'tab':'one'),tab);
+  $.cookie('one',tab);
 <?endswitch;?>
 }
 function done(key) {
@@ -586,7 +586,16 @@ function flashReport() {
   });
 }
 $(function() {
-  var tab = $.cookie('one')||$.cookie('tab')||'tab1';
+<?switch ($myPage['name']):?>
+<?case'Main':?>
+  const tab = $.cookie('tab')||'tab1';
+<?break;?>
+<?case'Cache':case'Data':case'Device':case'Flash':case'Parity':?>
+  const tab = $.cookie('one')||'tab1';
+<?break;?>
+<?default:?>
+  const tab = $.cookie('one')||'tab1';
+<?endswitch;?>
   if (tab=='tab0') tab = 'tab'+$('input[name$="tabs"]').length; else if ($('#'+tab).length==0) {initab(); tab = 'tab1';}
   $('#'+tab).attr('checked', true);
   updateTime();

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout.php
@@ -586,17 +586,26 @@ function flashReport() {
   });
 }
 $(function() {
+  let tab;
 <?switch ($myPage['name']):?>
 <?case'Main':?>
-  let tab = $.cookie('tab')||'tab1';
+  tab = $.cookie('tab')||'tab1';
 <?break;?>
 <?case'Cache':case'Data':case'Device':case'Flash':case'Parity':?>
-  let tab = $.cookie('one')||'tab1';
+  tab = $.cookie('one')||'tab1';
 <?break;?>
 <?default:?>
-  let tab = $.cookie('one')||'tab1';
+  tab = $.cookie('one')||'tab1';
 <?endswitch;?>
-  if (tab=='tab0') tab = 'tab'+$('input[name$="tabs"]').length; else if ($('#'+tab).length==0) {initab(); tab = 'tab1';}
+  /* Check if the tab is 'tab0' */
+  if (tab === 'tab0') {
+    /* Set tab to the last available tab based on input[name$="tabs"] length */
+    tab = 'tab' + $('input[name$="tabs"]').length;
+  } else if ($('#' + tab).length === 0) {
+    /* If the tab element does not exist, initialize a tab and set to 'tab1' */
+    initab();
+    tab = 'tab1';
+  }
   $('#'+tab).attr('checked', true);
   updateTime();
   $.jGrowl.defaults.closeTemplate = '<i class="fa fa-close"></i>';

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout.php
@@ -588,13 +588,13 @@ function flashReport() {
 $(function() {
 <?switch ($myPage['name']):?>
 <?case'Main':?>
-  const tab = $.cookie('tab')||'tab1';
+  let tab = $.cookie('tab')||'tab1';
 <?break;?>
 <?case'Cache':case'Data':case'Device':case'Flash':case'Parity':?>
-  const tab = $.cookie('one')||'tab1';
+  let tab = $.cookie('one')||'tab1';
 <?break;?>
 <?default:?>
-  const tab = $.cookie('one')||'tab1';
+  let tab = $.cookie('one')||'tab1';
 <?endswitch;?>
   if (tab=='tab0') tab = 'tab'+$('input[name$="tabs"]').length; else if ($('#'+tab).length==0) {initab(); tab = 'tab1';}
   $('#'+tab).attr('checked', true);


### PR DESCRIPTION
Several issues fixed with this PR:
- Tabbed page mode does not display the previous 'Main' selection on page refresh.
- Sub-pages (like device attributes) does not always start on the first tab.
- Return from sub-pages does not always return to the last selected 'Main' tab.

Plugins like UD do not work well at all.