### PR TITLE
Install `ca-certificates` during `tailscale_container_hook` operations to prevent SSL errors in some cases

### DIFF
--- a/share/docker/tailscale_container_hook
+++ b/share/docker/tailscale_container_hook
@@ -78,7 +78,7 @@ if [ ! -f /usr/bin/tailscale ] || [ ! -f /usr/bin/tailscaled ]; then
   if [ ! -z "${PACKAGES_UPDATE}" ]; then
     UPDATE_LOG=$(${PACKAGES_UPDATE} 2>&1)
   fi
-  INSTALL_LOG=$(${PACKAGES_INSTALL} jq wget ${INSTALL_IPTABLES}${PACKAGES_TROUBLESHOOTING} 2>&1)
+  INSTALL_LOG=$(${PACKAGES_INSTALL} jq wget ca-certificates ${INSTALL_IPTABLES}${PACKAGES_TROUBLESHOOTING} 2>&1)
   INSTALL_RESULT=$?
 
   if [ "${INSTALL_RESULT}" -eq 0 ]; then


### PR DESCRIPTION
In some cases, line 105 will fail because of SSL verification issues. Namely, that there are no root CAs installed in the container environment. 

```
TAILSCALE_VERSION=$(wget -qO- 'https://pkgs.tailscale.com/stable/?mode=json' | jq -r '.TarballsVersion')
```

Installing `ca-certificates` alongside `wget` and `jq` fixes this problem.

I have tested it on a few images on my Unraid 7 environment that do (`home-asssistant/home-assistant`) and don't (`gristlabs/grist`) have `ca-certificates` present, and have found this fix to be working.