### PR TITLE
fix: remove unraid-api.txt from diags

### DIFF
--- a/emhttp/plugins/dynamix/scripts/diagnostics
+++ b/emhttp/plugins/dynamix/scripts/diagnostics
@@ -722,12 +722,6 @@ if (file_exists($wgquick)) {
   run("todos <$wgquick >".escapeshellarg($log));
 }
 
-// generate unraid-api.txt
-if (file_exists("/usr/local/sbin/unraid-api")) {
-  $log = "/$diag/system/unraid-api.txt";
-  run("unraid-api report | todos >".escapeshellarg($log));
-}
-
 // generate testparm.txt
 $testparm = run("testparm -s 2>/dev/null");
 if (!$all)


### PR DESCRIPTION
no longer needed, graphql-api.log is better for troubleshooting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the generation of the unraid-api.txt report from the diagnostics collection process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->