### PR TITLE
Backport Fix: Revert allow docker context menus above or below

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
+++ b/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
@@ -2,7 +2,7 @@ var eventURL = '/plugins/dynamix.docker.manager/include/Events.php';
 
 function addDockerContainerContext(container, image, template, started, paused, update, autostart, webui, tswebui, shell, id, Support, Project, Registry, donateLink, ReadMe) {
   var opts = [];
-  context.settings({right:false,above:'auto'});
+  context.settings({right:false,above:false});
   if (started && !paused) {
     if (webui !== '' && webui != '#') opts.push({text:_('WebUI'), icon:'fa-globe', action:function(e){e.preventDefault();window.open(webui,'_blank');}});
     if (tswebui !== '' && tswebui != '#') opts.push({text:_('Tailscale WebUI'), icon:'fa-globe', action:function(e){e.preventDefault();window.open(tswebui,'_blank');}});


### PR DESCRIPTION
Revert as browser zoom levels (and mobile) can result in the context menu appearing above with the top items rendered off the screen.

Better to not render the last item(s) by always having the menu appear below than the important ones rendered above and unable to select

https://github.com/unraid/webgui/pull/2074