### PR TITLE
Php errors cause share edit page to malfunction.

### DIFF
--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -114,6 +114,7 @@ function presetSpace($val) {
 	}
 
 	/* Prepare the fsSize array for each pool */
+	$fsSize	= [];
 	foreach ($pools as $pool) {
 		$fsSize[$pool] = _var($disks[$pool], 'fsSize', 0);
 	}
@@ -121,8 +122,10 @@ function presetSpace($val) {
 	/* Get the maximum value from the large array, filtering out non-numeric values */
 	if (!empty($large)) {
 		$fsSize[''] = max(array_filter($large, 'is_numeric'));
-	} else {
+	} else if (!empty($fsSize)) {
 		$fsSize[''] = $fsSize[$pool];
+	} else {
+		$fsSize['']	= "0";
 	}
 
 	/* Get the cache pool size */
@@ -253,13 +256,16 @@ function fsFree() {
 		$fsFree[$pool] = _var($disks[$pool], 'fsFree', 0);
 	}
 
-	/* Determine the free filesystem space based on the poolsOnly flag */
+	/* Determine the free filesystem space */
 	if (!empty($large)) {
 		/* Set the maximum free filesystem space from the array of enabled disks */
 		$fsFree[''] = max(array_filter($large));
-	} else {
+	} else if (!empty($fsFree)) {
 		/* Set the minimum free filesystem space from the pool array */
 		$fsFree[''] = min(array_filter($fsFree));
+	} else {
+		/* The minimum free space cannot be determined from the array or pools so it is set to zero */
+		$fsFree['']	= "0";
 	}
 
 	/* Return the free filesystem space as a JSON encoded string */


### PR DESCRIPTION
When checking for min() and max() values for the array and pools used for the min free space calculation, the min() and max() functions fail on an empty array. This can happen when an array is defined and there are no pool devices. There are also some other cases like an included disk missing in the array that cause the issue. These php errors create a wonky share edit page to display,

Had to remove the repository and start with a fresh fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of filesystem size and free space calculations
	- Added robust fallback mechanisms for scenarios with incomplete filesystem data
	- Enhanced reliability of storage space reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->