### PR TITLE
Add pci checks in qemu

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/scripts/pcicheck.php
+++ b/emhttp/plugins/dynamix.vm.manager/scripts/pcicheck.php
@@ -16,7 +16,7 @@
 
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/Helpers.php";
-require_once "$docroot/plugins/dynamix.vm.manager/include/libvirt_helpers.php";
+
 
 $pci_device_changes = comparePCIData();
 $pcierror = false;

--- a/sbin/qemu
+++ b/sbin/qemu
@@ -7,7 +7,7 @@ if [ $DISABLE == "yes" ]
     exit 1 ;
 fi 
 PCI="no"
-#PCI=$(/usr/local/emhttp/plugins/dynamix.vm.manager/scripts/pcicheck.php "$@");
+PCI=$(/usr/local/emhttp/plugins/dynamix.vm.manager/scripts/pcicheck.php "$@");
 if [ $PCI == "yes" ]
     then 
     printf '\n%s\n' "Start/autostart is disabled PCI Change detected." >&2 ## Send message to stderr.


### PR DESCRIPTION
Fix to allow PCI check when qemu is run if libvirt is not running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reactivated PCI change detection in the VM manager, ensuring users are notified and prevented from proceeding when PCI changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->