### PR TITLE
Bug: Parity check notification often shows the previous parity check

### DIFF
--- a/emhttp/plugins/dynamix/nchan/parity_list
+++ b/emhttp/plugins/dynamix/nchan/parity_list
@@ -18,7 +18,7 @@ $log      = '/boot/config/parity-checks.log';
 $stamps   = '/var/tmp/stamps.ini';
 $resync   = '/var/tmp/resync.ini';
 $md5_old  = $spot_old = $fs_old = $proc_old = -1;
-$remove_resync_files = false;
+$remove_resync_files = 0;
 
 require_once "$docroot/webGui/include/Helpers.php";
 require_once "$docroot/webGui/include/publish.php";
@@ -108,14 +108,16 @@ while (true) {
 			file_put_contents($log, "$timestamp|$duration|$speed|$status|$error|$action|$size\n", FILE_APPEND);
 
 			/* Remove the resync files after the history file has been updated. */
-			$remove_resync_files = true;
+			$remove_resync_files = 1;
 
 			/* Parity check is completed. */
 			$echo = "";
-		} elseif ($remove_resync_files) {
+		} elseif ($remove_resync_files >= 3) {
 			delete_file($stamps, $resync);
 
-			$remove_resync_files = false;
+			$remove_resync_files = 0;
+		} elseif ($remove_resync_files != 0) {
+			$remove_resync_files++;
 		}
 	}
 


### PR DESCRIPTION
Delay deleting of resync files so the parity check notification gets the latest parity check from the history file and not the previous parity check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the background cleanup process to manage temporary files more efficiently. The update introduces a refined cycle-based control mechanism for file removal, contributing to improved system stability and optimal resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->