### PR TITLE
Revert Changes to Disk Shares being displayed

### DIFF
--- a/emhttp/plugins/dynamix/DiskList.page
+++ b/emhttp/plugins/dynamix/DiskList.page
@@ -1,7 +1,7 @@
 Menu="Shares:2"
 Title="Disk Shares"
 Tag="user-circle-o"
-Cond="_var($var,'fsState')!='Stopped' && ( (_var($var,'shareUser')=='e' && _var($var,'shareDisk')=='yes') || (_var($var,'shareUser')!='e' && _var($var,'shareDisk') != 'no') )"
+Cond="_var($var,'fsState')!='Stopped' && _var($var,'shareDisk')!='no'"
 ---
 <?PHP
 /* Copyright 2005-2023, Lime Technology

--- a/emhttp/plugins/dynamix/Shares.page
+++ b/emhttp/plugins/dynamix/Shares.page
@@ -1,7 +1,6 @@
 Menu="Tasks:2"
 Type="xmenu"
 Code="e92a"
-Cond="_var($var,'shareUser')=='e' || _var($var,'shareDisk') != 'no'"
 ---
 <?PHP
 if ($var['fsState']=="Stopped") {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the conditions governing disk display so that disks are now shown consistently based solely on their sharing status.
  - Streamlined the visibility rules for sharing options in the menu by removing redundant user-specific checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->