### PR TITLE
fix: PHP Warning in Wrappers.php

### DIFF
--- a/emhttp/plugins/dynamix/include/Wrappers.php
+++ b/emhttp/plugins/dynamix/include/Wrappers.php
@@ -212,7 +212,7 @@ function my_logger($message, $logger='webgui') {
  * @param array $getinfo Empty array passed by reference, will contain results of curl_getinfo and curl_error
  * @return string|false $out The fetched content
  */
-function http_get_contents(string $url, array $opts = [], array &$getinfo = NULL) {
+function http_get_contents(string $url, array $opts = [], ?array &$getinfo = NULL) {
   $ch = curl_init();
   if(isset($getinfo)) {
     curl_setopt($ch, CURLINFO_HEADER_OUT, TRUE);

--- a/emhttp/plugins/dynamix/include/Wrappers.php
+++ b/emhttp/plugins/dynamix/include/Wrappers.php
@@ -209,7 +209,7 @@ function my_logger($message, $logger='webgui') {
  * Fetches URL and returns content
  * @param string $url The URL to fetch
  * @param array $opts Array of options to pass to curl_setopt()
- * @param array $getinfo Empty array passed by reference, will contain results of curl_getinfo and curl_error
+ * @param ?array $getinfo Empty array passed by reference, will contain results of curl_getinfo and curl_error, or null if not needed
  * @return string|false $out The fetched content
  */
 function http_get_contents(string $url, array $opts = [], ?array &$getinfo = NULL) {


### PR DESCRIPTION
Implicitly marking parameter $getinfo as nullable is deprecated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced internal processing by refining parameter handling for improved stability and clarity. User-facing functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->