### PR TITLE
fix: plugin install filetree scrollbar styles

### DIFF
--- a/emhttp/plugins/dynamix.plugin.manager/PluginInstall.page
+++ b/emhttp/plugins/dynamix.plugin.manager/PluginInstall.page
@@ -75,5 +75,5 @@ Tag="download"
 
 <div class="max-w-20 mx-auto">
   <p><strong>_(Select local plugin file)_</strong></p>
-  <div id="plugin_tree" class="textarea h-50 overflow-y-scroll scrollbar-thin"></div>
+  <div id="plugin_tree" class="textarea h-50 overflow-y-auto"></div>
 </div>


### PR DESCRIPTION
- Changed overflow property of the plugin tree from 'overflow-y-scroll' to 'overflow-y-auto' to enhance the scrolling experience