### PR TITLE
Fix: Update status Docker containers

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -385,16 +385,17 @@ class DockerTemplates {
 			$tmp['Project'] = $tmp['Project'] ?? $this->getTemplateValue($image, 'Project');
 			$tmp['DonateLink'] = $tmp['DonateLink'] ?? $this->getTemplateValue($image, 'DonateLink');
 			$tmp['ReadMe'] = $tmp['ReadMe'] ?? $this->getTemplateValue($image, 'ReadMe');
-			if (empty($tmp['updated']) || $reload) {
-				if ($reload) $DockerUpdate->reloadUpdateStatus($image);
-				$tmp['updated'] = var_export($DockerUpdate->getUpdateStatus($image),true);
-			}
 			if (!$com) $tmp['updated'] = 'undef';
-			if ($ct['Manager'] !== 'dockerman')
+			if ($ct['Manager'] !== 'dockerman') {
 				$tmp['template'] = null;
-			else if (empty($tmp['template']) || $reload) {
+				$tmp['updated'] = null;
+			} else if (empty($tmp['template']) || $reload) {
 				$tmp['template'] = $this->getUserTemplate($name);
 				if ($reload) $DockerUpdate->updateUserTemplate($name);
+  			if (empty($tmp['updated']) || $reload) {
+					if ($reload) $DockerUpdate->reloadUpdateStatus($image);
+					$tmp['updated'] = var_export($DockerUpdate->getUpdateStatus($image),true);
+				}
 			}
 			//$this->debug("\n$name");
 			//foreach ($tmp as $c => $d) $this->debug(sprintf('   %-10s: %s', $c, $d));

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -392,7 +392,7 @@ class DockerTemplates {
 			} else if (empty($tmp['template']) || $reload) {
 				$tmp['template'] = $this->getUserTemplate($name);
 				if ($reload) $DockerUpdate->updateUserTemplate($name);
-  			if (empty($tmp['updated']) || $reload) {
+  				if (empty($tmp['updated']) || $reload) {
 					if ($reload) $DockerUpdate->reloadUpdateStatus($image);
 					$tmp['updated'] = var_export($DockerUpdate->getUpdateStatus($image),true);
 				}

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -200,10 +200,8 @@ foreach ($containers as $ct) {
         echo "<div class='advanced'><a class='exec' onclick=\"updateContainer('".addslashes(htmlspecialchars($name))."');\"><span style='white-space:nowrap;'><i class='fa fa-cloud-download fa-fw'></i> "._('force update')."</span></a></div>";
       } elseif (!empty($composestack)) {
         echo "<div><span><i class='fa fa-docker fa-fw'/></i> "._("Compose")."</span></div>";
-        echo "<span tyle='white-space:nowrap;'><i class='fa fa-check fa-fw'></i> "._('up-to-date')."</span>";
       } else {
         echo "<div><span><i class='fa fa-docker fa-fw'/></i> "._("3rd Party")."</span></div>";
-        echo "<span tyle='white-space:nowrap;'><i class='fa fa-check fa-fw'></i> "._('up-to-date')."</span>";
       }
       break;
     case 1:
@@ -212,10 +210,8 @@ foreach ($containers as $ct) {
         echo "<a class='exec' onclick=\"updateContainer('".addslashes(htmlspecialchars($name))."');\"><span style='white-space:nowrap;'><i class='fa fa-cloud-download fa-fw'></i> "._('apply update')."</span></a>";
       } elseif (!empty($composestack)) {
         echo "<div><span><i class='fa fa-docker fa-fw'/></i> Compose</span></a></div>";
-        echo "<span style='white-space:nowrap;'><i class='fa fa-cloud-download fa-fw'></i> "._('update available')."</span>";
       } else {
         echo "<div><span><i class='fa fa-docker fa-fw'/></i> 3rd Party</span></div>";
-        echo "<span style='white-space:nowrap;'><i class='fa fa-cloud-download fa-fw'></i> "._('update available')."</span>";
       }
       break;
     case 2:
@@ -228,10 +224,8 @@ foreach ($containers as $ct) {
         echo "<div class='advanced'><a class='exec' onclick=\"updateContainer('".addslashes(htmlspecialchars($name))."');\"><span style='white-space:nowrap;'><i class='fa fa-cloud-download fa-fw'></i> "._('force update')."</span></a></div>";
       } elseif (!empty($composestack)) {
         echo "<div><span><i class='fa fa-docker fa-fw'/></i> "._("Compose")."</span></div>";
-        echo "<span style='white-space:nowrap;'><i class='fa fa-unlink'></i> "._('not available')."</span>";
       } else {
         echo "<div><span><i class='fa fa-docker fa-fw'/></i> "._("3rd Party")."</span></div>";
-        echo "<span style='white-space:nowrap;'><i class='fa fa-unlink'></i> "._('not available')."</span>";
       }
       break;
     }


### PR DESCRIPTION
- make sure to only pull update information for Docker containers managed by `dockerman`
- make sure to only display update information on Docker page for containers managed by `dockerman`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the update status logic for templates, ensuring that notifications display only when necessary. This improvement results in more accurate and consistent update information.
  - Simplified feedback for container statuses by removing excessive update messages. The cleaner interface now provides a more streamlined view of container information, enhancing the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->