### PR TITLE
Fix: Re-enable smart test buttons after completion of test

### DIFF
--- a/emhttp/plugins/dynamix/Selftest.page
+++ b/emhttp/plugins/dynamix/Selftest.page
@@ -93,8 +93,8 @@ function testUpdate(init) {
       if (!init) timers.testUpdate = setTimeout(testUpdate,3000);
     } else {
       if ($('#smart_selftest').length) $('#smart_selftest').html('');
-      $('#short_test').val("_(Start)_");
-      $('#long_test').val("_(Start)_");
+      $('#short_test').val("_(Start)_").removeAttr('disabled');
+      $('#long_test').val("_(Start)_").removeAttr('disabled');
       if (!init) {
         $.removeCookie('test.<?=$dev?>');
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the short and long test buttons were not re-enabled after a test completed or stopped, ensuring users can start new tests without refreshing the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->