### PR TITLE
wireless: avoid double dns entries when static assignment is used

### DIFF
--- a/etc/rc.d/rc.wireless
+++ b/etc/rc.d/rc.wireless
@@ -104,8 +104,8 @@ ipaddr_up(){
     fi
   fi
   if [[ $DNS == yes ]]; then
-    [[ $IP == ipv4 ]] && echo "nameserver $SERVER4  # $PORT:v4" >>/etc/resolv.conf
-    [[ $IP == ipv6 ]] && echo "nameserver $SERVER6  # $PORT:v6" >>/etc/resolv.conf
+    [[ $IP == ipv4 && -z $(grep -om1 "nameserver $SERVER4" /etc/resolv.conf) ]] && echo "nameserver $SERVER4  # $PORT:v4" >>/etc/resolv.conf
+    [[ $IP == ipv6 && -z $(grep -om1 "nameserver $SERVER6" /etc/resolv.conf) ]] && echo "nameserver $SERVER6  # $PORT:v6" >>/etc/resolv.conf
   else
     [[ $IP == ipv4 ]] && sed -ri '/^nameserver .+# $PORT:v4/d' /etc/resolv.conf
     [[ $IP == ipv6 ]] && sed -ri '/^nameserver .+# $PORT:v6/d' /etc/resolv.conf


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved DNS configuration logic to verify if a nameserver entry already exists before adding one, preventing duplicate entries in the system's resolver settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->