### PR TITLE
fix: PHP Warning in state.php

### DIFF
--- a/emhttp/plugins/dynamix.my.servers/include/state.php
+++ b/emhttp/plugins/dynamix.my.servers/include/state.php
@@ -114,7 +114,7 @@ class ServerState
     /**
      * Retrieve the value of a webgui global setting.
      */
-    public function getWebguiGlobal(string $key, string $subkey = null) {
+    public function getWebguiGlobal(string $key, ?string $subkey = null) {
         if (!$subkey) {
             return _var($this->webguiGlobals, $key, '');
         }


### PR DESCRIPTION
Implicitly marking parameter $subkey as nullable is deprecated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced server functionality to support optional inputs, increasing flexibility in handling configuration scenarios without impacting overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->