### PR TITLE
Fix: Don't autostart containers on host network with TS enabled

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
+++ b/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
@@ -15,8 +15,7 @@ foreach ($autostart as $container) {
   }
     
   $doc = new DOMDocument();
-  $doc->load("/boot/config/plugins/dockerMan/templates-user/my-{$cont[0]}.xml");   
-  if ( ! $doc ) {
+  if (!$doc->load("/boot/config/plugins/dockerMan/templates-user/my-{$cont[0]}.xml")) { 
     $newAuto[] = $container;
     continue;
   }

--- a/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
+++ b/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
@@ -23,6 +23,7 @@ foreach ($autostart as $container) {
     if ( ($doc->getElementsByTagName("TailscaleEnabled")->item(0)->nodeValue ?? false) == true ) {
       exec("logger ".escapeshellarg("Autostart disabled on {$cont[0]} due to tailscale integration with host network."));
       exec("logger ".escapeshellarg("This is a security risk due to the possibility of unauthenticated access to your server's GUI and resources"));
+      exec("/usr/local/emhttp/plugins/dynamix/scripts/notify -e 'Autostart Disabled' -s 'Autostart Disabled' -d ".escapeshellarg("Autostart disabled automatically on {$cont[0]}")." -m ".escapeshellarg("Autostart has been automatically disabled on {$cont[0]} due to a security issue with container on network type host and tailscale integration enabled.  You should either switch the network type or disabled tailscale integration on this container")." -i 'alert' -l '/Docker'");
       continue;           
     }
   }

--- a/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
+++ b/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
@@ -1,2 +1,33 @@
-#!/bin/bash
+#!/usr/bin/php
+<?
 # Invoked after docker image loopback mounted but before docker is started
+$autostart = @file("/var/lib/docker/unraid-autostart",FILE_IGNORE_NEW_LINES);
+if ( ! $autostart ) exit();
+
+$newAuto = [];
+foreach ($autostart as $container) {
+  if (! trim($container) ) continue;
+
+  $cont = explode(" ",$container);
+  if ( ! is_file("/boot/config/plugins/dockerMan/templates-user/my-{$cont[0]}.xml")) {
+    $newAuto[] = $container;
+    continue;
+  }
+    
+  $doc = new DOMDocument();
+  $doc->load("/boot/config/plugins/dockerMan/templates-user/my-{$cont[0]}.xml");   
+  if ( ! $doc ) {
+    $newAuto[] = $container;
+    continue;
+  }
+  if ( ($doc->getElementsByTagName("Network")->item(0)->nodeValue ?? false) == "host" ) {
+    if ( ($doc->getElementsByTagName("TailscaleEnabled")->item(0)->nodeValue ?? false) == true ) {
+      exec("logger ".escapeshellarg("Autostart disabled on {$cont[0]} due to tailscale integration with host network."));
+      exec("logger ".escapeshellarg("This is a security risk due to the possibility of unauthenticated access to your server's GUI and resources"));
+      continue;           
+    }
+  }
+  $newAuto[] = $container;
+}
+file_put_contents("/var/lib/docker/unraid-autostart",implode("\n",$newAuto));
+?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the container autostart process with improved configuration validation to prevent auto-start of containers with conflicting security settings.

- **Refactor**
  - Transitioned the autostart initialization script to a new runtime environment, streamlining control flow and error handling for better system reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->