### PR TITLE
Bug: Show latest syslog entries by scrolling to the bottom of the log.

### DIFF
--- a/emhttp/plugins/dynamix/Syslog.page
+++ b/emhttp/plugins/dynamix/Syslog.page
@@ -90,20 +90,30 @@ function resize() {
   $('pre.up').height(Math.max(window.innerHeight-320,330));
 }
 <?endif;?>
+
 function showLog(log) {
-  logfile = log;
-  $('span.label input[type=checkbox]').prop('checked',true);
-  $('span.label').each(function(){
-    var type = $(this).attr('class').replace('label','').replace(/-/g,'');
-    $(this).removeClass().addClass(type+' label');
-  });
-  timers.syslog = setTimeout(function(){$('div.spinner.fixed').show('slow');},500);
-  $.post('/webGui/include/Syslog.php',{log:log,max:$('#max').val()||<?=$max?>},function(data){
-    clearTimeout(timers.syslog);
-    $('pre.up').html(data);
-    $('div.spinner.fixed').hide('slow');
-  });
+	logfile = log;
+	$('span.label input[type=checkbox]').prop('checked', true);
+	$('span.label').each(function() {
+		var type = $(this).attr('class').replace('label', '').replace(/-/g, '');
+		$(this).removeClass().addClass(type + ' label');
+	});
+	timers.syslog = setTimeout(function() { $('div.spinner.fixed').show('slow'); }, 500);
+
+	$.post('/webGui/include/Syslog.php', { log: log, max: $('#max').val() || <?=$max?> }, function(data) {
+		clearTimeout(timers.syslog);
+		$('pre.up').html(data);
+		$('div.spinner.fixed').hide('slow');
+
+		/* Scroll to bottom after the log is loaded */
+		const logContainer = document.querySelector("pre.up");
+		if (logContainer) {
+			logContainer.scrollTop = logContainer.scrollHeight;
+		}
+	});
 }
+
+
 $(function() {
   $('input#max').on('keydown',function(e) {
     if (e.keyCode === 13) {


### PR DESCRIPTION
When the syslog is loaded, scroll to the bottom of the log to show the most current log entries so a user does not have to manually scroll down the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically scrolls to display the most recent log entries when logs update, ensuring users immediately see the latest information.
  
- **Refactor**
  - Enhanced code consistency and readability for smoother log display functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->