### PR TITLE
feat: replace key improvements

### DIFF
--- a/emhttp/plugins/dynamix.my.servers/Registration.page
+++ b/emhttp/plugins/dynamix.my.servers/Registration.page
@@ -14,6 +14,9 @@ Tag="pencil"
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  */
+require_once "$docroot/plugins/dynamix/include/ReplaceKey.php";
+$replaceKey = new ReplaceKey();
+$replaceKey->check(true);
 ?>
 <unraid-i18n-host>
   <unraid-registration></unraid-registration>

--- a/emhttp/plugins/dynamix.plugin.manager/Downgrade.page
+++ b/emhttp/plugins/dynamix.plugin.manager/Downgrade.page
@@ -16,11 +16,12 @@ Tag="upload"
 /**
  * @note icon-update is rotated via CSS in myservers1.php
  */
+require_once "$docroot/plugins/dynamix/include/ReplaceKey.php";
+$replaceKey = new ReplaceKey();
+$replaceKey->check();
 
 require_once "$docroot/plugins/dynamix.my.servers/include/reboot-details.php";
-// Create an instance of the RebootDetails class
 $rebootDetails = new RebootDetails();
-// Get the current reboot details if there are any
 $rebootDetails->setPrevious();
 
 $serverNameEscaped = htmlspecialchars(str_replace(' ', '_', strtolower($var['NAME'])));

--- a/emhttp/plugins/dynamix.plugin.manager/Update.page
+++ b/emhttp/plugins/dynamix.plugin.manager/Update.page
@@ -13,6 +13,10 @@ Tag="upload"
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  */
+require_once "$docroot/plugins/dynamix/include/ReplaceKey.php";
+$replaceKey = new ReplaceKey();
+$replaceKey->check();
+
 require_once "$docroot/plugins/dynamix.my.servers/include/reboot-details.php";
 $rebootDetails = new RebootDetails();
 ?>

--- a/emhttp/plugins/dynamix.plugin.manager/include/UnraidCheckExec.php
+++ b/emhttp/plugins/dynamix.plugin.manager/include/UnraidCheckExec.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file exists to maintain separation of concerns between UnraidCheck and ReplaceKey.
+ * Instead of combining both classes directly, we utilize the unraidcheck script which already
+ * handles both operations in a simplified manner.
+ * 
+ * It's called via the WebguiCheckForUpdate function in composables/services/webgui.ts of the web components.
+ * Handles WebguiUnraidCheckExecPayload interface parameters:
+ * - altUrl?: string
+ * - json?: boolean
+ */
+class UnraidCheckExec
+{
+    private const SCRIPT_PATH = '/usr/local/emhttp/plugins/dynamix.plugin.manager/scripts/unraidcheck';
+
+    private function setupEnvironment(): void
+    {
+        header('Content-Type: application/json');
+
+        $params = [
+            'json' => 'true',
+        ];
+        // allows the web components to determine the OS_RELEASES url
+        if (isset($_GET['altUrl']) && filter_var($_GET['altUrl'], FILTER_VALIDATE_URL)) {
+            $params['altUrl'] = $_GET['altUrl'];
+        }
+        // pass the params to the unraidcheck script for usage in UnraidCheck.php
+        putenv('QUERY_STRING=' . http_build_query($params));
+    }
+
+    public function execute(): string
+    {
+        $this->setupEnvironment();
+        $output = [];
+        exec(self::SCRIPT_PATH, $output);
+        return implode("\n", $output);
+    }
+}
+
+// Usage
+$checker = new UnraidCheckExec();
+echo $checker->execute();

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/unraidcheck
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/unraidcheck
@@ -17,6 +17,9 @@ require_once "$docroot/plugins/dynamix/include/ReplaceKey.php";
 $replaceKey = new ReplaceKey();
 $replaceKey->check();
 
+// utilized by UnraidCheckExec.php to have UnraidCheck.php return a json response when this script is called directly
+parse_str(getenv('QUERY_STRING') ?? '', $_GET);
+
 require_once "$docroot/plugins/dynamix.plugin.manager/include/UnraidCheck.php";
 $unraidOsCheck = new UnraidOsCheck();
 $unraidOsCheck->checkForUpdate();

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/unraidcheck
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/unraidcheck
@@ -13,7 +13,10 @@
 ?>
 <?
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
-require_once "$docroot/plugins/dynamix.plugin.manager/include/UnraidCheck.php";
+require_once "$docroot/plugins/dynamix/include/ReplaceKey.php";
+$replaceKey = new ReplaceKey();
+$replaceKey->check();
 
