### PR TITLE
Refactor: Remove timeout option on inactive browsers

### DIFF
--- a/emhttp/plugins/dynamix/DisplaySettings.page
+++ b/emhttp/plugins/dynamix/DisplaySettings.page
@@ -329,9 +329,6 @@ _(Allow realtime updates on inactive browsers)_:
   <?=mk_option($display['liveUpdate'],"yes",_('Yes'))?>
   </select>
 
-_(Timeout in seconds before pausing realtime updates)_:
-: <input type="number" class="narrow" name="liveTime" value="<?=$display['liveTime']?>" maxlength="3">
-
 <input type="submit" name="#default" value="_(Default)_" onclick="filename='reset'">
 : <input type="submit" name="#apply" value="_(Apply)_" disabled><input type="button" value="_(Done)_" onclick="done()">
 </form>

--- a/emhttp/plugins/dynamix/default.cfg
+++ b/emhttp/plugins/dynamix/default.cfg
@@ -36,7 +36,6 @@ headerdescription="yes"
 showBannerGradient="yes"
 favorites="yes"
 liveUpdate="no"
-liveTime="0"
 [parity]
 mode="0"
 hour="0 0"

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout.php
@@ -1249,7 +1249,7 @@ $(window).focus(function() {
 $(window).blur(function() {
   blurTimer = setTimeout(function(){
     nchanFocusStop();
-  },<?=$display['liveTime']*1000?>);
+  },30000);
 });
 <?endif;?>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed the adjustable timeout control from display settings.
	- Standardized the pause for live updates to a fixed 30-second delay when focus is lost.
	- Removed the `liveTime` configuration option from the default settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->