### PR TITLE
Fix boot issue starting VM manager.

### DIFF
--- a/sbin/qemu
+++ b/sbin/qemu
@@ -7,7 +7,7 @@ if [ $DISABLE == "yes" ]
     exit 1 ;
 fi 
 PCI="no"
-PCI=$(/usr/local/emhttp/plugins/dynamix.vm.manager/scripts/pcicheck.php "$@");
+#PCI=$(/usr/local/emhttp/plugins/dynamix.vm.manager/scripts/pcicheck.php "$@");
 if [ $PCI == "yes" ]
     then 
     printf '\n%s\n' "Start/autostart is disabled PCI Change detected." >&2 ## Send message to stderr.


### PR DESCRIPTION
Disable PCI check in QEMU as stops system starting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where PCI-related checks could inadvertently disable start or autostart features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->