### PR TITLE
fix: VMTemplates modals

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/VMTemplates.page
+++ b/emhttp/plugins/dynamix.vm.manager/VMTemplates.page
@@ -18,7 +18,6 @@ Markdown="false"
 ?>
 <link type="text/css" rel="stylesheet" href="<?autov('/webGui/styles/jquery.switchbutton.css')?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/jquery.filetree.css")?>">
-<link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/jquery.ui.css")?>">
 
 <script src="<?autov('/webGui/javascript/jquery.switchbutton.js')?>"></script>
 <script src="<?autov('/plugins/dynamix.vm.manager/javascript/dynamix.vm.manager.js')?>"></script>


### PR DESCRIPTION
Removes duplicate CSS inclusion in template file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed the external jQuery UI styling from the interface, which may result in a different visual appearance for some UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->