### PR TITLE
Docker and VM: remove "path does not exist" warning

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
@@ -192,9 +192,10 @@ _(Docker vDisk size)_:
 _(Docker vDisk location)_:
 : <input type="text" id="DOCKER_IMAGE_FILE1" name="DOCKER_IMAGE_FILE1" autocomplete="off" spellcheck="false" value="<?=htmlspecialchars(_var($dockercfg,'DOCKER_IMAGE_FILE'))?>" placeholder="_(e.g.)_ /mnt/user/system/docker.img" data-pickcloseonfile="true" data-pickfilter="img" data-pickroot="/mnt" data-pickfolders="true" disabled required pattern="^[^\\]*(docker-xfs\.img|docker\.img)$">
   <span class="deleteLabel"><label><input type="checkbox" class="deleteCheckbox"> _(Delete vDisk file)_</label></span>
-  <?if ($var['fsState'] != "Started"):?><span><i class="fa fa-warning icon warning"></i> _(Modify with caution: unable to validate path until Array is Started)_</span>
-  <?elseif (!is_dir(dirname(htmlspecialchars(_var($dockercfg,'DOCKER_IMAGE_FILE'))))):?><span class="nonexist"><i class="fa fa-warning icon warning"></i> _(Path does not exist)_</span>
-  <?endif;?><span id="IMAGE_ERROR1" class="errortext"></span>
+<?if ($var['fsState'] != "Started"):?>
+  <span><i class="fa fa-warning icon warning"></i> _(Modify with caution: unable to validate path until Array is Started)_</span>
+<?endif;?>
+  <span id="IMAGE_ERROR1" class="errortext"></span>
 
 :docker_vdisk_location_help:
 
@@ -203,9 +204,10 @@ _(Docker vDisk location)_:
 _(Docker directory)_:
 : <input type="text" id="DOCKER_IMAGE_FILE2" name="DOCKER_IMAGE_FILE2" autocomplete="off" spellcheck="false" value="<?=htmlspecialchars(_var($dockercfg,'DOCKER_IMAGE_FILE'))?>" placeholder="_(e.g.)_ /mnt/user/system/docker" data-pickcloseonfile="true" data-pickfilter="HIDE_FILES_FILTER" data-pickroot="/mnt" data-pickfolders="true" disabled required pattern="^[^\\]*/$">
   <span class="deleteLabel"><label><input type="checkbox" class="deleteCheckbox"> _(Delete directory)_</label></span>
-  <?if ($var['fsState'] != "Started"):?><span><i class="fa fa-warning icon warning"></i> _(Modify with caution: unable to validate path until Array is Started)_</span>
-  <?elseif (!is_dir(dirname(_var($dockercfg,'DOCKER_IMAGE_FILE')))):?><span class="nonexist"><i class="fa fa-warning icon warning"></i> _(Path does not exist)_</span>
-  <?endif;?><span id="IMAGE_ERROR2" class="errortext"></span>
+<?if ($var['fsState'] != "Started"):?>
+  <span><i class="fa fa-warning icon warning"></i> _(Modify with caution: unable to validate path until Array is Started)_</span>
+<?endif;?>
+  <span id="IMAGE_ERROR2" class="errortext"></span>
 
 :docker_vdisk_directory_help:
 
@@ -217,11 +219,9 @@ _(Docker storage driver)_:
   <?=mk_option(_var($dockercfg,'DOCKER_BACKINGFS'), 'overlay2', _('overlay2'))?>
   <?=mk_option(_var($dockercfg,'DOCKER_BACKINGFS'), 'native', _('native'))?>
   </select>
-  <?if ($var['fsState'] != "Started"):?>
+<?if ($var['fsState'] != "Started"):?>
   <span id="WARNING_BACKINGFS" style="display:none;"><i class="fa fa-warning icon warning"></i>_(Only modify if this is a new installation since this can lead to unwanted behaviour!)_</span>
-  <?elseif (is_dir(_var($dockercfg,'DOCKER_IMAGE_FILE'))):?>
-  <span id="WARNING_BACKINGFS" style="display:none;"><i class="fa fa-warning icon warning"></i>_(Switching the Storage Driver requires to delete and rebuild the Docker directory manually!)_</span>
-  <?endif;?>
+<?endif;?>
 
 :docker_storage_driver_help:
 
@@ -229,11 +229,9 @@ _(Docker storage driver)_:
 
 _(Default appdata storage location)_:
 : <input type="text" id="DOCKER_APP_CONFIG_PATH" name="DOCKER_APP_CONFIG_PATH" autocomplete="off" spellcheck="false" value="<?=htmlspecialchars(_var($dockercfg,'DOCKER_APP_CONFIG_PATH'))?>" placeholder="_(e.g.)_ /mnt/user/appdata/" data-pickfilter="HIDE_FILES_FILTER" data-pickroot="/mnt" data-pickfolders="true" pattern="^[^\\]*/$">
-  <?if ($var['fsState'] != "Started"):?>
+<?if ($var['fsState'] != "Started"):?>
   <span><i class="fa fa-warning icon warning"></i> _(Modify with caution: unable to validate path until Array is Started)_</span>
