### PR TITLE
Set MTU of docker wireguard bridge to match wireguard default MTU

### DIFF
--- a/emhttp/plugins/dynamix/include/update.wireguard.php
+++ b/emhttp/plugins/dynamix/include/update.wireguard.php
@@ -114,7 +114,7 @@ function addDocker($vtun) {
   $error = false;
   [$index,$network] = newNet($vtun);
   if ($dockerd && dockerNet($vtun)) {
-    exec("docker network create $vtun --subnet=$network 2>/dev/null");
+    exec("docker network create -o 'com.docker.network.driver.mtu'='1420' $vtun --subnet=$network 2>/dev/null");
     $error = dockerNet($vtun);
   }
   if (!$error && !isNet($network)) {


### PR DESCRIPTION
The MTU needs to be set to at least to the wireguard default. While it seems to work just fine, to create a docker bridge with a MTU of 1500, it breaks in some cases. For example, if you "curl https://api.minecraftservices.com/publickeys" via a container thats running over that wireguard-docker-bridge, it fails.