### PR TITLE
Restore nchan_stub_status function

### DIFF
--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -393,6 +393,9 @@ build_locations(){
 	    nchan_channel_id "$1";
 	    nchan_channel_id_split_delimiter ",";
 	}
+	location /nchan_stub_status {
+	    nchan_stub_status;
+	}
 	#
 	# my servers proxy
 	#

--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -749,7 +749,7 @@ nginx_stop_forced(){
   else
     unraid_api_control stop
     # stop nchan publishers
-    /usr/local/sbin/monitor_nchan stop remove
+    /usr/local/sbin/monitor_nchan kill
     kill -TERM $(cat $PID)
     nginx_waitfor_shutdown
     if ! nginx_running; then REPLY="Stopped"; else REPLY="Failed"; fi

--- a/sbin/monitor_nchan
+++ b/sbin/monitor_nchan
@@ -26,10 +26,16 @@ nchan_start() {
   rm -f $nchan_list
 }
 
+if [[ $1 == kill ]]; then
+  echo "Stopping nchan processes..."
+  nchan_stop
+  rm -f $nchan_pid $disk_load
+  exit
+fi
+
 if [[ $1 == stop ]]; then
   echo "Stopping nchan processes..."
   nchan_stop
-  [[ $2 == remove ]] && rm -f $nchan_pid $disk_load
   exit
 fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new endpoint that provides real-time status information for the Nchan module, enhancing the server's monitoring capabilities.
	- Added a new method to cleanly terminate Nchan processes via a "kill" command.
- **Bug Fixes**
	- Updated the stopping mechanism for Nchan publishers to improve reliability during forced stops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->