### PR TITLE
feat: ServerState use UnraidCheck with ReplaceKey check

### DIFF
--- a/emhttp/plugins/dynamix.my.servers/Registration.page
+++ b/emhttp/plugins/dynamix.my.servers/Registration.page
@@ -14,6 +14,9 @@ Tag="pencil"
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  */
+/**
+ * @note ServerState class constructor will check for updates and new license key, bypassing the check window period, when rendering /Tools/Registration
+ */
 ?>
 <unraid-i18n-host>
   <unraid-registration></unraid-registration>

--- a/emhttp/plugins/dynamix.plugin.manager/Downgrade.page
+++ b/emhttp/plugins/dynamix.plugin.manager/Downgrade.page
@@ -15,6 +15,7 @@ Tag="upload"
  */
 /**
  * @note icon-update is rotated via CSS in myservers1.php
+ * @note ServerState class constructor will check for updates and new license key when rendering /Tools/Registration
  */
 
 require_once "$docroot/plugins/dynamix.my.servers/include/reboot-details.php";

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/unraidcheck
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/unraidcheck
@@ -9,11 +9,19 @@
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
+ *
+ * Usage:
+ *   unraidcheck                             - Normal check for updates
+ *   unraidcheck --force-replace-key-check   - Force check for new license key before update check
  */
 ?>
 <?
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/plugins/dynamix.plugin.manager/include/UnraidCheck.php";
 
+$forceReplaceKeyCheck = in_array('--force-replace-key-check', $argv);
+
 $unraidOsCheck = new UnraidOsCheck();
-$unraidOsCheck->checkForUpdate();
+$unraidOsCheckResult = $unraidOsCheck->checkForUpdate($forceReplaceKeyCheck);
+
+exit($unraidOsCheckResult ? 0 : 1);

--- a/emhttp/plugins/dynamix/include/InstallKey.php
+++ b/emhttp/plugins/dynamix/include/InstallKey.php
@@ -61,9 +61,12 @@ class KeyInstaller
             if ($returnVar === 0) {
                 $var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
                 if (_var($var, 'mdState') == "STARTED") {
-                    return $this->responseComplete(200, ['status' => _('Please Stop array to complete key installation')], _('success') . ', ' . _('Please Stop array to complete key installation'));
+                    return $this->responseComplete(200, [
+                        'status' => 'success',
+                        'message' => _('Please Stop array to complete key installation'),
+                    ]);
                 } else {
-                    return $this->responseComplete(200, ['status' => ''], _('success'));
+                    return $this->responseComplete(200, ['status' => 'success']);
                 }
             } else {
                 @unlink(escapeshellarg("/boot/config/$keyFile"));

--- a/emhttp/plugins/dynamix/include/InstallKey.php
+++ b/emhttp/plugins/dynamix/include/InstallKey.php
@@ -32,20 +32,20 @@ class KeyInstaller
      * @param int $httpcode https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
      * @param string|array $result - strings are assumed to be encoded JSON. Arrays will be encoded to JSON.
      */
-    private function responseComplete($httpcode, $result)
+    private function responseComplete($httpcode, $result): string
     {
         $mutatedResult = is_array($result) ? json_encode($result) : $result;
 
         if ($this->isGetRequest && $this->getHasUrlParam) { // return JSON to the caller
-          header('Content-Type: application/json');
-          http_response_code($httpcode);
-          exit((string)$mutatedResult);
+            header('Content-Type: application/json');
+            http_response_code($httpcode);
+            exit((string)$mutatedResult);
         } else { // return the result to the caller
-          return $mutatedResult;
+            return $mutatedResult;
         }
     }
 
-    public function installKey($keyUrl = null)
+    public function installKey($keyUrl = null): string
     {
         $url = unscript($keyUrl ?? _var($_GET, 'url'));
         $host = parse_url($url)['host'] ?? '';

--- a/emhttp/plugins/dynamix/include/ReplaceKey.php
+++ b/emhttp/plugins/dynamix/include/ReplaceKey.php
@@ -147,11 +147,17 @@ class ReplaceKey
         $KeyInstaller->installKey($key);
     }
 
-    private function writeJsonFile($file, $data)
+    private function writeJsonFile($file, $data, $append = false)
     {
-        if (!is_dir(dirname($file))) { // prevents errors when directory doesn't exist
+        if (!is_dir(dirname($file))) {
             mkdir(dirname($file));
         }
+
+        if ($append && file_exists($file)) {
+            $existing = json_decode(file_get_contents($file), true) ?: [];
+            $data = array_merge_recursive($existing, $data);
+        }
+
         file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
 
@@ -188,7 +194,9 @@ class ReplaceKey
                 '/tmp/ReplaceKey/error.json',
                 [
                     'error' => 'Failed to retrieve latest key after getting a `hasNewerKeyfile` in the validation response.',
-                ]
+                    'ts' => time(),
+                ],
+                true,
             );
             return;
         }

