### PR TITLE
Bug: Use exit instead of return to prevent php warnings.

### DIFF
--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -17,7 +17,7 @@ Tag="share-alt-square"
 <?
 if (!empty($name) && !array_key_exists($name, $shares)) {
   echo "<script>done()</script>";
-  return;
+  exit;
 }
 $width = [123,300];
 


### PR DESCRIPTION
Php warnings continue when a share is deleted.  Exit is a better choice than return to be sure the php code in the page is not executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error handling to immediately halt page processing when encountering specific unexpected conditions, ensuring that subsequent actions do not execute inadvertently.
	- This change improves system stability and consistency by preventing incomplete or unintended page responses.
	- The update safeguards against partial processing, providing a more reliable and predictable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->