### PR TITLE
fix: Replace unassigned_log with outgoingproxy_log

### DIFF
--- a/emhttp/plugins/dynamix/include/OutgoingProxyLib.php
+++ b/emhttp/plugins/dynamix/include/OutgoingProxyLib.php
@@ -187,7 +187,7 @@ function decrypt_data($data) {
 
     /* Ensure the decrypted data is UTF-8 encoded. */
     if (!mb_check_encoding($decrypted, 'UTF-8')) {
-        unassigned_log("Warning: Data is not UTF-8 encoded");
+        outgoingproxy_log("Warning: Data is not UTF-8 encoded");
         $decrypted = "";
     }
 


### PR DESCRIPTION
unassigned_log is not a valid function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the logging function used when decrypted data is not UTF-8 encoded, ensuring accurate logging in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->