### PR TITLE
fix: remote access via connect config in rc.nginx

### DIFF
--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -28,7 +28,8 @@ LOCATIONS="/etc/nginx/conf.d/locations.conf"
 INI="/var/local/emhttp/nginx.ini.new"
 CERTPATH="$SSL/certs/certificate_bundle.pem"
 TSCERTPATH="$SSL/certs/ts_bundle.pem"
-MYSERVERS="/boot/config/plugins/dynamix.my.servers/myservers.cfg"
+CONNECT_CONFIG="/boot/config/plugins/dynamix.my.servers/configs/connect.json"
+API_UTILS="/usr/local/share/dynamix.unraid.net/scripts/api_utils.sh"
 DEFAULTS="/etc/default/nginx"
 SYSTEM="/sys/class/net"
 SYSLOG="/var/log/syslog"
@@ -73,6 +74,23 @@ fi
 
 fqdn(){
   echo ${CERTNAME/'*'/${1//[.:]/-}}
+}
+
+# check if remote access should be enabled
+check_remote_access(){
+  # Check if connect plugin is enabled using api_utils.sh
+  if [[ -f $API_UTILS ]] && $API_UTILS is_api_plugin_enabled "unraid-api-plugin-connect"; then
+    # Plugin is enabled, check connect.json configuration
+    if [[ -f $CONNECT_CONFIG ]] && command -v jq >/dev/null 2>&1; then
+      local wanaccess=$(jq -r '.wanaccess' "$CONNECT_CONFIG" 2>/dev/null)
+      local username=$(jq -r '.username' "$CONNECT_CONFIG" 2>/dev/null)
+      # Enable remote access if wanaccess is true and username is not empty
+      if [[ $wanaccess == "true" && -n $username && $username != "null" ]]; then
+        return 0
+      fi
+    fi
+  fi
+  return 1
 }
 
 # create listening ports
@@ -568,7 +586,7 @@ build_ssl(){
     # define CSP frame-ancestors for cert
     CERTFA="https://*.${CERTNAME#*.}/"
     # check if Remote Access is enabled and fetch WANIP
-    if [[ -L /usr/local/sbin/unraid-api ]] && grep -qs 'wanaccess="yes"' $MYSERVERS && ! grep -qs 'username=""' $MYSERVERS; then
+    if [[ -L /usr/local/sbin/unraid-api ]] && check_remote_access; then
       WANACCESS=yes
       WANIP=$(curl https://wanip4.unraid.net/ 2>/dev/null)
       WANIP6=$(curl https://wanip6.unraid.net/ 2>/dev/null)
@@ -662,10 +680,10 @@ build_ssl(){
   # defined if ts_bundle.pem present:
   echo "NGINX_TAILSCALEFQDN=\"$TSFQDN\"" >>$INI
   # add included interfaces
-  for NET in ${!NET_FQDN[@]}; do
+  for NET in "${!NET_FQDN[@]}"; do
     echo "NGINX_${NET^^}FQDN=\"${NET_FQDN[$NET]}\"" >>$INI
   done
-  for NET in ${!NET_FQDN6[@]}; do
+  for NET in "${!NET_FQDN6[@]}"; do
     echo "NGINX_${NET^^}FQDN6=\"${NET_FQDN6[$NET]}\"" >>$INI
   done
   # atomically update file


### PR DESCRIPTION
Detect whether Connect is installed using the `$API_UTILS` script.

If installed, read pertinent config from the corresponding `connect.json` file instead of the deprecated `myservers.cfg`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of remote access status by using the Unraid Connect plugin's configuration for more accurate results.
  - Enhanced handling of network names with special characters or spaces.

- **Chores**
  - Updated internal configuration sources for remote access checks to use modern plugin settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->