### PR TITLE
fix: add ServerState dependency to login page

### DIFF
--- a/emhttp/plugins/dynamix/include/.login.php
+++ b/emhttp/plugins/dynamix/include/.login.php
@@ -1,6 +1,8 @@
 <?php
 // Included in login.php
 
+require_once "$docroot/plugins/dynamix.my.servers/include/state.php";
+
 // Only start a session to check if they have a cookie that looks like our session
 $server_name = strtok($_SERVER['HTTP_HOST'], ":");
 if (!empty($_COOKIE['unraid_' . md5($server_name)])) {


### PR DESCRIPTION
Prevents PHP fatal error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of login handling by ensuring necessary plugin state is loaded at the start of the login process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->