### PR TITLE
fix: rc.sshd determines which port to use

### DIFF
--- a/emhttp/plugins/dynamix/scripts/update_access
+++ b/emhttp/plugins/dynamix/scripts/update_access
@@ -15,15 +15,8 @@ SERV=/etc/services
 [[ -z $PORTSSH ]] && PORTSSH=22
 [[ -z $USE_UPNP ]] && USE_UPNP=no
 
-# update ssh daemon listening port
+# determine ssh daemon listening port
 CURRENT=$(grep -Pom1 '^#?Port \K\d+$' $CONF)
-if [[ $PORTSSH != $CURRENT ]]; then
-  if [[ $PORTSSH == 22 ]]; then
-    sed -ri 's/^#?Port [0-9]+$/#Port 22/' $CONF
-  else
-    sed -ri "s/^#?Port [0-9]+\$/Port $PORTSSH/" $CONF
-  fi
-fi
 
 # enable/disable SSH service
 if [[ $USE_SSH == yes ]]; then
@@ -31,7 +24,7 @@ if [[ $USE_SSH == yes ]]; then
     # start non-running ssh daemon
     /etc/rc.d/rc.sshd start
   else
-    # restart when port has changed
+    # restart when port has changed, rc.sshd will update value in $CONF
     [[ $PORTSSH != $CURRENT ]] && /etc/rc.d/rc.sshd restart
   fi
 elif [[ $(pgrep --ns $$ -cf $SSHD) -gt 0 ]]; then

--- a/etc/rc.d/rc.sshd
+++ b/etc/rc.d/rc.sshd
@@ -26,6 +26,7 @@ SSH_ETC="/etc/ssh"
 [[ -e /boot/config/ident.cfg ]] && . <(fromdos </boot/config/ident.cfg)
 
 # preset default values
+[[ -z $USE_SSH ]] && USE_SSH=no
 [[ -z $PORTSSH ]] && PORTSSH=22
 
 sshd_running(){
@@ -61,6 +62,8 @@ sshd_start(){
   local REPLY
   if sshd_running; then
     REPLY="Already started"
+  elif [[ $USE_SSH != yes ]]; then
+    REPLY="Disabled"
   else
     # make sure ssh dir exists on flash
     mkdir -p $SSH_BOOT

--- a/etc/rc.d/rc.sshd
+++ b/etc/rc.d/rc.sshd
@@ -11,6 +11,7 @@ DAEMON="SSH server daemon"
 CALLER="ssh"
 SSHD="/usr/sbin/sshd"
 CONF="/etc/ssh/sshd_config"
+INET=/etc/inetd.conf
 PID="/var/run/sshd.pid"
 SSH_BOOT="/boot/config/ssh"
 SSH_ETC="/etc/ssh"
@@ -21,6 +22,12 @@ SSH_ETC="/etc/ssh"
 # library functions
 . /etc/rc.d/rc.library.source
 
+# read settings
+[[ -e /boot/config/ident.cfg ]] && . <(fromdos </boot/config/ident.cfg)
+
+# preset default values
+[[ -z $PORTSSH ]] && PORTSSH=22
+
 sshd_running(){
   sleep 0.1
   # get all pids from sshd
@@ -28,6 +35,7 @@ sshd_running(){
 }
 
 sshd_build(){
+  # update interfaces
   if check && [[ -n $BIND ]]; then
     # remove existing entries
     sed -ri '/^#?(ListenAddress|AddressFamily) /d' $CONF
@@ -36,6 +44,15 @@ sshd_build(){
       sed -ri "/^#?Port /a ListenAddress ${BIND[$i]} # $(show ${BIND[$i]})" $CONF
     done
     sed -ri "/^#?Port /a AddressFamily $FAMILY" $CONF
+  fi
+  # update ssh daemon listening port
+  CURRENT=$(grep -Pom1 '^#?Port \K\d+$' $CONF)
+  if [[ $PORTSSH != $CURRENT ]]; then
+    if [[ $PORTSSH == 22 ]]; then
+      sed -ri 's/^#?Port [0-9]+$/#Port 22/' $CONF
+    else
+      sed -ri "s/^#?Port [0-9]+\$/Port $PORTSSH/" $CONF
+    fi
   fi
 }
 
@@ -48,7 +65,7 @@ sshd_start(){
     # make sure ssh dir exists on flash
     mkdir -p $SSH_BOOT
     # restore saved keys, config file, etc. (but not subdirs)
-    cp -n $SSH_BOOT/* $SSH_ETC 2>/dev/null
+    cp -f $SSH_BOOT/* $SSH_ETC 2>/dev/null
     chmod 600 $SSH_ETC/* 2>/dev/null
     # create host keys if needed and copy any newly generated key(s) back to flash
     ssh-keygen -A


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of SSH port updates by ensuring configuration changes are handled during SSH service restarts.
	- Enhanced SSH configuration management by overwriting existing config files with updated versions as needed.

- **Chores**
	- Streamlined internal handling of SSH settings to reduce direct configuration file edits and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->