### PR TITLE
feat: responsive improvements rd. 3

### DIFF
--- a/emhttp/plugins/dynamix/sheets/Eth0.css
+++ b/emhttp/plugins/dynamix/sheets/Eth0.css
@@ -8,10 +8,6 @@ span.blue {
 span.green {
     color: var(--green-800);
 }
-span.vshift {
-    margin-top: 0 !important;
-}
-
 /* Input styles */
 input.gap {
     margin-right: 6px;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -504,9 +504,6 @@ div.title {
 div.title span img {
     padding-right: 4px;
 }
-div.title.shift {
-    margin-top: -30px;
-}
 #menu {
     width: 100%;
     display: grid;
@@ -1169,17 +1166,6 @@ span.status {
     font-size: 1.4rem;
     display: inline-block;
     margin-left: auto;
-}
-span.status.vhshift {
-    margin-top: 0;
-    /* leaving for reference, but should likely not be needed anymore */
-    /* margin-right: -9px; */
-}
-span.status.vshift {
-    margin-top: -16px;
-}
-span.status.hshift {
-    margin-right: -20px;
 }
 span.diskinfo {
     float: left;
@@ -1966,6 +1952,14 @@ span#wlan0 {
 .scrollbar-thin {
     scrollbar-width: thin;
 }
+
+/* plugin overrides */
+/* fix UD title margin-top from overlapping tabs */
+div.title.ud,
+div#title.ud {
+    margin-top: 0 !important;
+}
+
 /*
  * Using CSS Nesting, to narrow down the scope of the styles to the .Theme--sidebar class.
  * This allows us to have default-azure & default-gray set css variables
@@ -2372,9 +2366,6 @@ span#wlan0 {
     }
     div.title:first-of-type {
         margin-top: 0;
-    }
-    div.title.shift {
-        margin-top: -12px;
     }
 
     .usage-bar {


### PR DESCRIPTION
- Removed unnecessary margin adjustments for .vshift and .hshift classes in Eth0.css and default-base.css.
- Added a new rule to fix the margin-top for UD titles to prevent overlapping with tabs.