### PR TITLE
Fix: Don't Display Disk Shares if there are non

### DIFF
--- a/emhttp/plugins/dynamix/DiskList.page
+++ b/emhttp/plugins/dynamix/DiskList.page
@@ -1,7 +1,7 @@
 Menu="Shares:2"
 Title="Disk Shares"
 Tag="user-circle-o"
-Cond="_var($var,'fsState')!='Stopped' && _var($var,'shareDisk')!='no'"
+Cond="_var($var,'fsState')!='Stopped' && ( (_var($var,'shareUser')=='e' && _var($var,'shareDisk')=='yes') || (_var($var,'shareUser')!='e' && _var($var,'shareDisk') != 'no') )"
 ---
 <?PHP
 /* Copyright 2005-2023, Lime Technology

--- a/emhttp/plugins/dynamix/Shares.page
+++ b/emhttp/plugins/dynamix/Shares.page
@@ -1,6 +1,7 @@
 Menu="Tasks:2"
 Type="xmenu"
 Code="e92a"
+Cond="_var($var,'shareUser')=='e' || _var($var,'shareDisk') != 'no'"
 ---
 <?PHP
 if ($var['fsState']=="Stopped") {


### PR DESCRIPTION
And if no shares available at all (user and disk shares disabled) don't display Shares tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved disk share display logic, now accounting for additional user settings to determine when disk shares are visible.
	- Refined menu visibility criteria to ensure the menu appears only when specific user or disk share settings are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->