### PR TITLE
Update mover - fix files[FILES]

### DIFF
--- a/sbin/mover
+++ b/sbin/mover
@@ -104,10 +104,10 @@ empty() {
   done
 
   # output list of files which could not be moved
-  shopt -s dotglob ; FILES=/mnt/$DISK/* ; shopt -u dotglob
-  if [ ${#files[@]} -gt 2 ]; then
+  shopt -s dotglob ; FILES=(/mnt/"$DISK"/*) ; shopt -u dotglob
+  if [ ${#FILES[@]} -gt 2 ]; then
     echo "mover: not moved:"
-    ls -1 --almost-all --recursive /mnt/$DISK
+    ls -1 --almost-all --recursive /mnt/"$DISK"
   fi
 
   rm -f $PIDFILE


### PR DESCRIPTION
possibly wrong variable `files` instead of `FILES`?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file handling and variable referencing for more reliable file operations.
	- Enhanced consistency and correctness when listing files, especially with disk names containing spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->