-  <?elseif (!is_dir(_var($dockercfg,'DOCKER_APP_CONFIG_PATH'))):?>
-  <span class="nonexist"><i class="fa fa-warning icon warning"></i> _(Path does not exist)_</span>
-  <?endif;?>
+<?endif;?>
 
 :docker_appdata_location_help:
 

--- a/emhttp/plugins/dynamix.vm.manager/VMSettings.page
+++ b/emhttp/plugins/dynamix.vm.manager/VMSettings.page
@@ -4,8 +4,8 @@ Icon="icon-virtualization"
 Tag="columns"
 ---
 <?PHP
-/* Copyright 2005-2023, Lime Technology
- * Copyright 2012-2023, Bergware International.
+/* Copyright 2005-2025, Lime Technology
+ * Copyright 2012-2025, Bergware International.
  * Copyright 2015-2021, Derek Macias, Eric Schultz, Jon Panozzo.
  *
  * This program is free software; you can redistribute it and/or
@@ -154,25 +154,29 @@ _(Libvirt vdisk size)_:
 
 _(Libvirt storage location)_:
 : <input type="text" id="IMAGE_FILE" name="IMAGE_FILE" autocomplete="off" spellcheck="false" value="<?=htmlspecialchars($domain_cfg['IMAGE_FILE']);?>" placeholder="e.g. /mnt/user/system/libvirt/libvirt.img" data-pickcloseonfile="true" data-pickfilter="img" data-pickroot="/mnt" data-pickfolders="true" required pattern="^[^\\]*libvirt\.img$">
- <?if (file_exists($domain_cfg['IMAGE_FILE'])):?><span id="deletePanel"><label><input type="checkbox" id="deleteCheckbox" /> _(Delete Image File)_</label></span><?endif;?>
- <?if (!$started):?><span><i class="fa fa-warning icon warning"></i> _(Modify with caution: unable to validate path until Array is Started)_</span>
- <?elseif (!is_dir(dirname($domain_cfg['IMAGE_FILE']))):?><span><i class="fa fa-warning icon warning"></i> _(Path does not exist)_</span>
- <?endif;?><span id="IMAGE_ERROR" class="errortext"></span>
+<?if (file_exists($domain_cfg['IMAGE_FILE'])):?>
+  <span id="deletePanel"><label><input type="checkbox" id="deleteCheckbox" /> _(Delete Image File)_</label></span><?endif;?>
+<?if (!$started):?>
+  <span><i class="fa fa-warning icon warning"></i> _(Modify with caution: unable to validate path until Array is Started)_</span>
+<?endif;?>
+  <span id="IMAGE_ERROR" class="errortext"></span>
 
 :vms_libvirt_location_help:
 
 <?endif;?>
 _(Default VM storage path)_:
 : <input type="text" id="domaindir" name="DOMAINDIR" autocomplete="off" spellcheck="false" data-pickfolders="true" data-pickfilter="HIDE_FILES_FILTER" data-pickroot="/mnt" value="<?=htmlspecialchars($domain_cfg['DOMAINDIR'])?>" placeholder="_(Click to Select)_" pattern="^[^\\]*/$">
-  <?if (!$started):?><span><i class="fa fa-warning icon warning"></i> _(Modify with caution: unable to validate path until Array is Started)_</span>
-  <?elseif (!is_dir($domain_cfg['DOMAINDIR'])):?><span><i class="fa fa-warning icon warning"></i> _(Path does not exist)_</span><?endif;?>
+<?if (!$started):?>
+  <span><i class="fa fa-warning icon warning"></i> _(Modify with caution: unable to validate path until Array is Started)_</span>
+<?endif;?>
 
 :vms_libvirt_storage_help:
 
 _(Default ISO storage path)_:
 : <input type="text" id="mediadir" name="MEDIADIR" autocomplete="off" spellcheck="false" data-pickfolders="true" data-pickfilter="HIDE_FILES_FILTER" data-pickroot="<?=is_dir('/mnt/user')?'/mnt/user':'/mnt'?>" value="<?=htmlspecialchars($domain_cfg['MEDIADIR'])?>" placeholder="_(Click to Select)_" pattern="^[^\\]*/$">
-  <?if (!$started):?><span><i class="fa fa-warning icon warning"></i> _(Modify with caution: unable to validate path until Array is Started)_</span>
-  <?elseif (!is_dir($domain_cfg['MEDIADIR'])):?><span><i class="fa fa-warning icon warning"></i> _(Path does not exist)_</span><?endif;?>
+<?if (!$started):?>
+  <span><i class="fa fa-warning icon warning"></i> _(Modify with caution: unable to validate path until Array is Started)_</span>
+<?endif;?>
 
 :vms_libvirt_iso_storage_help:
 

--- a/emhttp/plugins/dynamix/include/Wireless.php
+++ b/emhttp/plugins/dynamix/include/Wireless.php
@@ -135,7 +135,7 @@ case 'list':
 case 'join':
   if (is_readable($ssl)) extract(parse_ini_file($ssl));
   $token   = parse_ini_file($var)['csrf_token'];
-  $ssid    = rawurldecode($_POST['ssid']);
+  $ssid    = str_replace('"', '\"', rawurldecode($_POST['ssid']));
   $drop    = $_POST['task'] == 1;
   $manual  = $_POST['task'] == 3;
   $user    = _var($wifi[$ssid],'USERNAME') && isset($cipher, $key, $iv) ? openssl_decrypt($wifi[$ssid]['USERNAME'], $cipher, $key, 0, $iv) : _var($wifi[$ssid],'USERNAME');
