### PR TITLE
Optimize Docker page performance through algorithmic improvements

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -275,7 +275,8 @@ class DockerTemplates {
 		foreach ($templateList as $templatePath) {
 			$doc = new DOMDocument();
 			if (@$doc->load($templatePath)) {
-				$repository = DockerUtil::ensureImageTag($doc->getElementsByTagName('Repository')->item(0)->nodeValue??'');
+				$repoNode   = $doc->getElementsByTagName('Repository')->item(0);
+				$repository = DockerUtil::ensureImageTag($repoNode ? $repoNode->nodeValue : '');
 				if ($repository) {
 					$repositoryMap[$repository] = $templatePath;
 				}
@@ -298,7 +299,8 @@ class DockerTemplates {
 				}
 			}
 			
-			$TemplateField = $doc->getElementsByTagName($field)->item(0)->nodeValue??'';
+			$node = $doc->getElementsByTagName($field)->item(0);
+			$TemplateField = $node ? trim($node->nodeValue) : '';
 			return trim($TemplateField);
 		}
 		

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -288,9 +288,10 @@ class DockerTemplates {
 	}
 
 	public function getTemplateValue($Repository, $field, $scope='all',$name='') {
+		$cacheKey = $Repository . '|' . realpath($templatePath ?? '');
 		// Check if template is already cached
-		if (isset($this->templateFileCache[$Repository])) {
-			$doc = $this->templateFileCache[$Repository];
+		if (isset($this->templateFileCache[$cacheKey])) {
+			$doc = $this->templateFileCache[$cacheKey];
 			
 			if ($name) {
 				$templateName = @$doc->getElementsByTagName('Name')->item(0)->nodeValue ?? '';
@@ -312,7 +313,7 @@ class DockerTemplates {
 			$doc = new DOMDocument();
 			if (@$doc->load($templatePath)) {
 				// Cache the loaded document for future use
-				$this->templateFileCache[$Repository] = $doc;
+				$this->templateFileCache[$cacheKey] = $doc;
 				
 				if ($name) {
 					$templateName = @$doc->getElementsByTagName('Name')->item(0)->nodeValue ?? '';
@@ -321,7 +322,8 @@ class DockerTemplates {
 					}
 				}
 				
-				$TemplateField = $doc->getElementsByTagName($field)->item(0)->nodeValue??'';
+				$node = $doc->getElementsByTagName($field)->item(0);  
+				$TemplateField = $node ? trim($node->nodeValue) : '';  
 				return trim($TemplateField);
 			}
 		}


### PR DESCRIPTION
- Implement template-file-level caching to eliminate redundant XML parsing
- Add efficient image usage mapping to reduce O(N*M) complexity
- Optimize container fetching with selective batch operations
- In general: Improve Docker management interface loading times

These changes should be especially noticeable if one is using the power save scheduler AND has a lot of orphaned images (cause for this often could be nextcloud-aio or docker compose).
In my test scenario (with about 90 containers, 85 orphaned images and power save scheduler) i was able to reduce page loading from 20 seconds to ~8 seconds. On default scheduler i am still able to reduce load time from 5-6 seconds to about 3 seconds. In my testing DockerContainers.php file processed in 500ms compared to 2.5 seconds (using normal scheduler):
![grafik](https://github.com/user-attachments/assets/dc19083d-27b2-4ea1-b2a1-40a089999ae9)
![grafik](https://github.com/user-attachments/assets/21e84033-4c0b-4a3a-b016-12921f33c4c2)

I started measuring the moment in pressed ctrl+f5 and ended when all containers where showing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Performance Improvements**
  - Enhanced caching for template files and image usage data to reduce redundant processing.
  - Optimized container and image data retrieval, resulting in faster loading times and improved responsiveness when viewing Docker containers and images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210641590776916