### PR TITLE
UD devices not selectable in picker and file manager

### DIFF
--- a/emhttp/plugins/dynamix/include/FileTree.php
+++ b/emhttp/plugins/dynamix/include/FileTree.php
@@ -50,7 +50,7 @@ $match    = $_POST['match'];
 $checkbox = $_POST['multiSelect']=='true' ? "<input type='checkbox'>" : "";
 
 /* Excluded folders to not show in the dropdown in the '/mnt/' directory only. */
-$excludedFolders	= ["RecycleBin", "addons", "remotes", "rootshare", "user0"];
+$excludedFolders	= ["RecycleBin", "addons", "rootshare", "user0"];
 
 echo "<ul class='jqueryFileTree'>";
 if ($_POST['show_parent']=='true' && is_top($rootdir)) echo "<li class='directory collapsed'>$checkbox<a href='#' rel=\"".htmlspecialchars(dirname($rootdir))."\">..</a></li>";

--- a/emhttp/plugins/dynamix/include/ShareList.php
+++ b/emhttp/plugins/dynamix/include/ShareList.php
@@ -261,7 +261,7 @@ foreach ($shares as $name => $share) {
 		}
 	}
 
-	echo "<tr><td><a class='view' href=\"/$path/Browse?dir=/mnt/user/", rawurlencode($name), "\"><i class=\"icon-u-tab\" title=\"", _('Browse'), " /mnt/user/" . rawurlencode($name), "\"></i></a>";
+	echo "<tr><td><a class='view' href=\"/$path/Browse?dir=/mnt/user/", htmlspecialchars($name), "\"><i class=\"icon-u-tab\" title=\"", _('Browse'), " /mnt/user/" . htmlspecialchars($name), "\"></i></a>";
 	echo "<a class='info nohand' onclick='return false'><i class='fa fa-$orb orb $color-orb'></i><span style='left:18px'>$help</span></a>$luks<a href=\"/$path/Share?name=";
 	echo rawurlencode($name), "\" onclick=\"$.cookie('one','tab1')\">$name</a></td>";
 	echo "<td>{$share['comment']}</td>";


### PR DESCRIPTION
- Allow the remote share mounts to show in the file picker.
- The tool tip on a user share browse showed "%20" instead of a space on a share with a space.