### PR TITLE
fix: respect use_ssl with tailscale certs

### DIFF
--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -303,7 +303,7 @@ build_servers(){
 	EOF
     fi
   fi
-  if [[ -n $TSFQDN ]]; then
+  if [[ -n $TSFQDN && $USE_SSL != no ]]; then
     cat <<- EOF >>$SERVERS
 	#
 	# Redirect Tailscale http requests to https


### PR DESCRIPTION
Fixing an oddity with the Tailscale + WebGUI integration: if Tailscale is configured, rc.nginx ignores the USE_SSL setting and  always listens on the HTTPS port for all interfaces (not just tailscale1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Nginx configuration logic to ensure Tailscale HTTPS settings are only applied when SSL is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->