### PR TITLE
Avoid automatic shutdown while being logged in and visiting Boot.php

### DIFF
--- a/emhttp/plugins/dynamix/include/Boot.php
+++ b/emhttp/plugins/dynamix/include/Boot.php
@@ -157,6 +157,9 @@ $(document).ajaxSend(function(elm, xhr, s){
 </script>
 </head>
 <?
+if ($_SERVER['REQUEST_METHOD'] === 'POST'){
+
+
 $safemode = '/boot/unraidsafemode';
 $progress = (_var($var,'fsProgress')!='') ? "<br><span class='blue'>{$var['fsProgress']}</span>" : "<br>&nbsp;";
 
@@ -187,5 +190,6 @@ default:
 echo '</div>';
 echo '<div class="sub2"></div>';
 echo '</body>';
+}
 ?>
 </html>


### PR DESCRIPTION
This add a check for getting a post request. Currently you can accidentally shutdown your server by just simply visiting SERVER/webGui/include/Boot.php while being logged in. This is absolutely not good 🫣