### PR TITLE
fix: update header styles and layout in default-base.css

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/Docker.page
+++ b/emhttp/plugins/dynamix.docker.manager/Docker.page
@@ -18,9 +18,14 @@ Cond="exec(\"grep -o '^DOCKER_ENABLED=.yes' /boot/config/docker.cfg 2>/dev/null\
  */
 ?>
 <?
-if ($var['fsState'] != 'Started') {
-  echo "<div class='notice shift'>_(Array must be **Started** to view Docker containers)_.</div>";
-} elseif (!is_file('/var/run/dockerd.pid') || (!is_dir('/proc/'.@file_get_contents('/var/run/dockerd.pid')))) {
-  echo "<div class='notice shift'>_(Docker Service failed to start)_.</div>";
-}
+  $noticeMessage = null;
+  if ($var['fsState'] != 'Started') {
+    $noticeMessage = _('Array must be **Started** to view Docker containers');
+  } elseif (!is_file('/var/run/dockerd.pid') || (!is_dir('/proc/'.@file_get_contents('/var/run/dockerd.pid')))) {
+    $noticeMessage = _('Docker Service failed to start');
+  }
 ?>
+
+<? if ($noticeMessage): ?>
+  <p class="notice"><?= $noticeMessage ?></p>
+<? endif; ?>

--- a/emhttp/plugins/dynamix.vm.manager/VMs.page
+++ b/emhttp/plugins/dynamix.vm.manager/VMs.page
@@ -18,10 +18,19 @@ Cond="exec(\"grep -o '^SERVICE=.enable' /boot/config/domain.cfg 2>/dev/null\")"
  */
 ?>
 <?
-if ($var['fsState'] != "Started") {
-  echo "<div class='notice shift'>"._('Array must be **started** to view Virtual Machines').".</div>";
-} elseif (!is_file('/var/run/libvirt/libvirtd.pid') || (!is_dir('/proc/'.@file_get_contents('/var/run/libvirt/libvirtd.pid')))) {
-  echo "<div class='notice shift'>"._('Libvirt Service failed to start').".</div>";
+  $noticeMessage = null;
+  if ($var['fsState'] != "Started") {
+    $noticeMessage = _('Array must be **started** to view Virtual Machines');
+  } elseif (!is_file('/var/run/libvirt/libvirtd.pid') || (!is_dir('/proc/'.@file_get_contents('/var/run/libvirt/libvirtd.pid')))) {
+    $noticeMessage = _('Libvirt Service failed to start');
+  }
+?>
+<? if ($noticeMessage): ?>
+  <p class="notice"><?= $noticeMessage ?></p>
+<? endif; ?>
+
+<?
+if (count($pages) == 2) {
+  $tabbed = false;
 }
-if (count($pages)==2) $tabbed = false;
 ?>

--- a/emhttp/plugins/dynamix/Shares.page
+++ b/emhttp/plugins/dynamix/Shares.page
@@ -2,10 +2,20 @@ Menu="Tasks:2"
 Type="xmenu"
 Code="e92a"
 ---
-<?PHP
-if ($var['fsState']=="Stopped") {
-  echo "<p class='notice shift'>"._('Array must be **Started** to view Shares').".</p>";
-  return;
+<?
+  $noticeMessage = null;
+  if ($var['fsState'] == "Stopped") {
+    $noticeMessage = _('Array must be **Started** to view Shares');
+  }
+?>
+
+<? if ($noticeMessage): ?>
+  <p class="notice"><?= $noticeMessage ?></p>
+  <? return; ?>
+<? endif; ?>
+
+<?
+if (count($pages) == 2) {
+  $tabbed = false;
 }
-if (count($pages)==2) $tabbed = false;
 ?>


### PR DESCRIPTION
- Removes the `shift` class from these `notice` elements to fix spacing now that the `.content` element is position relative
- Moves away from echoing full HTML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the structure and readability of status and notice messages on the Docker, VM, and Shares pages. Notices are now displayed in a more consistent format, enhancing clarity for users. No changes to the actual messages or their conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->