### PR TITLE
refactor: DefaultPageLayout footer rendering

### DIFF
--- a/emhttp/plugins/dynamix/include/DefaultPageLayout.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout.php
@@ -863,40 +863,47 @@ unset($pages,$page,$pgs,$pg,$icon,$nchan,$running,$start,$stop,$row,$script,$opt
 annotate('Footer');
 
 function getArrayStatus($var) {
-    $progress = (_var($var,'fsProgress')!='') ? "&bullet;<span class='blue strong tour'>{$var['fsProgress']}</span>" : "";
-    
+    $progress = (_var($var,'fsProgress')!='') ? $var['fsProgress'] : "";
+
     $statusMap = [
         'Stopped' => ['class' => 'red', 'icon' => 'stop-circle', 'text' => _('Array Stopped')],
         'Starting' => ['class' => 'orange', 'icon' => 'pause-circle', 'text' => _('Array Starting')],
         'Stopping' => ['class' => 'orange', 'icon' => 'pause-circle', 'text' => _('Array Stopping')],
         'default' => ['class' => 'green', 'icon' => 'play-circle', 'text' => _('Array Started')]
     ];
-    
+
     $state = _var($var,'fsState');
     $status = $statusMap[$state] ?? $statusMap['default'];
-    
-    return sprintf(
-        "<span class='%s strong'><i class='fa fa-%s'></i> %s</span>%s",
-        $status['class'],
-        $status['icon'],
-        $status['text'],
-        $progress
-    );
+
+    return [
+        'class' => $status['class'],
+        'icon' => $status['icon'],
+        'text' => $status['text'],
+        'progress' => $progress
+    ];
 }
 
 ?>
 <footer id="footer">
     <span id="statusraid">
-        <span id="statusbar"><?= getArrayStatus($var) ?></span>
+        <span id="statusbar">
+            <? $status = getArrayStatus($var); ?>
+            <span class="<?=$status['class']?> strong">
+                <i class="fa fa-<?=$status['icon']?>"></i> <?=$status['text']?>
+            </span>
+            <? if ($status['progress']): ?>
+                &bullet;<span class="blue strong tour"><?=$status['progress']?></span>
+            <? endif; ?>
+        </span>
     </span>
     <span id="user-notice" class="red-text"></span>
-    <?php if ($wlan0): ?>
+    <? if ($wlan0): ?>
         <span id="wlan0" class="grey-text" onclick="wlanSettings()">
             <i class="fa fa-wifi fa-fw"></i>
         </span>
-    <?php endif; ?>
+    <? endif; ?>
     <span id="copyright">
-        Unraid&reg; webGui &copy;2024, Lime Technology, Inc.
+        Unraid&reg; webGui &copy;<?=date('Y')?>, Lime Technology, Inc.
         <a href="https://docs.unraid.net/go/manual/" target="_blank" title="<?=_('Online manual')?>">
             <i class="fa fa-book"></i> <?=_('manual')?>
         </a>

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout.php
@@ -858,61 +858,8 @@ unset($pages,$page,$pgs,$pg,$icon,$nchan,$running,$start,$stop,$row,$script,$opt
 <div class="spinner fixed"></div>
 <form name="rebootNow" method="POST" action="/webGui/include/Boot.php"><input type="hidden" name="cmd" value="reboot"></form>
 <iframe id="progressFrame" name="progressFrame" frameborder="0"></iframe>
-<?
-// Build footer
-annotate('Footer');
 
-function getArrayStatus($var) {
-    $progress = (_var($var,'fsProgress')!='') ? $var['fsProgress'] : "";
-
-    $statusMap = [
-        'Stopped' => ['class' => 'red', 'icon' => 'stop-circle', 'text' => _('Array Stopped')],
-        'Starting' => ['class' => 'orange', 'icon' => 'pause-circle', 'text' => _('Array Starting')],
-        'Stopping' => ['class' => 'orange', 'icon' => 'pause-circle', 'text' => _('Array Stopping')],
-        'default' => ['class' => 'green', 'icon' => 'play-circle', 'text' => _('Array Started')]
-    ];
-
-    $state = _var($var,'fsState');
-    $status = $statusMap[$state] ?? $statusMap['default'];
-
-    return [
-        'class' => $status['class'],
-        'icon' => $status['icon'],
-        'text' => $status['text'],
-        'progress' => $progress
-    ];
-}
-
-?>
-<footer id="footer">
-    <span id="statusraid">
-        <span id="statusbar">
-            <? $status = getArrayStatus($var); ?>
-            <span class="<?=$status['class']?> strong">
-                <i class="fa fa-<?=$status['icon']?>"></i> <?=$status['text']?>
-            </span>
-            <? if ($status['progress']): ?>
-                &bullet;<span class="blue strong tour"><?=$status['progress']?></span>
-            <? endif; ?>
-        </span>
-    </span>
-    <span id="user-notice" class="red-text"></span>
-    <? if ($wlan0): ?>
-        <span id="wlan0" class="grey-text" onclick="wlanSettings()">
-            <i class="fa fa-wifi fa-fw"></i>
-        </span>
-    <? endif; ?>
-    <span id="copyright">
-        Unraid&reg; webGui &copy;<?=date('Y')?>, Lime Technology, Inc.
-        <a href="https://docs.unraid.net/go/manual/" target="_blank" title="<?=_('Online manual')?>">
-            <i class="fa fa-book"></i> <?=_('manual')?>
-        </a>
-        <unraid-theme-switcher 
-            current="<?=$theme?>"
-            themes='<?=htmlspecialchars(json_encode(['azure', 'gray', 'black', 'white']), ENT_QUOTES, 'UTF-8')?>'>
-        </unraid-theme-switcher>
-    </span>
-</footer>
+<? require_once "$docroot/webGui/include/DefaultPageLayout/Footer.php"; ?>
 
 <script>
 // Firefox specific workaround, not needed anymore in firefox version 100 and higher

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout.php
@@ -861,25 +861,52 @@ unset($pages,$page,$pgs,$pg,$icon,$nchan,$running,$start,$stop,$row,$script,$opt
 <?
 // Build footer
 annotate('Footer');
-echo '<div id="footer"><span id="statusraid"><span id="statusbar">';
-$progress = (_var($var,'fsProgress')!='') ? "&bullet;<span class='blue strong tour'>{$var['fsProgress']}</span>" : "";
-switch (_var($var,'fsState')) {
-case 'Stopped':
-  echo "<span class='red strong'><i class='fa fa-stop-circle'></i> ",_('Array Stopped'),"</span>$progress"; break;
-case 'Starting':
-  echo "<span class='orange strong'><i class='fa fa-pause-circle'></i> ",_('Array Starting'),"</span>$progress"; break;
-case 'Stopping':
-  echo "<span class='orange strong'><i class='fa fa-pause-circle'></i> ",_('Array Stopping'),"</span>$progress"; break;
-default:
-  echo "<span class='green strong'><i class='fa fa-play-circle'></i> ",_('Array Started'),"</span>$progress"; break;
+
+function getArrayStatus($var) {
+    $progress = (_var($var,'fsProgress')!='') ? "&bullet;<span class='blue strong tour'>{$var['fsProgress']}</span>" : "";
+    
+    $statusMap = [
+        'Stopped' => ['class' => 'red', 'icon' => 'stop-circle', 'text' => _('Array Stopped')],
+        'Starting' => ['class' => 'orange', 'icon' => 'pause-circle', 'text' => _('Array Starting')],
+        'Stopping' => ['class' => 'orange', 'icon' => 'pause-circle', 'text' => _('Array Stopping')],
+        'default' => ['class' => 'green', 'icon' => 'play-circle', 'text' => _('Array Started')]
+    ];
+    
+    $state = _var($var,'fsState');
+    $status = $statusMap[$state] ?? $statusMap['default'];
+    
+    return sprintf(
+        "<span class='%s strong'><i class='fa fa-%s'></i> %s</span>%s",
+        $status['class'],
+        $status['icon'],
+        $status['text'],
+        $progress
+    );
 }
-echo "</span></span><span id='countdown'></span><span id='user-notice' class='red-text'></span>";
-if ($wlan0) echo "<span id='wlan0' class='grey-text' onclick='wlanSettings()'><i class='fa fa-wifi fa-fw'></i></span>";
-echo "<span id='copyright'>Unraid&reg; webGui &copy;2024, Lime Technology, Inc.";
-echo " <a href='https://docs.unraid.net/go/manual/' target='_blank' title=\""._('Online manual')."\"><i class='fa fa-book'></i> "._('manual')."</a>";
-echo "<unraid-theme-switcher current='$theme' themes='".htmlspecialchars(json_encode(['azure', 'gray', 'black', 'white']), ENT_QUOTES, 'UTF-8')."'></unraid-theme-switcher>";
-echo "</span></div>";
+
 ?>
+<footer id="footer">
+    <span id="statusraid">
+        <span id="statusbar"><?= getArrayStatus($var) ?></span>
+    </span>
+    <span id="user-notice" class="red-text"></span>
+    <?php if ($wlan0): ?>
+        <span id="wlan0" class="grey-text" onclick="wlanSettings()">
+            <i class="fa fa-wifi fa-fw"></i>
+        </span>
+    <?php endif; ?>
+    <span id="copyright">
+        Unraid&reg; webGui &copy;2024, Lime Technology, Inc.
+        <a href="https://docs.unraid.net/go/manual/" target="_blank" title="<?=_('Online manual')?>">
+            <i class="fa fa-book"></i> <?=_('manual')?>
+        </a>
+        <unraid-theme-switcher 
+            current="<?=$theme?>"
+            themes='<?=htmlspecialchars(json_encode(['azure', 'gray', 'black', 'white']), ENT_QUOTES, 'UTF-8')?>'>
+        </unraid-theme-switcher>
+    </span>
+</footer>
+
 <script>
 // Firefox specific workaround, not needed anymore in firefox version 100 and higher
 //if (typeof InstallTrigger!=='undefined') $('#nav-block').addClass('mozilla');

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/Footer.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/Footer.php
@@ -2,13 +2,12 @@
 function releaseDateYear() {
     global $var;
 
+    $date = new DateTime();
     $timestamp = _var($var, 'regBuildTime', '');
-    if (!$timestamp) {
-        return '';
+    if ($timestamp) {
+        $date->setTimestamp($timestamp);
     }
 
-    $date = new DateTime();
-    $date->setTimestamp($timestamp);
     return $date->format('Y');
 }
 

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/Footer.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/Footer.php
@@ -1,4 +1,8 @@
 <?
+/**
+ * Returns the release year based on regBuildTime or the current year if not available
+ * @return string Year in YYYY format
+ */
 function releaseDateYear() {
     global $var;
 
@@ -10,7 +14,11 @@ function releaseDateYear() {
 
     return $date->format('Y');
 }
-
+/**
+ * Returns array status information based on filesystem state
+ * @param array $var Global state variable containing filesystem information
+ * @return array Status with class, icon, text and progress information
+ */
 function getArrayStatus($var) {
     $progress = (_var($var,'fsProgress')!='') ? $var['fsProgress'] : "";
 

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/Footer.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/Footer.php
@@ -1,0 +1,52 @@
+<?
+function getArrayStatus($var) {
+    $progress = (_var($var,'fsProgress')!='') ? $var['fsProgress'] : "";
+
+    $statusMap = [
+        'Stopped' => ['class' => 'red', 'icon' => 'stop-circle', 'text' => _('Array Stopped')],
+        'Starting' => ['class' => 'orange', 'icon' => 'pause-circle', 'text' => _('Array Starting')],
+        'Stopping' => ['class' => 'orange', 'icon' => 'pause-circle', 'text' => _('Array Stopping')],
+        'default' => ['class' => 'green', 'icon' => 'play-circle', 'text' => _('Array Started')]
+    ];
+
+    $state = _var($var,'fsState');
+    $status = $statusMap[$state] ?? $statusMap['default'];
+
+    return [
+        'class' => $status['class'],
+        'icon' => $status['icon'],
+        'text' => $status['text'],
+        'progress' => $progress
+    ];
+}
+?>
+
+<footer id="footer">
+    <span id="statusraid">
+        <span id="statusbar">
+            <? $status = getArrayStatus($var); ?>
+            <span class="<?=$status['class']?> strong">
+                <i class="fa fa-<?=$status['icon']?>"></i> <?=$status['text']?>
+            </span>
+            <? if ($status['progress']): ?>
+                &bullet;<span class="blue strong tour"><?=$status['progress']?></span>
+            <? endif; ?>
+        </span>
+    </span>
+    <span id="user-notice" class="red-text"></span>
+    <? if ($wlan0): ?>
+        <span id="wlan0" class="grey-text" onclick="wlanSettings()">
+            <i class="fa fa-wifi fa-fw"></i>
+        </span>
+    <? endif; ?>
+    <span id="copyright">
+        Unraid&reg; webGui &copy;<?=date('Y')?>, Lime Technology, Inc.
+        <a href="https://docs.unraid.net/go/manual/" target="_blank" title="<?=_('Online manual')?>">
+            <i class="fa fa-book"></i> <?=_('manual')?>
+        </a>
+        <unraid-theme-switcher 
+            current="<?=$theme?>"
+            themes='<?=htmlspecialchars(json_encode(['azure', 'gray', 'black', 'white']), ENT_QUOTES, 'UTF-8')?>'>
+        </unraid-theme-switcher>
+    </span>
+</footer>

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/Footer.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/Footer.php
@@ -1,4 +1,17 @@
 <?
+function releaseDateYear() {
+    global $var;
+
+    $timestamp = _var($var, 'regBuildTime', '');
+    if (!$timestamp) {
+        return '';
+    }
+
+    $date = new DateTime();
+    $date->setTimestamp($timestamp);
+    return $date->format('Y');
+}
+
 function getArrayStatus($var) {
     $progress = (_var($var,'fsProgress')!='') ? $var['fsProgress'] : "";
 
@@ -40,7 +53,7 @@ function getArrayStatus($var) {
         </span>
     <? endif; ?>
     <span id="copyright">
-        Unraid&reg; webGui &copy;<?=date('Y')?>, Lime Technology, Inc.
+        Unraid&reg; webGui &copy;<?=releaseDateYear()?>, Lime Technology, Inc.
         <a href="https://docs.unraid.net/go/manual/" target="_blank" title="<?=_('Online manual')?>">
             <i class="fa fa-book"></i> <?=_('manual')?>
         </a>


### PR DESCRIPTION
This is the start of abstracting bits out of `DefaultPageLayout` into more manageable pieces.

- Changed the footer from rendering with `echo` statements for HTML elements into only using PHP for dynamic data
- Parses `regBuildTime` from `$var` to make the copyright year dynamic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The application's footer now includes a dynamic display of system status, progress updates, user notifications, access to wireless settings (when applicable), an online manual link, and theme selection.

- **Refactor**
  - The footer functionality has been reorganized into a modular structure for improved maintainability and a more streamlined user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->