### PR TITLE
Fix: Last container wouldn't autostart

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
+++ b/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
@@ -4,6 +4,7 @@
 $autostart = @file("/var/lib/docker/unraid-autostart",FILE_IGNORE_NEW_LINES);
 if ( ! $autostart ) exit();
 
+$flag = false;
 $newAuto = [];
 foreach ($autostart as $container) {
   if (! trim($container) ) continue;
@@ -15,7 +16,7 @@ foreach ($autostart as $container) {
   }
     
   $doc = new DOMDocument();
-  if (!$doc->load("/boot/config/plugins/dockerMan/templates-user/my-{$cont[0]}.xml")) { 
+  if (!$doc->load("/boot/config/plugins/dockerMan/templates-user/my-{$cont[0]}.xml")) {
     $newAuto[] = $container;
     continue;
   }
@@ -24,10 +25,12 @@ foreach ($autostart as $container) {
       exec("logger ".escapeshellarg("Autostart disabled on {$cont[0]} due to tailscale integration with host network."));
       exec("logger ".escapeshellarg("This is a security risk due to the possibility of unauthenticated access to your server's GUI and resources"));
       exec("/usr/local/emhttp/plugins/dynamix/scripts/notify -e 'Autostart Disabled' -s 'Autostart Disabled' -d ".escapeshellarg("Autostart disabled automatically on {$cont[0]}")." -m ".escapeshellarg("Autostart has been automatically disabled on {$cont[0]} due to a security issue with container on network type host and tailscale integration enabled.  You should either switch the network type or disabled tailscale integration on this container")." -i 'alert' -l '/Docker'");
+      $flag = true;
       continue;           
     }
   }
   $newAuto[] = $container;
 }
-file_put_contents("/var/lib/docker/unraid-autostart",implode("\n",$newAuto)."\n");
+if ( $flag )
+  file_put_contents("/var/lib/docker/unraid-autostart",implode("\n",$newAuto."\n");
 ?>

--- a/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
+++ b/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
@@ -29,5 +29,5 @@ foreach ($autostart as $container) {
   }
   $newAuto[] = $container;
 }
-file_put_contents("/var/lib/docker/unraid-autostart",implode("\n",$newAuto));
+file_put_contents("/var/lib/docker/unraid-autostart",implode("\n",$newAuto)."\n");
 ?>

--- a/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
+++ b/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
@@ -32,5 +32,5 @@ foreach ($autostart as $container) {
   $newAuto[] = $container;
 }
 if ( $flag )
-  file_put_contents("/var/lib/docker/unraid-autostart",implode("\n",$newAuto."\n");
+  file_put_contents("/var/lib/docker/unraid-autostart",implode("\n",$newAuto)."\n");
 ?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated configuration output formatting to consistently include a trailing newline, ensuring smoother processing and enhanced reliability.
	- Enhanced security measures by conditionally disabling containers with specific network settings and integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->