### PR TITLE
Limit 'lsof' command to valid mount points in /nchan/update_1.

### DIFF
--- a/emhttp/plugins/dynamix/nchan/update_1
+++ b/emhttp/plugins/dynamix/nchan/update_1
@@ -29,7 +29,7 @@ require_once "$docroot/webGui/include/Translations.php";
 $locale_init = $locale;
 
 /* Parse the ini files */
-$shares = parse_ini_file('state/shares.ini', true);
+$shares = parse_ini_file($varroot.'/shares.ini', true);
 $disks = parse_ini_file('state/disks.ini', true);
 
 function update_translation($locale) {
@@ -97,7 +97,6 @@ while (true) {
   if (count($fans)) $echo['fan'] = array_map(function($fan){return "$fan RPM";},$fans);
 
   // add streams information
-  /* Extract keys from both ini files */
   $paths = array_keys($disks);
 
   /* Validate and filter accessible mount points */

--- a/emhttp/plugins/dynamix/nchan/update_1
+++ b/emhttp/plugins/dynamix/nchan/update_1
@@ -28,6 +28,10 @@ require_once "$docroot/webGui/include/Translations.php";
 // remember current language
 $locale_init = $locale;
 
+/* Parse the ini files */
+$shares = parse_ini_file('state/shares.ini', true);
+$disks = parse_ini_file('state/disks.ini', true);
+
 function update_translation($locale) {
   global $docroot,$language;
   $language = [];
@@ -91,10 +95,25 @@ while (true) {
   }
   // add fans information
   if (count($fans)) $echo['fan'] = array_map(function($fan){return "$fan RPM";},$fans);
+
   // add streams information
-  exec('LANG="en_US.UTF8" lsof -Fn /mnt/* 2>/dev/null|awk -F/ \'$1=="n" && $2=="mnt" && $5!="" {print $4"/"$5"/"$6"/"$7}\'|sort -u|awk -F/ \'{print $1}\'',$lsof);
-  $share = array_keys(parse_ini_file("$varroot/shares.ini",true));
-  $count = array_count_values($lsof);
+  /* Extract keys from both ini files */
+  $paths = array_merge(array_keys($shares), array_keys($disks));
+
+  /* Construct the list of paths */
+  $mnt_paths = array_map(function($key) {
+    return '/mnt/'.escapeshellarg($key);
+  }, $paths);
+
+  /* Combine paths into the command */
+  $mnt_list = implode(' ', $mnt_paths);
+
+  /* Build and execute the modified command */
+  $command = 'LANG="en_US.UTF8" timeout 3 lsof -Fn '.$mnt_list.' 2>/dev/null | awk -F/ \'$1=="n" && $2=="mnt" && $5!="" {print $4"/"$5"/"$6"/"$7}\' | sort -u | awk -F/ \'{print $1}\'';
+  exec($command, $lsof);
+
+  $share = array_keys($shares);
+  $count = array_count_values($lsof ?? array());
   foreach ($share as $name) $echo['stream'][] = $count[$name]??0;
   $echo = json_encode($echo);
   $md5_new = md5($echo,true);

--- a/emhttp/plugins/dynamix/nchan/update_1
+++ b/emhttp/plugins/dynamix/nchan/update_1
@@ -29,7 +29,7 @@ require_once "$docroot/webGui/include/Translations.php";
 $locale_init = $locale;
 
 /* Parse the ini files */
-$shares = parse_ini_file($varroot.'/shares.ini', true);
+$shares = parse_ini_file('state/shares.ini', true);
 $disks = parse_ini_file('state/disks.ini', true);
 
 function update_translation($locale) {
@@ -97,6 +97,7 @@ while (true) {
   if (count($fans)) $echo['fan'] = array_map(function($fan){return "$fan RPM";},$fans);
 
   // add streams information
+  /* Extract keys from both ini files */
   $paths = array_keys($disks);
 
   /* Validate and filter accessible mount points */

--- a/emhttp/plugins/dynamix/nchan/update_1
+++ b/emhttp/plugins/dynamix/nchan/update_1
@@ -98,12 +98,19 @@ while (true) {
 
   // add streams information
   /* Extract keys from both ini files */
-  $paths = array_merge(array_keys($shares), array_keys($disks));
+  $paths = array_keys($disks);
+
+  /* Validate and filter accessible mount points */
+  $valid_paths = array_filter($paths, function($key) {
+    $mnt_path = '/mnt/' . $key;
+    /* Check if the directory exists and is a valid mount point */
+    return is_dir($mnt_path) && trim(shell_exec("mountpoint -q " . escapeshellarg($mnt_path) . " && echo 1")) === '1';
+  });
 
   /* Construct the list of paths */
   $mnt_paths = array_map(function($key) {
     return '/mnt/'.escapeshellarg($key);
-  }, $paths);
+  }, $valid_paths);
 
   /* Combine paths into the command */
   $mnt_list = implode(' ', $mnt_paths);


### PR DESCRIPTION
- Only do 'lsof' command in 'update_1' on disk devices.  There is no need to do the 'lsof' command on UD mount points.  When a UD remote share goes offline, it can hang any 'lsof' commands.
- Add 3 second timeout so 'lsof' will always terminate and not hang.
- The 'lsof' command is used to update the stream count on the Dsshboard page on SMB shares.