### PR TITLE
Fix php error when shell_exec() returns a null value.

### DIFF
--- a/emhttp/plugins/dynamix/nchan/update_1
+++ b/emhttp/plugins/dynamix/nchan/update_1
@@ -104,7 +104,7 @@ while (true) {
   $valid_paths = array_filter($paths, function($key) {
     $mnt_path = '/mnt/' . $key;
     /* Check if the directory exists and is a valid mount point */
-    return is_dir($mnt_path) && trim(shell_exec("mountpoint -q " . escapeshellarg($mnt_path) . " && echo 1")) === '1';
+    return is_dir($mnt_path) && trim((shell_exec("mountpoint -q " . escapeshellarg($mnt_path) . " && echo 1")) ?? '') === '1';
   });
 
   /* Construct the list of paths */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the internal logic for validating mount points to enhance overall system reliability and avoid unexpected issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->