### PR TITLE
style: enable horizontal scrolling for legacy content

### DIFF
--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1294,6 +1294,7 @@ a.list {
     position: relative;
     width: 100%;
     box-sizing: border-box;
+    overflow-x: auto; /* Allows unresponsive set width legacy content to scroll horizontally as needed. */
 
     /**
     * Force remove any small empty space elements.


### PR DESCRIPTION
- Added `overflow-x: auto;` to allow unresponsive set width legacy content to scroll horizontally as needed in default-base.css.