### PR TITLE
Bug: Fix php warning when file does not exist.

### DIFF
--- a/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
+++ b/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
@@ -177,7 +177,11 @@ foreach (glob($plugins,GLOB_NOSORT) as $plugin_link) {
             if (!$os) $updates++;
           } else {
             //status is considered outdated when older than 1 day
-            $status = filectime($filename) > (time()-86400) ? "<span class='green-text'><i class='fa fa-check fa-fw'></i>&nbsp;"._('up-to-date')."</span>" : "<span class='orange-text'><i class='fa fa-flash fa-fw'></i>&nbsp;"._('need check')."</span>";
+            if (file_exists($filename)) {
+              $status = filectime($filename) > (time()-86400) ? "<span class='green-text'><i class='fa fa-check fa-fw'></i>&nbsp;"._('up-to-date')."</span>" : "<span class='orange-text'><i class='fa fa-flash fa-fw'></i>&nbsp;"._('need check')."</span>";
+            } else {
+              $status = "<span class='red-text'><i class='fa fa-exclamation-triangle fa-fw'></i>&nbsp;"._('cannot check')."</span>";
+            }
           }
         }
       }


### PR DESCRIPTION
When plugin file does not exist, show "cannot check" instead of getting a php warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the plugin status experience by ensuring that unavailable plugins display a clear, accurate status message.
  - This enhancement prevents confusion by showing a specific message when a plugin cannot be verified, ensuring reliable information on plugin availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->