### PR TITLE
feat: vm responsive layout fallback

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/include/VMedit.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/VMedit.php
@@ -105,12 +105,25 @@ if (strpos($strSelectedTemplate,"User-") !== false) {
 <link type="text/css" rel="stylesheet" href="<?autov('/plugins/dynamix.vm.manager/styles/dynamix.vm.manager.css')?>">
 <link type="text/css" rel="stylesheet" href="<?autov('/plugins/dynamix.vm.manager/styles/edit.css')?>">
 
-<span class="status advancedview_panel"><input type="checkbox" class="inlineview"><input type="checkbox" class="advancedview"></span>
-<div class="domain">
+<div class="Content--non-responsive domain">
 	<form id="vmform" method="POST">
 	<input type="hidden" name="domain[type]" value="kvm" />
 	<input type="hidden" name="template[name]" value="<?=htmlspecialchars($strSelectedTemplateUT)?>" />
 	<input type="hidden" name="template[iconold]" value="<?=htmlspecialchars($arrLoad['icon'])?>" />
+
+	<table>
+		<tbody>
+			<tr>
+				<td>&nbsp;</td>
+				<td>
+					<span class="status advancedview_panel">
+						<input type="checkbox" class="inlineview">
+						<input type="checkbox" class="advancedview">
+					</span>
+				</td>
+			</tr>
+		</tbody>
+	</table>
 
 	<table>
 		<tr>

--- a/emhttp/plugins/dynamix.vm.manager/styles/edit.css
+++ b/emhttp/plugins/dynamix.vm.manager/styles/edit.css
@@ -65,6 +65,7 @@ body {
 
 #vmform .multiple {
     position: relative;
+    margin-bottom: 2rem;
 }
 #vmform .sectionbutton {
     position: absolute;

--- a/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -492,7 +492,7 @@ const displayOptions = <?= json_encode($arrDisplayOptions, JSON_HEX_TAG | JSON_H
 	<tr class="advanced">
 		<td><span class="advanced">_(CPU)_ </span>_(Mode)_:</td>
 		<td>
-			<span class="width"><select id="cpu" name="domain[cpumode]" class="cpu narrow">
+			<span class="width"><select id="cpu" name="domain[cpumode]" class="cpu">
 			<?mk_dropdown_options(['host-passthrough' => _('Host Passthrough').' ('.$strCPUModel.')', 'custom' => _('Emulated').' ('._('QEMU64').')'], $arrConfig['domain']['cpumode']);?>
 			</select></span>
 			<span class="advanced label <?=$migratehidden?>" id="domain_cpumigrate_text">_(Migratable)_:</span>

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1312,6 +1312,11 @@ a.list {
     }
 }
 
+/* Necessary evil to prevent rewrites of complex page templates for responsive layout - i.e. VMedit.php */
+.Content--non-responsive {
+    min-width: 1200px;
+}
+
 .tabs {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Because the VMEdit.php template is custom and doesn't match the dev style of `*.page` files, this makes a refactor for a completely responsive layout extremely difficult and prone to errors.

So a solution, that could easily be used by other templates (especially by plugin authors), is to wrap their content w/ a `Content--non-responsive` class. And this will add a min-width of 1200px, which matches the legacy non-responsve webgui width.

- This PR includes that CSS class on the main wrapper of the VMEdit.php parent wrapper element.
- fix: vm edit cpu width