### PR TITLE
fix: docker settings page

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
@@ -424,7 +424,6 @@ $port = normalize($network);
 [$range,$size]  = my_explode('/',_var($dockercfg,"DOCKER_RANGE_$port"));
 $disabled       = $subnet ? '':'disabled';
 $dhcpDisabled   = $range ? '':'disabled';
-$hide_eth       = hide_eth($network);
 ?>
 <?if ($protocol[$network] != 'ipv6' && ($network != 'wlan0' || lan_port('wlan0',true) == 1)):?>
 


### PR DESCRIPTION
[https://github.com/unraid/webgui/pull/2235 removed the declartion of the `hide_eth` function](https://github.com/unraid/webgui/pull/2235/files#diff-1430f10b584f6057b6ee106b09cde1ea2ab428423c89aa1a317876b92e755a66L121-L125) but the function was still being used when trying to declare `$hide_eth`, even though `$hide_eth` was not used at all.