--- a/emhttp/plugins/dynamix/include/ReplaceKey.php
+++ b/emhttp/plugins/dynamix/include/ReplaceKey.php
@@ -147,15 +147,10 @@ class ReplaceKey
         $KeyInstaller->installKey($key);
     }
 
-    private function writeJsonFile($file, $data, $append = false)
+    private function writeJsonFile($file, $data)
     {
         if (!is_dir(dirname($file))) {
             mkdir(dirname($file));
-        }
-
-        if ($append && file_exists($file)) {
-            $existing = json_decode(file_get_contents($file), true) ?: [];
-            $data = array_merge_recursive($existing, $data);
         }
 
         file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
@@ -195,8 +190,7 @@ class ReplaceKey
                 [
                     'error' => 'Failed to retrieve latest key after getting a `hasNewerKeyfile` in the validation response.',
                     'ts' => time(),
-                ],
-                true,
+                ]
             );
             return;
         }

--- a/emhttp/plugins/dynamix/include/ReplaceKey.php
+++ b/emhttp/plugins/dynamix/include/ReplaceKey.php
@@ -175,7 +175,7 @@ class ReplaceKey
 
         $isWithinWindow = ($now >= $sevenDaysBefore && $now <= $sevenDaysAfter);
 
-        if ($forceCheck || $isWithinWindow) {
+        if (!$forceCheck && !$isWithinWindow) {
             return;
         }
 

--- a/emhttp/plugins/dynamix/include/ReplaceKey.php
+++ b/emhttp/plugins/dynamix/include/ReplaceKey.php
@@ -145,6 +145,16 @@ class ReplaceKey
 
         $KeyInstaller = new KeyInstaller();
         $KeyInstaller->installKey($key);
+
+        // Set up notification for new key installation
+        $keyType = basename($key, '.key');
+        $output  = _var($notify,'plugin');
+        $script  = '/usr/local/emhttp/webGui/scripts/notify';
+        $event   = "Installed New $keyType License";
+        $subject = "Your new $keyType license key has been automatically installed";
+        $description = "";
+
+        exec("$script -e ".escapeshellarg($event)." -s ".escapeshellarg($subject)." -d ".escapeshellarg($description)." -i ".escapeshellarg("normal $output")." -l '/Tools/Registration' -x");
     }
 
     private function writeJsonFile($file, $data)

--- a/emhttp/plugins/dynamix/include/ReplaceKey.php
+++ b/emhttp/plugins/dynamix/include/ReplaceKey.php
@@ -155,20 +155,21 @@ class ReplaceKey
         file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
 
-    public function check()
+    public function check(bool $forceCheck = false)
     {
         // we don't need to check
         if (empty($this->guid) || empty($this->keyfile) || empty($this->regExp)) {
             return;
         }
 
-        // set $isAlreadyExpired to true if regExp is in the past
-        $isAlreadyExpired = $this->regExp <= time();
-        // if regExp is seven days or less from now, we need to check
-        $isWithinSevenDays = $this->regExp <= strtotime('+7 days');
+        // Check if we're within the 7-day window before and after regExp
+        $now = time();
+        $sevenDaysBefore = strtotime('-7 days', $this->regExp);
+        $sevenDaysAfter = strtotime('+7 days', $this->regExp);
 
-        $shouldCheck = $isAlreadyExpired || $isWithinSevenDays;
-        if (!$shouldCheck) {
+        $isWithinWindow = ($now >= $sevenDaysBefore && $now <= $sevenDaysAfter);
+
+        if ($forceCheck || $isWithinWindow) {
             return;
         }
 


### PR DESCRIPTION
Coupling `ReplaceKey` check into `UnraidCheck` ensures the user is always on their most up to date license key if they have auto-extension enabled when OS Updates are being checked – weather the OS Update checks are automatic via the scheduled setting or manually via user action – Check for OS Updates btn in the top right dropdown or going to `/Tools/Update`, `/Tools/Downgrade`, or `/Tools/Registration`.

This coupling has been integrated into the `ServerState` constructor to ensure that any changes to `var.ini` that may happen during a automatically license key install are reflected throughout the ServerState class.