### PR TITLE
Fix: PHP error if a favourite page no longer exists

### DIFF
--- a/emhttp/plugins/dynamix/scripts/restore_favorites
+++ b/emhttp/plugins/dynamix/scripts/restore_favorites
@@ -7,6 +7,7 @@ $file = fopen($cfg,'r');
 while (($page = fgets($file))!==false) {
   // update each favorite
   $page = rtrim($page);
+  if ( ! is_file($page) ) continue;
   $line = fopen($page,'r');
   if ($line === false) continue;
   // get current Menu settings


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved system stability by ensuring only valid items are processed during the favorites operation, reducing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->