### PR TITLE
fix: enable PHP warnings for beta|rc

### DIFF
--- a/etc/rc.d/rc.S
+++ b/etc/rc.d/rc.S
@@ -181,9 +181,13 @@ if [[ $NONVFAT == btrfs || $NONVFAT == xfs ]]; then
   /usr/bin/chmod -R 644 /boot
 fi
 
-# invoke testing hook (only for test versions)
 . /etc/unraid-version
-if [[ -f /boot/config/rc.S.extra && $version =~ beta ]]; then
+# log all PHP warnings (for beta|rc releases)
+if [[ $version =~ -(beta|rc) ]]; then
+  sed -i 's/^error_reporting=.*/error_reporting=E_ALL/' /etc/php.d/errors-php.ini
+fi
+# invoke testing hook (for -(beta|rc).x.y releases)
+if [[ -f /boot/config/rc.S.extra && $version =~ -(beta|rc)\.[0-9]+\.[0-9]+$ ]]; then
   . /boot/config/rc.S.extra
 fi
 # and continue in separate script

--- a/etc/rc.d/rc.S
+++ b/etc/rc.d/rc.S
@@ -183,7 +183,7 @@ fi
 
 . /etc/unraid-version
 # log all PHP warnings (for beta|rc releases)
-if [[ $version =~ -(beta|rc) ]]; then
+if [[ -f /etc/php.d/errors-php.ini && $version =~ -(beta|rc) ]]; then
   sed -i 's/^error_reporting=.*/error_reporting=E_ALL/' /etc/php.d/errors-php.ini
 fi
 # invoke testing hook (for -(beta|rc).x.y releases)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced pre-release handling by extending support to both beta and release candidate versions.
  - Improved error reporting for pre-release builds, enabling more effective logging of PHP warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->