### PR TITLE
fix: nfsd restarts

### DIFF
--- a/etc/rc.d/rc.nfsd
+++ b/etc/rc.d/rc.nfsd
@@ -105,9 +105,7 @@ nfsd_stop(){
     REPLY="Already stopped"
   else
     killall --ns $$ rpc.mountd 2>/dev/null
-    killall --ns $$ nfsd 2>/dev/null
-    sleep 1
-    killall --ns $$ -9 nfsd 2>/dev/null
+    run $NFSD 0
     killall --ns $$ rpc.rquotad 2>/dev/null
     run $EXPORTFS -au
     if ! nfsd_running; then REPLY="Stopped"; else REPLY="Failed"; fi

--- a/etc/rc.d/rc.nfsd
+++ b/etc/rc.d/rc.nfsd
@@ -128,7 +128,7 @@ nfsd_reload(){
 nfsd_update(){
   if nfsd_running && check && [[ "$(this)" != "-H ${BIND// / -H }" ]]; then
     log "Updating $DAEMON..."
-    nfsd_reload
+    nfsd_restart
   fi
 }
 


### PR DESCRIPTION
rc.nfsd does not stop nfsd. Even after running `/etc/rc.d/rc.nfsd stop` and `/etc/rc.d/rc.rpc stop`, nfsd continues to run.

As a result, changes to `/etc/default/nfs` (e.g., Tailscale interfaces) are never applied.

nfsd cannot be killed using `killall`. Per the [kernel server documentation](https://docs.kernel.org/admin-guide/nfs/nfsd-admin-interfaces.html), knfsd is shut down by setting the number of threads to zero.