### PR TITLE
Show logout button on localhost

### DIFF
--- a/emhttp/plugins/dynamix/LogoutButton.page
+++ b/emhttp/plugins/dynamix/LogoutButton.page
@@ -2,7 +2,6 @@ Menu="Buttons:2"
 Title="Logout"
 Icon="icon-u-logout"
 Code="e937"
-Cond="$_SERVER['HTTP_HOST']!='localhost'"
 ---
 <?PHP
 /* Copyright 2005-2023, Lime Technology


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved issue where the logout button was not visible or functional when accessing the application via "localhost." The logout button now appears and works regardless of the host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->