+require_once "$docroot/plugins/dynamix.plugin.manager/include/UnraidCheck.php";
 $unraidOsCheck = new UnraidOsCheck();
 $unraidOsCheck->checkForUpdate();

--- a/emhttp/plugins/dynamix/include/InstallKey.php
+++ b/emhttp/plugins/dynamix/include/InstallKey.php
@@ -32,20 +32,20 @@ class KeyInstaller
      * @param int $httpcode https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
      * @param string|array $result - strings are assumed to be encoded JSON. Arrays will be encoded to JSON.
      */
-    private function responseComplete($httpcode, $result)
+    private function responseComplete($httpcode, $result): string
     {
         $mutatedResult = is_array($result) ? json_encode($result) : $result;
 
         if ($this->isGetRequest && $this->getHasUrlParam) { // return JSON to the caller
-          header('Content-Type: application/json');
-          http_response_code($httpcode);
-          exit((string)$mutatedResult);
+            header('Content-Type: application/json');
+            http_response_code($httpcode);
+            exit((string)$mutatedResult);
         } else { // return the result to the caller
-          return $mutatedResult;
+            return $mutatedResult;
         }
     }
 
-    public function installKey($keyUrl = null)
+    public function installKey($keyUrl = null): string
     {
         $url = unscript($keyUrl ?? _var($_GET, 'url'));
         $host = parse_url($url)['host'] ?? '';
@@ -61,9 +61,12 @@ class KeyInstaller
             if ($returnVar === 0) {
                 $var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
                 if (_var($var, 'mdState') == "STARTED") {
-                    return $this->responseComplete(200, ['status' => _('Please Stop array to complete key installation')], _('success') . ', ' . _('Please Stop array to complete key installation'));
+                    return $this->responseComplete(200, [
+                        'status' => 'success',
+                        'message' => _('Please Stop array to complete key installation'),
+                    ]);
                 } else {
-                    return $this->responseComplete(200, ['status' => ''], _('success'));
+                    return $this->responseComplete(200, ['status' => 'success']);
                 }
             } else {
                 @unlink(escapeshellarg("/boot/config/$keyFile"));

--- a/emhttp/plugins/dynamix/include/ReplaceKey.php
+++ b/emhttp/plugins/dynamix/include/ReplaceKey.php
@@ -147,15 +147,10 @@ class ReplaceKey
         $KeyInstaller->installKey($key);
     }
 
-    private function writeJsonFile($file, $data, $append = false)
+    private function writeJsonFile($file, $data)
     {
         if (!is_dir(dirname($file))) {
             mkdir(dirname($file));
-        }
-
-        if ($append && file_exists($file)) {
-            $existing = json_decode(file_get_contents($file), true) ?: [];
-            $data = array_merge_recursive($existing, $data);
         }
 
         file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
@@ -175,7 +170,7 @@ class ReplaceKey
 
         $isWithinWindow = ($now >= $sevenDaysBefore && $now <= $sevenDaysAfter);
 
-        if ($forceCheck || $isWithinWindow) {
+        if (!$forceCheck && !$isWithinWindow) {
             return;
         }
 
@@ -195,8 +190,7 @@ class ReplaceKey
                 [
                     'error' => 'Failed to retrieve latest key after getting a `hasNewerKeyfile` in the validation response.',
                     'ts' => time(),
-                ],
-                true,
+                ]
             );
             return;
         }


### PR DESCRIPTION
Reflects recent changes to the same files in the `api` repo

- feat: `ReplaceKey` 7 day window around `regExp` & new `forceCheck` param
- feat: `ReplaceKey` notification for installing auto-extended license key
- feat: adds `ReplaceKey` check to `/Tools/Downgrade`, `/Tools/Update`, & `/Tools/Registration` as they're directly related to a license key's OS Update eligibility date.
- fix: `KeyInstaller` class success responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced key management functionality has been integrated into registration, update, and downgrade workflows, ensuring proactive checks and smoother transitions.
  - Key installation responses now deliver clear status messages and improved error notifications, offering users more reliable feedback.
  - A new class for executing update checks has been introduced, further refining the update process.
  - Optimized overall flow ensures smoother system operations and a more robust user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->