### PR TITLE
Revert "Fix: Allow docker context menu to be either above or below depending …"

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
+++ b/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
@@ -2,7 +2,7 @@ var eventURL = '/plugins/dynamix.docker.manager/include/Events.php';
 
 function addDockerContainerContext(container, image, template, started, paused, update, autostart, webui, tswebui, shell, id, Support, Project, Registry, donateLink, ReadMe) {
   var opts = [];
-  context.settings({right:false,above:'auto'});
+  context.settings({right:false,above:false});
   if (started && !paused) {
     if (webui !== '' && webui != '#') opts.push({text:_('WebUI'), icon:'fa-globe', action:function(e){e.preventDefault();window.open(webui,'_blank');}});
     if (tswebui !== '' && tswebui != '#') opts.push({text:_('Tailscale WebUI'), icon:'fa-globe', action:function(e){e.preventDefault();window.open(tswebui,'_blank');}});


### PR DESCRIPTION
Reverts unraid/webgui#2074

Reverting as if the browser zoom > ~120% the first container's context goes up and gets cutoff.  More important to be able to go to the WebUI etc of the first container than to be able to go to donate etc on the last container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the positioning behavior of the context menu for Docker containers, ensuring it consistently appears below the target element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->