### PR TITLE
File manager: add UD shares to top level user shares

### DIFF
--- a/emhttp/plugins/dynamix/SMBExtras.page
+++ b/emhttp/plugins/dynamix/SMBExtras.page
@@ -33,7 +33,7 @@ $(function(){
 <input type="hidden" name="#include" value="/webGui/include/update.file.php">
 <input type="hidden" name="#file" value="<?=$file;?>">
 _(Samba extra configuration)_:
-: <textarea spellcheck="false" cols="80" rows="<?=substr_count($text,"\n")+1?>" maxlength="2048" name="text" style="resize:none;font-family:bitstream;width:65.5%" <?if ($var['fsState']=="Started"):?>disabled<?endif;?>><?=htmlspecialchars($text)?></textarea>
+: <textarea spellcheck="false" cols="80" rows="<?=substr_count($text,"\n")+1?>" maxlength="2048" name="text" <?if ($var['fsState']=="Started"):?>disabled<?endif;?>><?=htmlspecialchars($text)?></textarea>
 
 &nbsp;
 : <input type="submit" value="_(Apply)_" disabled><input type="button" value="_(Done)_" onclick="done()"><?if ($var['fsState']=="Started"):?>*_(Array must be **Stopped** to change)_*<?endif;?>

--- a/emhttp/plugins/dynamix/include/FileTree.php
+++ b/emhttp/plugins/dynamix/include/FileTree.php
@@ -45,14 +45,15 @@ $docroot = '/usr/local/emhttp';
 require_once "$docroot/webGui/include/Secure.php";
 
 $rootdir  = path(realpath($_POST['dir']));
+$topdir   = '/mnt/';
+$userdir  = '/mnt/user/';
 $filters  = (array)$_POST['filter'];
 $match    = $_POST['match'];
 $checkbox = $_POST['multiSelect'] == 'true' ? "<input type='checkbox'>" : "";
 
 /* Excluded folders to not show in the dropdown in the '/mnt/' directory only. */
 $excludedFolders = ['RecycleBin', 'addons', 'rootshare'];
-
-$udShares = ['addons','disks','remotes'];
+$udShares = ['disks','remotes'];
 
 echo "<ul class='jqueryFileTree'>";
 if ($_POST['show_parent'] == 'true' && is_top($rootdir)) {
@@ -62,10 +63,6 @@ if ($_POST['show_parent'] == 'true' && is_top($rootdir)) {
 if (is_low($rootdir) && is_dir($rootdir)) {
   $dirs = $files = [];
   $names = array_filter(scandir($rootdir, SCANDIR_SORT_NONE), function($n){return $n != '.' && $n != '..';});
-  if (is_top($rootdir)) {
-    // add unassigned devices top level shares
-    foreach ($udShares as $name) if (is_dir($rootdir.$name) && !in_array($rootdir.$name, $names)) $names[] = $rootdir.$name;
-  }
   natcasesort($names);
   foreach ($names as $name) {
     if (is_dir($rootdir.$name)) {
@@ -82,10 +79,16 @@ if (is_low($rootdir) && is_dir($rootdir)) {
     if ($name === '.Recycle.Bin') continue;
 
     /* Exclude folders only when directory is '/mnt/' */
-    if (in_array($name, $excludedFolders) && $rootdir === '/mnt/') continue;
+    if (in_array($name, $excludedFolders) && $rootdir === $topdir) continue;
 
     if (empty($match) || preg_match("/$match/", $rootdir.$name.'/')) {
       echo "<li class='directory collapsed'>$checkbox<a href='#' rel=\"$htmlRel/\">$htmlName</a></li>";
+    }
+  }
+  if ($rootdir === $userdir) {
+    // add unassigned devices top level shares
+    foreach ($udShares as $name) if (is_dir($topdir.$name)) {
+      echo "<li class='directory collapsed'>$checkbox<a href='#' rel=\"{$topdir}{$name}/\">$name</a></li>";
     }
   }
   foreach ($files as $name) {

--- a/emhttp/plugins/dynamix/sheets/SMBExtras.css
+++ b/emhttp/plugins/dynamix/sheets/SMBExtras.css
@@ -1,0 +1,5 @@
+textarea {
+    resize: none;
+    font-family: bitstream;
+    width: 63%;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new CSS file for styling `textarea` elements, ensuring a consistent look and feel.
  
- **Refactor**
  - Adjusted the logic for displaying file shares in dropdown menus to show only relevant directories.
  - Streamlined how top-level and user-specific directories are handled, enhancing the browsing experience for available shares. 

- **Style**
  - Simplified the styling of the `<textarea>` element by removing inline CSS properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->