### PR TITLE
Improvements to Disk Usage Graph

### DIFF
--- a/emhttp/plugins/dynamix/DisplaySettings.page
+++ b/emhttp/plugins/dynamix/DisplaySettings.page
@@ -19,6 +19,8 @@ Tag="desktop"
 $void = "<img src='/webGui/images/banner.png' id='image' width='330' height='30' onclick='$(&quot;#drop&quot;).click()' style='cursor:pointer' title='_(Click to select PNG file)_'>";
 $icon = "<i class='fa fa-trash top' title='_(Restore default image)_' onclick='restore()'></i>";
 $plugins = '/var/log/plugins';
+$width    = [166,300];
+$disks    = array_filter($disks,'my_is_data_disk');
 
 require_once "$docroot/plugins/dynamix.plugin.manager/include/PluginHelpers.php";
 ?>
@@ -117,6 +119,8 @@ $(function() {
     if ($('#dropbox').triggerHandler({type:'drop',dataTransfer:{files:files}})==false) e.stopImmediatePropagation();
   });
   presetBanner(document.display_settings);
+  
+  $('#usage_disks').dropdownchecklist({emptyText:"_(None)_", width:<?=$width[0]?>, explicitClose:"..._(close)_"});
 });
 </script>
 
@@ -239,6 +243,13 @@ _(Show array utilization indicator)_:
 : <select name="usage">
   <?=mk_option($display['usage'], "0",_('No'))?>
   <?=mk_option($display['usage'], "1",_('Yes'))?>
+  </select>
+
+_(Utilization indicator disks)_:
+: <select id="usage_disks" name="usage_disks[]" multiple="multiple" style="display:none">
+  <?foreach ($disks as $disk):?>
+  <?=mk_option_check($display['usage_disks'],_var($disk,'name'),_var($disk,'name'))?>
+  <?endforeach;?>
   </select>
 
 _(Temperature unit)_:

--- a/emhttp/plugins/dynamix/include/Helpers.php
+++ b/emhttp/plugins/dynamix/include/Helpers.php
@@ -100,16 +100,40 @@ function my_word($num) {
   $words = ['zero','one','two','three','four','five','six','seven','eight','nine','ten','eleven','twelve','thirteen','fourteen','fifteen','sixteen','seventeen','eighteen','nineteen','twenty','twenty-one','twenty-two','twenty-three','twenty-four','twenty-five','twenty-six','twenty-seven','twenty-eight','twenty-nine','thirty'];
   return $num<count($words) ? _($words[$num],1) : $num;
 }
+function my_contains_one_of($haystack, $needles) {
+  foreach ($needles as $needle) {
+      if (str_contains($haystack, $needle)) {
+          return true; // Found a match
+      }
+  }
+  return false; // No match found
+}
+function my_is_data_disk($disk) {
+  if (strpos(_var($disk,'type'), 'Data')!==false) {
+    // Disk is part of the array
+    return true;
+  }
+  if (strpos(_var($disk,'type'), 'Cache')!==false) {
+    if (_var($disk,'fsFree', -1)!=-1) {
+      // Disk is part of a pool and the master
+      return true;
+    }
+  }
+  return false;
+}
 function my_usage() {
   global $disks,$var,$display;
   $arraysize=0;
   $arrayfree=0;
   foreach ($disks as $disk) {
-    if (strpos(_var($disk,'name'),'disk')!==false) {
-      $arraysize += _var($disk,'sizeSb',0);
-      $arrayfree += _var($disk,'fsFree',0);
+    if (my_contains_one_of(_var($disk,'name'), explode(',',_var($display, "usage_disks")))) {
+      if (my_is_data_disk($disk)) {
+        $arraysize += _var($disk,'sizeSb',0);
+        $arrayfree += _var($disk,'fsFree',0);
+      }
     }
   }
+
   if (_var($var,'fsNumMounted',0)>0) {
     $used = $arraysize ? 100-round(100*$arrayfree/$arraysize) : 0;
     echo "<div class='usage-bar'><span style='width:{$used}%' class='".usage_color($display,$used,false)."'>{$used}%</span></div>";
@@ -288,13 +312,6 @@ function transpose_user_path($path) {
   }
   return $path;
 }
-// custom parse_ini_file/string functions to deal with '#' comment lines
-function my_parse_ini_string($text, $sections=false, $scanner=INI_SCANNER_NORMAL) {
-  return parse_ini_string(preg_replace('/^#/m',';',$text),$sections,$scanner);
-}
-function my_parse_ini_file($file, $sections=false, $scanner=INI_SCANNER_NORMAL) {
-  return my_parse_ini_string(file_get_contents($file),$sections,$scanner);
-}
 function cpu_list() {
   exec('cat /sys/devices/system/cpu/*/topology/thread_siblings_list|sort -nu', $cpus);
   return $cpus;
@@ -394,5 +411,10 @@ function get_realvolume($path) {
     $reallocation = $realexplode[0];
   }
   return $reallocation;
+}
+function device_exists($name)
+{
+  global $disks,$devs;
+  return (array_key_exists($name, $disks) && !str_contains(_var($disks[$name],'status'),'_NP')) || (array_key_exists($name, $devs));
 }
 ?>


### PR DESCRIPTION
Made some improvements to the Disk Usage Graph in the Menu Bar on the Top Right. It is decoupled from the array and configurable which arrays/pools should be included in the calculations. The filtering is done by disk type, either Data (Array Disks) or Cache (Pools). In case of pools it is also limit to only drives with a valid fsFree, as only the first drive in the pool has it filled.

I am not able to get the saving of the selected disks to work, so it is kinda a WIP, but any help is appreciated! 