@@ -229,7 +229,7 @@ case 'join':
   echo "</form>";
   break;
 case 'forget':
-  $ssid = rawurldecode($_POST['ssid']);
+  $ssid = str_replace('"', '\"', rawurldecode($_POST['ssid']));
   if ($wifi[$ssid]['GROUP'] == 'active') exec("/etc/rc.d/rc.wireless stop &>/dev/null &");
   unset($wifi[$ssid]);
   saveWifi();

--- a/emhttp/plugins/dynamix/include/update.wireguard.php
+++ b/emhttp/plugins/dynamix/include/update.wireguard.php
@@ -1,6 +1,6 @@
 <?PHP
-/* Copyright 2005-2023, Lime Technology
- * Copyright 2012-2023, Bergware International.
+/* Copyright 2005-2025, Lime Technology
+ * Copyright 2012-2025, Bergware International.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2,
@@ -32,57 +32,65 @@ $dockernet = "172.31";
 $t1 = '10'; // 10 sec timeout
 $t2 = '15'; // 15 sec timeout
 
-function mask2cidr($mask) {
-  $long = ip2long($mask);
-  $base = ip2long('255.255.255.255');
-  return 32-log(($long ^ $base)+1,2);
+function thisNet() {
+  $sys = '/sys/class/net';
+  $dev = file_exists("$sys/br0") ? 'br0' : (file_exists("$sys/bond0") ? 'bond0' : 'eth0');
+  $ip4 = exec("ip -4 -br addr show dev $dev | awk '{print \$3;exit}'");
+  $net = exec("ip -4 route show $ip4 dev $dev | awk '{print \$1;exit}'");
+  $gw  = exec("ip -4 route show default dev $dev | awk '{print \$3;exit}'");
+  return [$dev, $net, $gw];
 }
-function thisNet($ethX='eth0') {
-  extract(parse_ini_file('state/network.ini',true));
-  $net = long2ip(ip2long(_var($$ethX,'IPADDR:0')) & ip2long(_var($$ethX,'NETMASK:0'))).'/'.mask2cidr(_var($$ethX,'NETMASK:0'));
-  $dev = _var($$ethX,'BRIDGING')=='yes' ? _var($$ethX,'BRNAME') : (_var($$ethX,'BONDING')=='yes' ? _var($$ethX,'BONDNAME') : $ethX);
-  return [$dev,$net,$$ethX['GATEWAY:0']];
-}
+
 function ipv4($ip) {
-  return strpos($ip,'.')!==false;
+  return strpos($ip, '.') !== false;
 }
+
 function ipv6($ip) {
-  return strpos($ip,':')!==false;
+  return strpos($ip, ':') !== false;
 }
+
 function ipset($ip) {
   return ipv4($ip) ? $ip : "[$ip]";
 }
+
 function ipsplit($ip) {
   return ipv4($ip) ? ':' : ']:';
 }
+
 function ipv4Addr($value) {
-  return array_filter(array_map('trim',explode(',',$value)),'ipv4');
+  return array_filter(array_map('trim', explode(',', $value)), 'ipv4');
 }
+
 function ipv6Addr($value) {
-  return array_filter(array_map('trim',explode(',',$value)),'ipv6');
+  return array_filter(array_map('trim', explode(',', $value)), 'ipv6');
 }
+
 function ipfilter(&$list) {
   // we only import IPv4 addresses, strip any IPv6 addresses
-  $list = implode(', ',ipv4Addr($list));
+  $list = implode(', ', ipv4Addr($list));
 }
+
 function host($ip) {
-  return strpos($ip,'/')!==false ? $ip : (ipv4($ip) ? "$ip/32" : "$ip/128");
+  return strpos($ip, '/') !== false ? $ip : (ipv4($ip) ? "$ip/32" : "$ip/128");
 }
+
 function isNet($network) {
-  return !empty(exec("ip rule|grep -Pom1 'from $network'"));
+  return !empty(exec("ip rule | grep -Pom1 'from $network'"));
 }
+
 function newNet($vtun) {
   global $dockernet;
-  $i = substr($vtun,2)+200;
-  return [$i,"$dockernet.$i.0/24"];
+  $i = substr($vtun ,2) + 200;
+  return [$i, "$dockernet.$i.0/24"];
 }
-function wgState($vtun,$state,$type=0) {
-  global $t1,$etc;
+
+function wgState($vtun, $state, $type=0) {
+  global $t1, $etc;
   $tmp = '/tmp/wg-quick.tmp';
   $log = '/var/log/wg-quick.log';
   exec("timeout $t1 wg-quick $state $vtun 2>$tmp");
   file_put_contents($log, "wg-quick $state $vtun\n".file_get_contents($tmp)."\n", FILE_APPEND);
-  if ($type==8) {
+  if ($type == 8) {
     // make VPN tunneled access for Docker containers only
     $table = exec("grep -Pom1 'fwmark \K[\d]+' $tmp");
     $route = implode(ipv4Addr(exec("grep -Pom1 '^Address=\K.+$' $etc/$vtun.conf")));
@@ -92,23 +100,28 @@ function wgState($vtun,$state,$type=0) {
   }
   delete_file($tmp);
 }
+
 function status($vtun) {
-  return in_array($vtun,explode(" ",exec("wg show interfaces")));
+  return in_array($vtun, explode(" ", exec("wg show interfaces")));
 }
+
 function vtun() {
   global $etc;
   $x = 0; while (file_exists("$etc/wg{$x}.conf")) $x++;
   return "wg{$x}";
 }
+
 function normalize(&$id) {
   // ensure correct capitalization of keywords, some VPN providers use the wrong case
   global $normalize;
   // allow fallback for non-included keywords
   $id = $normalize[strtolower($id)] ?? $id;
 }
+
 function dockerNet($vtun) {
   return empty(exec("docker network ls --filter name='$vtun' --format='{{.Name}}'"));
 }
+
 function addDocker($vtun) {
   global $dockerd;
   $error = false;
@@ -125,6 +138,7 @@ function addDocker($vtun) {
   }
   return $error;
 }
+
 function delDocker($vtun) {
   global $dockerd;
   $error = false;
@@ -139,13 +153,15 @@ function delDocker($vtun) {
   }
   return $error;
 }
-function delPeer($vtun,$id='') {
-  global $etc,$name;
+
+function delPeer($vtun, $id='') {
+  global $etc, $name;
   $dir = "$etc/peers";
-  foreach (glob("$dir/peer-$name-$vtun-$id*",GLOB_NOSORT) as $peer) delete_file($peer);
+  foreach (glob("$dir/peer-$name-$vtun-$id*", GLOB_NOSORT) as $peer) delete_file($peer);
 }
+
 function addPeer(&$x) {
-  global $peers,$var;
+  global $peers, $var;
   $peers[$x] = ['[Interface]'];                                         // [Interface]
   if (isset($var['client'])) $peers[$x][] = $var['client'];             // #name
   if (isset($var['privateKey'])) $peers[$x][] = $var['privateKey'];     // PrivateKey
@@ -164,38 +180,40 @@ function addPeer(&$x) {
   $peers[$x][] = _var($var,'allowedIPs');                               // AllowedIPs
   $x++;
 }
-function autostart($vtun,$cmd) {
+
+function autostart($vtun, $cmd) {
   global $etc;
   $autostart = "$etc/autostart";
-  $list = file_exists($autostart) ? array_filter(explode(' ',file_get_contents($autostart))) : [];
-  $key = array_search($vtun,$list);
+  $list = file_exists($autostart) ? array_filter(explode(' ', file_get_contents($autostart))) : [];
+  $key = array_search($vtun, $list);
   switch ($cmd) {
-    case 'off': if ($key!==false) unset($list[$key]); break;
-    case 'on' : if ($key===false) $list[] = $vtun; break;
+    case 'off': if ($key !== false) unset($list[$key]); break;
+    case 'on' : if ($key === false) $list[] = $vtun; break;
   }
-  if (count($list)) file_put_contents($autostart,implode(' ',$list)); else delete_file($autostart);
+  if (count($list)) file_put_contents($autostart, implode(' ', $list)); else delete_file($autostart);
 }
+
 function createPeerFiles($vtun) {
-  global $etc,$peers,$name,$gone,$vpn;
+  global $etc, $peers, $name, $gone, $vpn;
   $dir = "$etc/peers";
   $tmp = "/tmp/list.tmp";
   if (is_dir($dir)) {
     if (count($gone)) {
       foreach ($gone as $peer) {
         // one or more peers are removed, delete the associated files
-        [$n,$i] = my_explode('-',$peer);
-        delPeer($n,$i);
+        [$n, $i] = my_explode('-', $peer);
+        delPeer($n, $i);
       }
       $new = 1;
       $peer = "$dir/peer-$name-$vtun";
-      $files = glob("$peer-*.conf",GLOB_NOSORT);
+      $files = glob("$peer-*.conf", GLOB_NOSORT);
       natsort($files);
       foreach ($files as $file) {
-        $id = explode('-',basename($file,'.conf'))[3];
+        $id = explode('-', basename($file,'.conf'))[3];
         if ($id > $new) {
           // rename files to match revised peers list
-          rename($file,"$peer-$new.conf");
-          rename(str_replace('.conf','.png',$file),"$peer-$new.png");
+          rename($file, "$peer-$new.conf");
+          rename(str_replace('.conf','.png', $file), "$peer-$new.png");
         }
         $new++;
       }
@@ -208,37 +226,40 @@ function createPeerFiles($vtun) {
     if (empty($peer[1])) break; // tunnel without any peers
     $cfg    = "$dir/peer-$name-$vtun-$id.conf";
     $cfgold = @file_get_contents($cfg) ?: '';
-    $cfgnew = implode("\n",$peer)."\n";
-    if ($cfgnew !== $cfgold && $vpn==0) {
-      $list[] = "$vtun: peer $id (".($peer[1][0]=='#' ? substr($peer[1],1) : _('no name')).')';
-      file_put_contents($cfg,$cfgnew);
-      $png = str_replace('.conf','.png',$cfg);
+    $cfgnew = implode("\n", $peer)."\n";
+    if ($cfgnew !== $cfgold && $vpn == 0) {
+      $list[] = "$vtun: peer $id (".($peer[1][0] == '#' ? substr($peer[1],1) : _('no name')).')';
+      file_put_contents($cfg, $cfgnew);
+      $png = str_replace('.conf', '.png', $cfg);
       exec("qrencode -t PNG -r $cfg -o $png");
     }
   }
   // store the peer names which are updated
-  if (count($list)) file_put_contents($tmp,implode("<br>",$list)); else delete_file($tmp);
+  if (count($list)) file_put_contents($tmp, implode("<br>", $list)); else delete_file($tmp);
 }
+
 function createList($list) {
-  return implode(', ',array_unique(array_filter(array_map('trim',explode(',',$list)))));
+  return implode(', ', array_unique(array_filter(array_map('trim', explode(',', $list)))));
 }
+
 function createIPs($list) {
-  return implode(', ',array_map('host',array_filter(array_map('trim',explode(',',$list)))));
+  return implode(', ', array_map('host', array_filter(array_map('trim', explode(',', $list)))));
 }
-function parseInput($vtun,&$input,&$x) {
+
+function parseInput($vtun, &$input, &$x) {
   // assign values to parameters, be aware that certain parameters are assigned by parseInput itself
   // this is based on the sequence of processing
-  global $conf,$user,$var,$default4,$default6,$vpn,$tunip;
+  global $conf, $user, $var, $default4, $default6, $vpn, $tunip;
   $tunnel = $protocol = null; // satisfy code checkers
   $section = 0; $addPeer = false;
   foreach ($input as $key => $value) {
-    if ($key[0]=='#') continue;
-    [$id,$i] = array_pad(explode(':',$key),2,0);
+    if ($key[0] == '#') continue;
+    [$id, $i] = array_pad(explode(':', $key), 2, 0);
     if ($i != $section) {
-      if ($section==0) {
+      if ($section == 0) {
         // add WG routing for docker containers. Only IPv4 supported
-        [$index,$network] = newNet($vtun);
-        [$device,$thisnet,$gateway] = thisNet();
+        [$index, $network] = newNet($vtun);
+        [$device, $thisnet, $gateway] = thisNet();
         $conf[]  = "PostUp=ip -4 route flush table $index";
         $conf[]  = "PostUp=ip -4 route add default via $tunip dev $vtun table $index";
         $conf[]  = "PostUp=ip -4 route add $thisnet via $gateway dev $device table $index";
@@ -254,14 +275,14 @@ function parseInput($vtun,&$input,&$x) {
     switch ($id) {
     case 'Name':
       if ($value) $conf[] = "#$value";
-      if ($i==0) {
+      if ($i == 0) {
         $var['server'] = $value ? "#$value" : false;
       } else {
         $var['client'] = $value ? "#$value" : false;
       }
       break;
     case 'PrivateKey':
-      if ($i==0) {
+      if ($i == 0) {
         $conf[] = "$id=$value";
       } else {
         if ($value) $user[] = "$id:$x=\"$value\"";
@@ -269,7 +290,7 @@ function parseInput($vtun,&$input,&$x) {
       }
       break;
     case 'PublicKey':
-      if ($i==0) {
+      if ($i == 0) {
         $user[] = "$id:0=\"$value\"";
         $var['publicKey'] = "$id=$value";
       } else {
@@ -292,11 +313,11 @@ function parseInput($vtun,&$input,&$x) {
       }
       break;
     case 'TYPE':
-      $list = $value<4 ? ($value%2==1 ? _var($var,'subnets1') : _var($var,'subnets2')) : ($value<6 ? ($value%2==1 ? _var($var,'shared1') : _var($var,'shared2')) : _var($var,'default'));
+      $list = $value < 4 ? ($value%2 == 1 ? _var($var,'subnets1') : _var($var,'subnets2')) : ($value < 6 ? ($value%2 == 1 ? _var($var,'shared1') : _var($var,'shared2')) : _var($var,'default'));
       $var['allowedIPs'] = createIPs($list);
-      $var['tunnel'] = ($value==2||$value==3) ? $tunnel : false;
+      $var['tunnel'] = ($value == 2 || $value == 3) ? $tunnel : false;
       $user[] = "$id:$x=\"$value\"";
-      if ($value>=7) $vpn = $value;
+      if ($value >= 7) $vpn = $value;
       break;
     case 'Network6': if (!$protocol) break;
     case 'Network':
@@ -308,7 +329,7 @@ function parseInput($vtun,&$input,&$x) {
       break;
     case 'Address':
       $hosts = createIPs($value);
-      if ($i==0) {
+      if ($i == 0) {
         $conf[] = "$id=$value";
         $tunnel = "$id=$hosts";
         $tunip  = implode(ipv4Addr($value));
@@ -322,13 +343,13 @@ function parseInput($vtun,&$input,&$x) {
       $var['mtu'] = $value ? "$id=$value" : false;
       break;
     case 'Endpoint':
-      if ($i==0) {
+      if ($i == 0) {
         $user[] = "$id:0=\"$value\"";
         $var['endpoint'] = $value ? "Endpoint=".ipset($value) : false;
       } else {
         if ($value) $conf[] = "$id=$value";
         $var['listenport'] = $value ? "ListenPort=".(explode(ipsplit($value),$value)[1]??'') : false;
-        if ($var['endpoint'] && strpos(_var($var,'endpoint'),ipsplit(_var($var,'endpoint')))===false) $var['endpoint'] .= ":".(explode(ipsplit(_var($var,'internet')),_var($var,'internet'))[1]??'');
+        if ($var['endpoint'] && strpos(_var($var,'endpoint'),ipsplit(_var($var,'endpoint'))) === false) $var['endpoint'] .= ":".(explode(ipsplit(_var($var,'internet')),_var($var,'internet'))[1] ?? '');
       }
       break;
     case 'PersistentKeepalive':
@@ -348,6 +369,7 @@ function parseInput($vtun,&$input,&$x) {
     }
   }
 }
+
 $default4 = '0.0.0.0/0';
 $default6 = '::/0';
 
@@ -381,20 +403,20 @@ case 'update':
   $var['shared2']  = "AllowedIPs=".createList(_var($_POST,'#shared2'));
   $var['internet'] = "Endpoint=".createList(_var($_POST,'#internet'));
   $x = 1; $vpn = 0;
-  parseInput($vtun,$_POST,$x);
+  parseInput($vtun, $_POST, $x);
   addPeer($x);
   addDocker($vtun);
   $upstate = status($vtun);
   wgState($vtun,'down');
-  file_put_contents($file,implode("\n",$conf)."\n");
-  file_put_contents($cfg,implode("\n",$user)."\n");
+  file_put_contents($file, implode("\n", $conf)."\n");
+  file_put_contents($cfg, implode("\n", $user)."\n");
   createPeerFiles($vtun);
-  if ($upstate) wgState($vtun,'up',_var($_POST,'#type'));
+  if ($upstate) wgState($vtun, 'up', _var($_POST,'#type'));
   // if $tunip (with dots to slashes) not found in nginx config, then reload nginx to add it
   $nginx = parse_ini_file('/var/local/emhttp/nginx.ini');
-  if (stripos($nginx['NGINX_CERTNAME'],'.myunraid.net')!==false) {
+  if (stripos($nginx['NGINX_CERTNAME'],'.myunraid.net') !== false) {
     $key = 'NGINX_'.strtoupper($vtun).'FQDN';
-    if (!isset($nginx[$key]) || stripos($nginx[$key],str_replace('.','-',$tunip))===false) {
+    if (!isset($nginx[$key]) || stripos($nginx[$key], str_replace('.', '-', $tunip)) === false) {
       exec("/etc/rc.d/rc.nginx reload");
     }
   }
@@ -404,28 +426,28 @@ case 'toggle':
   $vtun = _var($_POST,'#vtun');
   switch (_var($_POST,'#wg')) {
   case 'stop':
-    wgState($vtun,'down');
+    wgState($vtun, 'down');
     echo status($vtun) ? 1 : 0;
     break;
   case 'start':
-    [$index,$network] = newNet($vtun);
+    [$index, $network] = newNet($vtun);
     if (!isNet($network)) {
       exec("ip -4 rule add from $network table $index");
       exec("ip -4 route add unreachable default table $index");
     }
-    wgState($vtun,'up',_var($_POST,'#type'));
+    wgState($vtun, 'up', _var($_POST,'#type'));
     echo status($vtun) ? 0 : 1;
     break;
   }
   break;
 case 'ping':
   $addr = $_POST['#addr'];
-  echo exec("ping -qc1 -W4 $addr|grep -Pom1 '1 received'");
+  echo exec("ping -qc1 -W4 $addr | grep -Pom1 '1 received'");
   break;
 case 'public':
   $ip = _var($_POST,'#ip');
-  $v4 = _var($_POST,'#prot')!='6';
-  $v6 = _var($_POST,'#prot')!='';
+  $v4 = _var($_POST,'#prot') != '6';
+  $v6 = _var($_POST,'#prot') != '';
   $int_ipv4 = $v4 ? (preg_match("/^$validIP4$/",$ip) ? $ip : (@dns_get_record($ip,DNS_A)[0]['ip'] ?: '')) : '';
   $ext_ipv4 = $v4 ? (http_get_contents('https://wanip4.unraid.net') ?: '') : '';
   $int_ipv6 = $v6 ? (preg_match("/^$validIP6$/",$ip) ? $ip : (@dns_get_record($ip,DNS_AAAA)[0]['ipv6'] ?: '')) : '';
@@ -436,20 +458,20 @@ case 'addtunnel':
   $vtun = vtun();
   $name = _var($_POST,'#name');
   touch("$etc/$vtun.conf");
-  wgState($vtun,'down');
+  wgState($vtun, 'down');
   delete_file("$etc/$vtun.cfg");
   delPeer($vtun);
-  autostart($vtun,'off');
+  autostart($vtun, 'off');
   break;
 case 'deltunnel':
   $vtun = _var($_POST,'#vtun');
   $name = _var($_POST,'#name');
   $error = delDocker($vtun);
   if (!$error) {
-    wgState($vtun,'down');
-    delete_file("$etc/$vtun.conf","$etc/$vtun.cfg");
+    wgState($vtun, 'down');
+    delete_file("$etc/$vtun.conf", "$etc/$vtun.cfg");
     delPeer($vtun);
-    autostart($vtun,'off');
+    autostart($vtun, 'off');
     // remove tunnel url from nginx config
     $nginx = parse_ini_file('/var/local/emhttp/nginx.ini');
     $key = 'NGINX_'.strtoupper($vtun).'FQDN';
@@ -462,16 +484,16 @@ case 'deltunnel':
 case 'import':
   $name = _var($_POST,'#name');
   $user = $peers = $var = $import = $sort = [];
-  $entries = array_filter(array_map('trim',preg_split('/\[(Interface|Peer)\]/',_var($_POST,'#data'))));
+  $entries = array_filter(array_map('trim',preg_split('/\[(Interface|Peer)\]/', _var($_POST,'#data'))));
   foreach($entries as $key => $entry) {
     $i = $key-1;
     foreach (explode("\n",$entry) as $row) {
-      if (ltrim($row)[0]!='#') {
-        [$id,$data] = array_map('trim',my_explode('=',$row));
+      if (ltrim($row)[0] != '#') {
+        [$id, $data] = array_map('trim', my_explode('=',$row));
         normalize($id);
         $import["$id:$i"] = $data;
       } elseif ($i >= 0) {
-        $import["Name:$i"] = substr(trim($row),1);
+        $import["Name:$i"] = substr(trim($row), 1);
       }
     }
   }
@@ -480,7 +502,7 @@ case 'import':
   unset($import['ListenPort:0']);
   $import['UPNP:0'] = 'no';
   $import['NAT:0'] = 'no';
-  [$subnet,$mask] = my_explode('/',_var($import,'Address:0'));
+  [$subnet, $mask] = my_explode('/', _var($import,'Address:0'));
   if (ipv4($subnet)) {
     $mask = ($mask > 0 && $mask < 32) ? $mask : 24;
     $import['Network:0'] = long2ip(ip2long($subnet) & (0x100000000-2**(32-$mask))).'/'.$mask;
@@ -488,37 +510,37 @@ case 'import':
     $import['PROT:0'] = '';
   } else {
     $mask = ($mask > 0 && $mask < 128) ? $mask : 64;
-    $import['Network6:0'] = strstr($subnet,'::',true).'::/'.$mask;
+    $import['Network6:0'] = strstr($subnet, '::', true).'::/'.$mask;
     $import['Address:0'] = $subnet;
     $import['PROT:0'] = '6';
   }
   $import['Endpoint:0'] = '';
   for ($n = 1; $n <= $i; $n++) {
-    $vpn = array_map('trim',explode(',',_var($import,"AllowedIPs:$n")));
+    $vpn = array_map('trim',explode(',', _var($import,"AllowedIPs:$n")));
     $vpn = (in_array($default4,$vpn) || in_array($default6,$vpn)) ? 8 : 0;
     if ($vpn==8) $import["Address:$n"] = '';
     $import["TYPE:$n"] = $vpn;
     ipfilter(_var($import,"AllowedIPs:$n"));
-    if (_var($import,"TYPE:$n")==0) $var['subnets1'] = "AllowedIPs="._var($import,"AllowedIPs:$n");
+    if (_var($import,"TYPE:$n") == 0) $var['subnets1'] = "AllowedIPs="._var($import,"AllowedIPs:$n");
   }
   foreach ($import as $key => $val) $sort[] = explode(':',$key)[1];
-  array_multisort($sort,$import);
+  array_multisort($sort, $import);
   $x = 1;
   $conf = ['[Interface]'];
-  $var['default'] = _var($import,'PROT:0')=='' ? "AllowedIPs=$default4" : "AllowedIPs=$default6";
+  $var['default'] = _var($import,'PROT:0') == '' ? "AllowedIPs=$default4" : "AllowedIPs=$default6";
   $var['internet'] = "Endpoint=unknown";
   $vtun = vtun();
-  parseInput($vtun,$import,$x);
+  parseInput($vtun, $import, $x);
   addPeer($x);
-  file_put_contents("$etc/$vtun.conf",implode("\n",$conf)."\n");
-  file_put_contents("$etc/$vtun.cfg",implode("\n",$user)."\n");
+  file_put_contents("$etc/$vtun.conf", implode("\n",$conf)."\n");
+  file_put_contents("$etc/$vtun.cfg", implode("\n",$user)."\n");
   delPeer($vtun);
   addDocker($vtun);
-  autostart($vtun,'off');
+  autostart($vtun, 'off');
   echo $vtun;
   break;
 case 'autostart':
-  autostart(_var($_POST,'#vtun'),_var($_POST,'#start'));
+  autostart(_var($_POST,'#vtun'), _var($_POST,'#start'));
   break;
 case 'upnp':
   $upnp = '/var/tmp/upnp';
@@ -528,14 +550,14 @@ case 'upnp':
     $xml = @file_get_contents($upnp) ?: '';
     if ($xml) {
       exec("timeout $t1 stdbuf -o0 upnpc -u $xml -m $link -l 2>&1|grep -qm1 'refused'",$output,$code);
-      if ($code!=1) $xml = '';
+      if ($code != 1) $xml = '';
     }
     if (!$xml) {
       exec("timeout $t2 stdbuf -o0 upnpc -m $link -l 2>/dev/null|grep -Po 'desc: \K.+'",$desc);
-      foreach ($desc as $url) if ($url && strpos($url,$gw)!==false) {$xml = $url; break;}
+      foreach ($desc as $url) if ($url && strpos($url,$gw) !== false) {$xml = $url; break;}
     }
   } else $xml = "";
-  file_put_contents($upnp,$xml);
+  file_put_contents($upnp, $xml);
   echo $xml;
   break;
 case 'upnpc':
@@ -544,10 +566,10 @@ case 'upnpc':
   $vtun = _var($_POST,'#vtun');
   $link = _var($_POST,'#link');
   $ip   = _var($_POST,'#ip');
-  if (_var($_POST,'#wg')=='active') {
-    exec("timeout $t1 stdbuf -o0 upnpc -u $xml -m $link -l 2>/dev/null|grep -Po \"^(ExternalIPAddress = \K.+|.+\KUDP.+>$ip:[0-9]+ 'WireGuard-$vtun')\"",$upnp);
-    [$addr,$upnp] = array_pad($upnp,2,'');
-    [$type,$rule] = my_explode(' ',$upnp);
+  if (_var($_POST,'#wg') == 'active') {
+    exec("timeout $t1 stdbuf -o0 upnpc -u $xml -m $link -l 2>/dev/null|grep -Po \"^(ExternalIPAddress = \K.+|.+\KUDP.+>$ip:[0-9]+ 'WireGuard-$vtun')\"", $upnp);
+    [$addr, $upnp] = array_pad($upnp, 2, '');
+    [$type, $rule] = my_explode(' ', $upnp);
     echo $rule ? "UPnP: $addr:$rule/$type" : _("UPnP: forwarding not set");
   } else {
     echo _("UPnP: tunnel is inactive");

--- a/emhttp/plugins/dynamix/scripts/diagnostics
+++ b/emhttp/plugins/dynamix/scripts/diagnostics
@@ -26,7 +26,7 @@ $cli = empty($zip);
 
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/Helpers.php";
-require_once "$docroot/webGui/include/Wrappers.php";
+require_once "$docroot/webGui/include/publish.php";
 
 if (is_file('/boot/syslinux/syslinux.cfg')) {
   $bootenv = '/boot/syslinux';
@@ -45,18 +45,7 @@ $pools = pools_filter($disks);
 require_once "$docroot/webGui/include/CustomMerge.php";
 
 function write(...$messages){
-  $com = curl_init();
-  curl_setopt_array($com,[
-    CURLOPT_URL => 'http://localhost/pub/diagnostics?buffer_length=1',
-    CURLOPT_UNIX_SOCKET_PATH => '/var/run/nginx.socket',
-    CURLOPT_POST => 1,
-    CURLOPT_RETURNTRANSFER => true
-  ]);
-  foreach ($messages as $message) {
-    curl_setopt($com, CURLOPT_POSTFIELDS, $message);
-    curl_exec($com);
-  }
-  curl_close($com);
+  foreach ($messages as $message) publish('diagnostics', $message);
 }
 
 function run($cmd, &$save=null, $timeout=30) {
@@ -64,7 +53,7 @@ function run($cmd, &$save=null, $timeout=30) {
   // output command for display
   write($cmd);
   // execute command with timeout of 30s
-  exec("timeout -s9 $timeout $cmd", $save);
+  exec("LC_ALL=en_US.UTF-8 timeout -s9 $timeout $cmd", $save);
   return implode("\n",$save);
 }
 
@@ -470,7 +459,7 @@ foreach ($ports as $port) {
   file_put_contents("/$diag/system/ethtool.txt", "--------------------------------\r\n", FILE_APPEND);
 }
 run("ip -br a|todos >".escapeshellarg("/$diag/system/ifconfig.txt"));
-if (!$all) maskIP("/$diag/system/ifconfig.txt");
+maskIP("/$diag/system/ifconfig.txt");
 
 // create system information (suppress errors)
 run("find /sys/kernel/iommu_groups/ -type l 2>/dev/null|sort -V|todos >".escapeshellarg("/$diag/system/iommu_groups.txt"));

--- a/emhttp/plugins/dynamix/scripts/diagnostics
+++ b/emhttp/plugins/dynamix/scripts/diagnostics
@@ -48,7 +48,6 @@ function write(...$messages){
   foreach ($messages as $message) publish('diagnostics', $message);
 }
 
-// Modify run function to include error logging
 function run($cmd, &$save=null, $timeout=30) {
   // output command for display
   write($cmd);

--- a/emhttp/plugins/dynamix/scripts/diagnostics
+++ b/emhttp/plugins/dynamix/scripts/diagnostics
@@ -49,12 +49,11 @@ function write(...$messages){
 }
 
 function run($cmd, &$save=null, $timeout=30) {
-  global $cli,$diag;
   // output command for display
   write($cmd);
   // execute command with timeout of 30s
   exec("LC_ALL=en_US.UTF-8 timeout -s9 $timeout $cmd", $save);
-  return implode("\n",$save);
+  return implode("\n", $save);
 }
 
 function newline($file) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed warnings about non-existent directory paths in Docker and VM settings; only a caution message is shown if the array is not started.  
- **Style**
  - Improved formatting and clarity of warning messages in VM settings.  
  - Modernized code style and spacing in WireGuard update module for better readability.  
- **Chores**
  - Updated copyright years in VM settings.  
  - Simplified diagnostics script by removing error logging and improving locale handling during command execution.  
- **New Features**
  - Enhanced network interface detection in WireGuard update module using dynamic system commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->