### PR TITLE
Refactor: Only reload Main/Dash on visibility if Live Updates disabled

### DIFF
--- a/emhttp/plugins/dynamix/include/DefaultPageLayout.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout.php
@@ -1288,7 +1288,10 @@ $('body').on('click','a,.ca_href', function(e) {
   }
 });
 
-// Start & stop live updates when window loses focus
+// Only include window focus/blur event handlers when live updates are disabled
+// to prevent unnecessary page reloads when live updates are already handling data refreshes
+// nchanPaused / blurTimer used elsewhere so need to always be defined
+
 var nchanPaused = false;
 var blurTimer = false;
 

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout.php
@@ -1292,25 +1292,19 @@ $('body').on('click','a,.ca_href', function(e) {
 var nchanPaused = false;
 var blurTimer = false;
 
+<? if ( $display['liveUpdate'] == "no" ):?>
 $(window).focus(function() {
   nchanFocusStart();
 });
 
 // Stop nchan on loss of focus
-<? if ( $display['liveUpdate'] == "no" ):?>
 $(window).blur(function() {
   blurTimer = setTimeout(function(){
     nchanFocusStop();
   },30000);
 });
-<?endif;?>
 
 document.addEventListener("visibilitychange", (event) => {
-  <? if ( $display['liveUpdate'] == "no" ):?>
-  if (document.hidden) {
-    nchanFocusStop();
-  }
-<?else:?>
   if (document.hidden) {
     nchanFocusStop();
   } else {
@@ -1326,7 +1320,6 @@ document.addEventListener("visibilitychange", (event) => {
       nchanFocusStart();
     <?endif;?>
   }
-<?endif;?>
 });
 
 function nchanFocusStart() {
@@ -1367,6 +1360,7 @@ function nchanFocusStop(banner=true) {
     }
   }
 }
+<?endif;?>
 </script>
 </body>
 </html>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of live updates when switching browser tabs or windows, ensuring updates are paused or resumed appropriately based on the live update setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->