### PR TITLE
Feat: Terminal - Add button to manually open if popup blocked

### DIFF
--- a/emhttp/plugins/dynamix/Terminal.page
+++ b/emhttp/plugins/dynamix/Terminal.page
@@ -15,23 +15,34 @@ Icon="terminal"
 ?>
 <script>
 $(function(){
+  newTerminalOpen();
+});
+
+function newTerminalOpen() {
   var d = new Date();
   try {
     openTerminal('ttyd', 'Web Terminal ' + d.getTime(), '');
   } catch (e) {
-    console.error('Failed to open terminal:', e);
-    window.location.href = '/';
+    $('#popupFailed').show();
     return;
   }
   // Give time for terminal to open then go back to the previous page
   var referer = '<?= htmlspecialchars($_SERVER['HTTP_REFERER'] ?? '', ENT_QUOTES) ?>';
   setTimeout(function(){
     // Only redirect to same origin or fallback to home
-    if (referer && referer.indexOf(window.location.origin) === 0) {
+    if (referer && referer.indexOf(window.location.origin) === 0 && basename(referer) != "Terminal") {
       window.location.href = referer;
     } else {
       window.location.href = '/';
     }
   }, 5000);
-});
+}
+
+function basename(path) {
+  return path.replace(/.*\//, '');
+}
 </script>
+<span id='popupFailed' style='display:none;'>
+_(Terminal failed to automatically open - Popup blocked.  Either enable popups in your browser or click this:)_
+<input type='button' onclick='newTerminalOpen();' value='_(Open Terminal)_'></input>
+</span>

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
@@ -165,7 +165,6 @@ function openTerminal(tag,name,more) {
   tty_window = makeWindow(name+(more=='.log'?more:''),Math.min(screen.availHeight,800),Math.min(screen.availWidth,1200));
   if ( tty_window === null ) {
     throw new Error('Failed to open terminal window');
-    return;
   }
   var socket = ['ttyd','syslog'].includes(tag) ? '/webterminal/'+tag+'/' : '/logterminal/'+name+(more=='.log'?more:'')+'/';
   $.get('/webGui/include/OpenTerminal.php',{tag:tag,name:name,more:more},function(){setTimeout(function(){tty_window.location=socket; tty_window.focus();},200);});

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
@@ -163,6 +163,10 @@ function openTerminal(tag,name,more) {
   // open terminal window (run in background)
   name = name.replace(/[ #]/g,"_");
   tty_window = makeWindow(name+(more=='.log'?more:''),Math.min(screen.availHeight,800),Math.min(screen.availWidth,1200));
+  if ( tty_window === null ) {
+    throw new Error('Failed to open terminal window');
+    return;
+  }
   var socket = ['ttyd','syslog'].includes(tag) ? '/webterminal/'+tag+'/' : '/logterminal/'+name+(more=='.log'?more:'')+'/';
   $.get('/webGui/include/OpenTerminal.php',{tag:tag,name:name,more:more},function(){setTimeout(function(){tty_window.location=socket; tty_window.focus();},200);});
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a retry button for users to manually reopen the terminal if the popup is blocked.
  - Terminal windows now display a timestamped title when opened.

- **Bug Fixes**
  - Improved error handling when opening the terminal window fails, providing clearer feedback and preventing unintended redirects.
  - Prevented automatic redirects back to the Terminal page to avoid navigation loops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->