### PR TITLE
fix: hide empty dt, dd, p tags w/ only hidden inputs

### DIFF
--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1283,6 +1283,7 @@ a.list {
     * Necessary evil to prevent needing to rewrite .page file parsing and allow for a more responsive page.
     */
     dt, dd, p {
+        &:has(input[type="hidden"]:only-child),
         &:empty {
             display: none !important;
             margin: 0 !important;


### PR DESCRIPTION
The markdown parser will wrap random elements based on the whitespacing in a `.page` file. 

With the `dl` elements now with a CSS grid ruleset, these empty `dd` & `dt` tags were creating weird spacing issues.

This additional selector should take care of most of remaining rouge elements.