### PR TITLE
fix: ui-dialog min and max sizes

### DIFF
--- a/emhttp/plugins/dynamix/styles/default-dynamix.css
+++ b/emhttp/plugins/dynamix/styles/default-dynamix.css
@@ -1465,7 +1465,8 @@ div.icon-zip {
     left: 50% !important;
     transform: translate(-50%, -50%) !important;
     box-sizing: border-box;
-    min-width: 95vw;
+    width: 100% !important;
+    max-width: 100rem;
 
     * {
         box-sizing: border-box;
@@ -1476,7 +1477,8 @@ div.icon-zip {
         flex-direction: column;
         align-items: center;
         height: auto !important;
-        max-height: 70vh;
+        min-height: 35vh !important;
+        max-height: 70vh !important;
         overflow-y: auto;
         padding-top: 2rem;
         padding-bottom: 2rem;


### PR DESCRIPTION
- Set width to 100% and max-width to 100rem for better layout control.
- Adjusted min-height to 35vh while maintaining max-height at 70vh for enhanced flexibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated dialog appearance to use a fixed width and set new minimum and maximum height constraints for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->