### PR TITLE
refactor: sanitize shell arguments in WireGuard update script

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -53,7 +53,7 @@ $names = array_map('var_split',$autostart);
 
 // Grab Tailscale json from container
 function tailscale_stats($name) {
-  exec("docker exec -i ".$name." /bin/sh -c \"tailscale status --json | jq '{Self: .Self, ExitNodeStatus: .ExitNodeStatus, Version: .Version}'\" 2>/dev/null", $TS_stats);
+  exec("docker exec -i ".escapeshellarg($name)." /bin/sh -c \"tailscale status --json | jq '{Self: .Self, ExitNodeStatus: .ExitNodeStatus, Version: .Version}'\" 2>/dev/null", $TS_stats);
   if (!empty($TS_stats)) {
     $TS_stats = implode("\n", $TS_stats);
     return json_decode($TS_stats, true);
@@ -68,12 +68,12 @@ function tailscale_json_dl($file, $url) {
     mkdir('/tmp/tailscale', 0777, true);
   }
   if (!file_exists($file)) {
-    exec("wget -T 3 -q -O ".$file." ".$url, $output, $dl_status);
+    exec("wget -T 3 -q -O ".escapeshellarg($file)." ".escapeshellarg($url), $output, $dl_status);
   } else {
     $fileage =  time() - filemtime($file);
     if ($fileage > 86400) {
       unlink($file);
-      exec("wget -T 3 -q -O ".$file." ".$url, $output, $dl_status);
+      exec("wget -T 3 -q -O ".escapeshellarg($file)." ".escapeshellarg($url), $output, $dl_status);
     }
   }
   if ($dl_status === 0) {

--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -627,7 +627,7 @@ function execCommand($command, $echo=true) {
     echo '<p class="logLine" id="logBody"></p></fieldset>\');show_Wait('.$waitID.');</script>';
     @flush();
   }
-  $proc = popen("$command 2>&1",'r');
+  $proc = popen(escapeshellcmd($command)." 2>&1",'r');
   while ($out = fgets($proc)) {
     $out = preg_replace("%[\t\n\x0B\f\r]+%", '', $out);
     if ($echo) {

--- a/emhttp/plugins/dynamix.plugin.manager/include/UnraidUpdateCancel.php
+++ b/emhttp/plugins/dynamix.plugin.manager/include/UnraidUpdateCancel.php
@@ -38,7 +38,7 @@ class UnraidUpdateCancel
       shell_exec("mv -f /boot/previous/* /boot");
       unlink($this->PLG_BOOT);
       unlink($this->PLG_VAR);
-      symlink(escapeshellarg("{$this->USR_LOCAL_PLUGIN_UNRAID_PATH}/{$this->PLG_FILENAME}"), $this->PLG_VAR);
+      symlink("{$this->USR_LOCAL_PLUGIN_UNRAID_PATH}/{$this->PLG_FILENAME}", $this->PLG_VAR);
 
       // Restore README.md by echoing the content into the file
       $readmeFile = "{$this->USR_LOCAL_PLUGIN_UNRAID_PATH}/README.md";

--- a/emhttp/plugins/dynamix.plugin.manager/include/UnraidUpdateCancel.php
+++ b/emhttp/plugins/dynamix.plugin.manager/include/UnraidUpdateCancel.php
@@ -38,7 +38,7 @@ class UnraidUpdateCancel
       shell_exec("mv -f /boot/previous/* /boot");
       unlink($this->PLG_BOOT);
       unlink($this->PLG_VAR);
-      symlink("{$this->USR_LOCAL_PLUGIN_UNRAID_PATH}/{$this->PLG_FILENAME}", $this->PLG_VAR);
+      symlink(escapeshellarg("{$this->USR_LOCAL_PLUGIN_UNRAID_PATH}/{$this->PLG_FILENAME}"), $this->PLG_VAR);
 
       // Restore README.md by echoing the content into the file
       $readmeFile = "{$this->USR_LOCAL_PLUGIN_UNRAID_PATH}/README.md";

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/language
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/language
@@ -181,13 +181,13 @@ function language($method, $xml_file, &$error) {
       }
     }
     $path = "$docroot/languages/$name";
-    exec("mkdir -p $path");
+    exec("mkdir -p ".escapeshellarg($path));
     @unlink("$docroot/webGui/javascript/translate.$name.js");
     foreach (glob("$path/*.dot",GLOB_NOSORT) as $dot_file) unlink($dot_file);
-    exec("unzip -qqLjo -d $path $save", $dummy, $err);
+    exec("unzip -qqLjo -d ".escapeshellarg($path)." ".escapeshellarg($save), $dummy, $err);
     if ($err > 1) {
       @unlink($save);
-      exec("rm -rf $path");
+      exec("rm -rf ".escapeshellarg($path));
       $error = "unzip failed. Error code $err";
       return false;
     }
@@ -196,7 +196,7 @@ function language($method, $xml_file, &$error) {
     $name = $xml->LanguagePack;
     if ($name) {
       $path = "$docroot/languages/$name";
-      exec("rm -rf $path");
+      exec("rm -rf ".escapeshellarg($path));
       @unlink("$docroot/webGui/javascript/translate.$name.js");
       @unlink("$boot/lang-$name.xml");
       @unlink("$plugins/lang-$name.xml");
@@ -243,7 +243,7 @@ if ($method == 'checkall') {
     $name = str_replace('lang-', '', basename($lang_file, '.xml'));
     $lang = language('Language', $lang_file, $error) ?: $name;
     write("language: checking $lang language pack ...\n");
-    exec(realpath($argv[0])." check $name >/dev/null");
+    exec(realpath($argv[0])." check ".escapeshellarg($name)." >/dev/null");
   }
   write("language: checking finished.\n");
   done(0);
@@ -265,7 +265,7 @@ if ($method == 'updateall') {
     // update only when newer
     if (strcmp($latest, $version) > 0) {
       write("language: updating $lang language pack ...\n");
-      exec(realpath($argv[0])." update $name >/dev/null");
+      exec(realpath($argv[0])." update ".escapeshellarg($name)." >/dev/null");
     }
   }
   write("language: updating finished.\n");

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/multiplugin
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/multiplugin
@@ -41,7 +41,7 @@ foreach ($plugins as $plugin) {
   if (!$plugin || (!$cmd = $call[pathinfo($plugin,PATHINFO_EXTENSION)])) continue;
   $line = '';
   $pluginArg = $method == "update" ? basename($plugin) : $plugin;
-  $run = popen("$cmd $method $pluginArg",'r');
+  $run = popen("$cmd ".escapeshellarg($method)." ".escapeshellarg($pluginArg),'r');
   while (!feof($run)) {
     $line .= fgetc($run);
     if (!empty($line) && in_array($line[-1],["\r","\n"])) {write($line); $line = '';}

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
@@ -239,7 +239,7 @@ function download($url, $name, &$error, $write=true) {
     $plg = basename($url);
     $plg = str_replace('"', '', $plg);
     $tries = (strpos($url, '.cdn') !== false) ? "1" : "3";
-    if ($file = popen("wget --compression=auto --no-cache --progress=dot --retry-connrefused --prefer-family=IPv4 --timeout=10 --tries=$tries --waitretry=$tries -O $name $url 2>&1", 'r')) {
+    if ($file = popen("wget --compression=auto --no-cache --progress=dot --retry-connrefused --prefer-family=IPv4 --timeout=10 --tries=$tries --waitretry=$tries -O ".escapeshellarg($name)." ".escapeshellarg($url)." 2>&1", 'r')) {
       if ($write) write("plugin: downloading: $plg ...\r");
       $level = -1;
         while (($line = fgets($file)) !== false) {
@@ -460,18 +460,18 @@ function plugin($method, $plugin_file, &$error) {
     // Maybe "run" the file now
     //
     if ($file->attributes()->Run) {
-      $command = $file->attributes()->Run;
+      $command = escapeshellcmd($file->attributes()->Run);
       if ($name) {
         my_logger("running: $command $name", $logger);
-        $retval = run("$command $name");
+        $retval = run("$command ".escapeshellarg($name));
       } elseif ($file->LOCAL) {
         my_logger("running: $command $file->LOCAL", $logger);
-        $retval = run("$command $file->LOCAL");
+        $retval = run("$command ".escapeshellarg($file->LOCAL));
       } elseif ($file->INLINE) {
         my_logger("running: 'anonymous'", $logger);
         $name = '/tmp/inline.sh';
         file_put_contents($name, $file->INLINE);
-        $retval = run("$command $name");
+        $retval = run("$command ".escapeshellarg($name));
         unlink($name);
       }
       if ($retval != 0) {

--- a/emhttp/plugins/dynamix/include/FileSystemStatus.php
+++ b/emhttp/plugins/dynamix/include/FileSystemStatus.php
@@ -21,14 +21,14 @@ function zfs($data) {return "zfs-".strtok($data,' ');}
 
 switch ($cmd) {
 case 'status':
-  exec("ps -C btrfs -o cmd=|awk '/$path\$/{print $2}'",$btrfs);
-  exec("/usr/sbin/zpool status $path|grep -Po '(scrub|resilver) in progress'",$zfs);
+  exec("ps -C btrfs -o cmd=|awk '/".escapeshellarg($path)."\$/{print $2}'",$btrfs);
+  exec("/usr/sbin/zpool status ".escapeshellarg($path)."|grep -Po '(scrub|resilver) in progress'",$zfs);
   echo implode(',',array_merge(array_map('btrfs',$btrfs),array_map('zfs',$zfs)));
   break;
 case 'btrfs-balance':
 case 'btrfs-scrub':
   $cmd = explode('-',$cmd)[1];
-  echo shell_exec("/sbin/btrfs $cmd status $path");
+  echo shell_exec("/sbin/btrfs $cmd status ".escapeshellarg($path));
   break;
 case 'zfs-scrub':
 case 'zfs-resilver':

--- a/emhttp/plugins/dynamix/include/Helpers.php
+++ b/emhttp/plugins/dynamix/include/Helpers.php
@@ -322,14 +322,14 @@ function my_mkdir($dirname,$permissions = 0777,$recursive = false,$own = "nobody
       $parent = str_replace('/mnt/user/', "/mnt/$realdisk/", $parent);
     }
   }
-  $fstype = trim(shell_exec(" stat -f -c '%T' $parent"));
+  $fstype = trim(shell_exec(" stat -f -c '%T' ".escapeshellarg($parent)));
   $rtncode = false;
   write_logging("fstype:$fstype parent $parent dir name $dirname\n");
   switch ($fstype) {
     case "zfs":
       if (is_dir($parent.'/.zfs')) {
         write_logging("ZFS Volume\n");
-        $zfsdataset = trim(shell_exec("zfs list -H -o name  $parent")); 
+        $zfsdataset = trim(shell_exec("zfs list -H -o name  ".escapeshellarg($parent))); 
         write_logging("Shell $zfsdataset\n");
         $zfsdataset .= str_replace($parent,"",$dirname);
         write_logging("Dataset $zfsdataset\n");

--- a/emhttp/plugins/dynamix/include/OpenTerminal.php
+++ b/emhttp/plugins/dynamix/include/OpenTerminal.php
@@ -31,14 +31,15 @@ if (!empty($display['tty'])) exec("sed -ri 's/fontSize=[0-9]+/fontSize={$display
 
 function wait($name,$cmd) {
   global $run,$wait;
-  $exec = "/var/tmp/$name.run.sh";
+  $sanitized_name = preg_replace('/[^\w\-\.]/', '', $name);
+  $exec = "/var/tmp/$sanitized_name.run.sh";
   file_put_contents($exec,"#!/bin/bash\n$run $cmd\n$wait\n");
   chmod($exec,0755);
-  return $exec;
+  return escapeshellarg($exec);
 }
 function command($path,$file) {
   global $run,$wait,$rows;
-  return (file_exists($file) && substr($file,0,strlen($path))==$path) ? "$run tail -f -n $rows '$file'" : $wait;
+  return (file_exists($file) && substr($file,0,strlen($path))==$path) ? "$run tail -f -n $rows ".escapeshellarg($file) : $wait;
 }
 switch ($_GET['tag']) {
 case 'ttyd':
@@ -47,26 +48,26 @@ case 'ttyd':
   exec('pgrep --ns $$ -f '."'$sock'", $ttyd_pid, $retval);
   if ($retval == 0) {
     // check if there are any child processes, ie, curently open tty windows
-    exec('pgrep --ns $$ -P '.$ttyd_pid[0], $output, $retval);
+    exec('pgrep --ns $$ -P '.escapeshellarg($ttyd_pid[0]), $output, $retval);
     // no child processes, restart ttyd to pick up possible font size change
-    if ($retval != 0) exec("kill ".$ttyd_pid[0]);
+    if ($retval != 0) exec("kill ".escapeshellarg($ttyd_pid[0]));
   }
-  if ($retval != 0) exec("ttyd-exec -i '$sock' '" . posix_getpwuid(0)['shell'] . "' --login");
+  if ($retval != 0) exec("ttyd-exec -i ".escapeshellarg($sock)." ".escapeshellarg(posix_getpwuid(0)['shell'])." --login");
   break;
 case 'syslog':
   // read syslog file
   $path = '/var/log/';
   $file = realpath($path.$_GET['name']);
   $sock = "/var/run/syslog.sock";
-  exec("ttyd-exec -s9 -om1 -i '$sock' ".command($path,$file));
+  exec("ttyd-exec -s9 -om1 -i ".escapeshellarg($sock)." ".command($path,$file));
   break;
 case 'disklog':
   // read disk log info (main page)
   $name = unbundle($_GET['name']);
   $sock = "/var/tmp/$name.sock";
-  $ata  = exec("ls -n '/sys/block/$name'|grep -Pom1 'ata\d+'");
+  $ata  = exec("ls -n ".escapeshellarg("/sys/block/$name")."|grep -Pom1 'ata\d+'");
   $dev  = $ata ? $name.'|'.$ata.'[.:]' : $name;
-  exec("ttyd-exec -s9 -om1 -i '$sock' ".wait($name,"grep -P \"'$dev'\" '/var/log/syslog*'"));
+  exec("ttyd-exec -s9 -om1 -i ".escapeshellarg($sock)." ".wait($name,"grep -P ".escapeshellarg("'$dev'")." ".escapeshellarg("/var/log/syslog*")));
   break;
 case 'log':
   // read vm log file
@@ -74,7 +75,7 @@ case 'log':
   $name = unbundle($_GET['name']);
   $file = realpath($path.$_GET['more']);
   $sock = "/var/tmp/$name.sock";
-  exec("ttyd-exec -s9 -om1 -i '$sock' ".command($path,$file));
+  exec("ttyd-exec -s9 -om1 -i ".escapeshellarg($sock)." ".command($path,$file));
   break;
 case 'docker':
   $name = unbundle($_GET['name']);
@@ -82,22 +83,22 @@ case 'docker':
   if ($more=='.log') {
     // read docker container log
     $sock = "/var/tmp/$name.log.sock";
-    if (empty(exec("docker ps --filter=name='$name' --format={{.Names}}")))
-      $docker = wait($name,"docker logs -n $rows '$name'"); // container stopped
+    if (empty(exec("docker ps --filter=name=".escapeshellarg($name)." --format={{.Names}}")))
+      $docker = wait($name,"docker logs -n $rows ".escapeshellarg($name)); // container stopped
     else
-      $docker = "$run docker logs -f -n $rows '$name'"; // container started
-    exec("ttyd-exec -s9 -om1 -i '$sock' $docker");
+      $docker = "$run docker logs -f -n $rows ".escapeshellarg($name); // container started
+    exec("ttyd-exec -s9 -om1 -i ".escapeshellarg($sock)." $docker");
   } else {
     // docker console command
     $sock = "/var/tmp/$name.sock";
-    exec("ttyd-exec -s9 -om1 -i '$sock' docker exec -it '$name' $more");
+    exec("ttyd-exec -s9 -om1 -i ".escapeshellarg($sock)." docker exec -it ".escapeshellarg($name)." ".escapeshellarg($more));
   }
   break;
 case 'lxc':
   $name = unbundle($_GET['name']);
   $more = unbundle($_GET['more']);
   $sock = "/var/tmp/$name.sock";
-  exec("ttyd-exec -s9 -om1 -i '$sock' lxc-attach '$name' $more");
+  exec("ttyd-exec -s9 -om1 -i ".escapeshellarg($sock)." lxc-attach ".escapeshellarg($name)." ".escapeshellarg($more));
   break;
 }
 ?>

--- a/emhttp/plugins/dynamix/include/ProcessStatus.php
+++ b/emhttp/plugins/dynamix/include/ProcessStatus.php
@@ -23,7 +23,8 @@ case 'crontab':
   $pid = file_exists("/boot/config/plugins/{$_POST['plugin']}/{$_POST['job']}.cron");
   break;
 case 'preclear_disk':
-  $pid = exec("ps -o pid,command --ppid 1|awk -F/ ".escapeshellarg("/$name .*{$_POST['device']}$/{print $1;exit}"));
+  $device = escapeshellarg($_POST['device']);
+  $pid = exec("ps -o pid,command --ppid 1|awk -F/ ".escapeshellarg("/$name .*{$device}$/{print $1;exit}"));
   break;
 case is_numeric($name):
   $pid = exec("lsof -i:$name -Pn|awk '/\(LISTEN\)/{print $2;exit}'");

--- a/emhttp/plugins/dynamix/include/SMTPtest.php
+++ b/emhttp/plugins/dynamix/include/SMTPtest.php
@@ -30,12 +30,14 @@ function PsExecute($command, $timeout = 20, $sleep = 2) {
   return false;
 }
 function PsEnded($pid) {
-  exec("ps -eo pid|grep $pid",$output);
+  $pid = (int)$pid;
+  exec("ps -eo pid|grep ".escapeshellarg($pid),$output);
   foreach ($output as $list) if (trim($list)==$pid) return false;
   return true;
 }
 function PsKill($pid) {
-  exec("kill -9 $pid");
+  $pid = (int)$pid;
+  exec("kill -9 ".escapeshellarg($pid));
 }
 if (PsExecute("$docroot/webGui/scripts/notify -s 'Unraid SMTP Test' -d 'Test message received!' -i 'alert' -l '/Settings/Notifications' -t")) {
   $result = exec("tail -3 /var/log/syslog|awk '/sSMTP/ {getline;print}'|cut -d']' -f2|cut -d'(' -f1");

--- a/emhttp/plugins/dynamix/include/SmartInfo.php
+++ b/emhttp/plugins/dynamix/include/SmartInfo.php
@@ -244,11 +244,15 @@ case "identify":
   }
   break;
 case "save":
-  exec("smartctl -x $type ".escapeshellarg("/dev/$port")." >".escapeshellarg("$docroot/{$_POST['file']}"));
+  // Validate file path is within docroot and does not contain directory traversal
+  $safe_file = basename(preg_replace('/[^\w\.-]/', '', $_POST['file']));
+  exec("smartctl -x $type ".escapeshellarg("/dev/$port")." >".escapeshellarg("$docroot/$safe_file"));
   break;
 case "delete":
-  if (strpos(realpath("/var/tmp/{$_POST['file']}"), "/var/tmp/") === 0) {
-    @unlink("/var/tmp/{$_POST['file']}");
+  // Validate file path to prevent path traversal attacks
+  $safe_file = basename(preg_replace('/[^\w\.-]/', '', $_POST['file']));
+  if (strpos(realpath("/var/tmp/$safe_file"), "/var/tmp/") === 0) {
+    @unlink("/var/tmp/$safe_file");
   }
   break;
 case "short":

--- a/emhttp/plugins/dynamix/include/StartCommand.php
+++ b/emhttp/plugins/dynamix/include/StartCommand.php
@@ -19,7 +19,7 @@ function pgrep($proc) {
 }
 
 if (isset($_POST['kill']) && $_POST['kill'] > 1) {
-  exec("kill ".$_POST['kill']);
+  exec("kill ".escapeshellarg($_POST['kill']));
   foreach (glob("/tmp/plugins/pluginPending/*") as $file) unlink($file);
   die();
 }

--- a/emhttp/plugins/dynamix/nchan/file_manager
+++ b/emhttp/plugins/dynamix/nchan/file_manager
@@ -138,7 +138,7 @@ while (true) {
       if (!empty($pid)) {
         $reply['status'] = '<i class="fa fa-circle-o-notch fa-spin dfm"></i>'._('Removing').'... '.exec("tail -1 $status");
       } else {
-        exec("find ".quoted($source)." -name \"*\" -print -delete 1>$status 2>$null & echo \$!", $pid);
+        exec("find ".quoted($source)." -name ".escapeshellarg("*")." -print -delete 1>$status 2>$null & echo \$!", $pid);
       }
       break;
     case 2: // rename folder
@@ -197,14 +197,14 @@ while (true) {
       if (!empty($pid)) {
         $reply['status'] = '<i class="fa fa-circle-o-notch fa-spin dfm"></i>'._('Updating').'... '.exec("tail -2 $status | grep -Pom1 \"^.+ of '\\K[^']+\"");
       } else {
-        exec("chown -Rfv $target ".quoted($source)." 1>$status 2>$error & echo \$!", $pid);
+        exec("chown -Rfv ".escapeshellarg($target)." ".quoted($source)." 1>$status 2>$error & echo \$!", $pid);
       }
       break;
     case 12: // change permission
       if (!empty($pid)) {
         $reply['status'] = '<i class="fa fa-circle-o-notch fa-spin dfm"></i>'._('Updating').'... '.exec("tail -2 $status | grep -Pom1 \"^.+ of '\\K[^']+\"");
       } else {
-        exec("chmod -Rfv $target ".quoted($source)." 1>$status 2>$error & echo \$!", $pid);
+        exec("chmod -Rfv ".escapeshellarg($target)." ".quoted($source)." 1>$status 2>$error & echo \$!", $pid);
       }
       break;
     case 15: // search
@@ -215,7 +215,7 @@ while (true) {
       }
       break;
     case 99: // kill running background process
-      if (!empty($pid)) exec("kill $pid");
+      if (!empty($pid)) exec("kill ".escapeshellarg($pid));
       delete_file($active, $status, $error);
       unset($pid, $move);
       break;

--- a/emhttp/plugins/dynamix/scripts/diagnostics
+++ b/emhttp/plugins/dynamix/scripts/diagnostics
@@ -84,7 +84,8 @@ function newline($file) {
 }
 
 function shareDisks($share) {
-  return str_replace(',',', ',exec("shopt -s dotglob; getfattr --no-dereference --absolute-names --only-values -n system.LOCATIONS ".escapeshellarg("/mnt/user/$share")." 2>/dev/null") ?: "");
+  $share_path = "/mnt/user/$share";
+  return str_replace(',',', ',exec("shopt -s dotglob; getfattr --no-dereference --absolute-names --only-values -n system.LOCATIONS ".escapeshellarg($share_path)." 2>/dev/null") ?: "");
 }
 
 function anonymize($text, $select) {

--- a/emhttp/plugins/dynamix/scripts/netconfig
+++ b/emhttp/plugins/dynamix/scripts/netconfig
@@ -41,12 +41,12 @@ function update_wireguard($ifname) {
   foreach (glob("/etc/wireguard/*.conf",GLOB_NOSORT) as $wg) {
     $vtun = basename($wg,'.conf');
     // interface has changed?
-    if (exec("grep -Pom1 ' dev $nic ' $wg")=='') {
+    if (exec("grep -Pom1 ' dev ".escapeshellarg($nic)." ' ".escapeshellarg($wg))=='') {
       my_logger("updated wireguard $vtun configuration", 'netconfig');
-      exec("sed -ri 's/ dev (br0|bond0|eth0) / dev $nic /' $wg");
+      exec("sed -ri 's/ dev (br0|bond0|eth0) / dev ".escapeshellarg($nic)." /' ".escapeshellarg($wg));
     }
     // restart active wireguard tunnels
-    if (in_array($vtun,$active)) exec("wg-quick down $vtun; sleep 1; wg-quick up $vtun");
+    if (in_array($vtun,$active)) exec("wg-quick down ".escapeshellarg($vtun)."; sleep 1; wg-quick up ".escapeshellarg($vtun));
   }
 }
 


### PR DESCRIPTION
Updated the update.wireguard.php script to use escapeshellarg for all shell command arguments, enhancing security by preventing command injection vulnerabilities. This change affects various functions including isPort, carrier, thisNet, and others that execute system commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced security by escaping shell command arguments across multiple plugins and scripts to prevent injection vulnerabilities.
	- Sanitized user inputs and filenames to avoid path traversal and command injection issues.
- **Style**
	- Standardized translation string formatting for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->