### PR TITLE
Fix: Disk Shares tab (Shares) would appear if enable disk shares were…

### DIFF
--- a/emhttp/plugins/dynamix/DiskList.page
+++ b/emhttp/plugins/dynamix/DiskList.page
@@ -1,7 +1,7 @@
 Menu="Shares:2"
 Title="Disk Shares"
 Tag="user-circle-o"
-Cond="_var($var,'fsState')!='Stopped' && _var($var,'shareDisk')!='no'"
+Cond="_var($var,'fsState')!='Stopped' && _var($var,'shareDisk')=='yes'"
 ---
 <?PHP
 /* Copyright 2005-2023, Lime Technology


### PR DESCRIPTION
… set to 'auto'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted disk sharing display logic to ensure disk shares are shown only when explicitly enabled, providing a more accurate and expected user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->