### PR TITLE
mover addon

### DIFF
--- a/sbin/mover
+++ b/sbin/mover
@@ -88,6 +88,11 @@ start() {
 empty() {
   DISK="$1"
 
+  if [ ! -d "/mnt/$DISK" ]; then
+    echo "Error: disk '$DISK' not found"
+    exit 1
+  fi
+
   if [ -f $PIDFILE ]; then
     if ps h $(cat $PIDFILE) | grep mover ; then
         echo "mover: already running"


### PR DESCRIPTION
small check for mover in empty()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to check for the existence of the specified disk before proceeding, displaying an error message if the disk is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->