### PR TITLE
Fix: Enable Apply button when adding a VLAN

### DIFF
--- a/emhttp/plugins/dynamix/Eth0.page
+++ b/emhttp/plugins/dynamix/Eth0.page
@@ -468,6 +468,7 @@ function checkNetworkAccess(form) {
 }
 
 function addVLAN(port) {
+  $('input[value="<?=_("Apply")?>"],input[value="Apply"]').prop('disabled',false);
   var index = 1;
   while ($('#index-'+port+'-'+index).length) index++;
   var template = $($('<div/>').loadTemplate($('#network-template-'+port)).html().replace(/INDEX/g,index));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the VLAN management interface to ensure the "Apply" button is enabled immediately after adding a VLAN, allowing users to submit changes without extra steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->