### PR TITLE
Wireless: escape double quotes (") in ssid

### DIFF
--- a/emhttp/plugins/dynamix/include/Wireless.php
+++ b/emhttp/plugins/dynamix/include/Wireless.php
@@ -135,7 +135,7 @@ case 'list':
 case 'join':
   if (is_readable($ssl)) extract(parse_ini_file($ssl));
   $token   = parse_ini_file($var)['csrf_token'];
-  $ssid    = rawurldecode($_POST['ssid']);
+  $ssid    = str_replace('"', '\"', rawurldecode($_POST['ssid']));
   $drop    = $_POST['task'] == 1;
   $manual  = $_POST['task'] == 3;
   $user    = _var($wifi[$ssid],'USERNAME') && isset($cipher, $key, $iv) ? openssl_decrypt($wifi[$ssid]['USERNAME'], $cipher, $key, 0, $iv) : _var($wifi[$ssid],'USERNAME');
@@ -229,7 +229,7 @@ case 'join':
   echo "</form>";
   break;
 case 'forget':
-  $ssid = rawurldecode($_POST['ssid']);
+  $ssid = str_replace('"', '\"', rawurldecode($_POST['ssid']));
   if ($wifi[$ssid]['GROUP'] == 'active') exec("/etc/rc.d/rc.wireless stop &>/dev/null &");
   unset($wifi[$ssid]);
   saveWifi();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of SSIDs containing double-quote characters when joining or forgetting wireless networks, ensuring accurate processing and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->