### PR TITLE
feat: add exception handling and reload active key after installation

### DIFF
--- a/emhttp/plugins/dynamix/scripts/install_key
+++ b/emhttp/plugins/dynamix/scripts/install_key
@@ -34,6 +34,7 @@ if (in_array($host,['keys.lime-technology.com','lime-technology.com'])) {
   write("Downloading $keyfile ...\n");
   exec("/usr/bin/wget -q -O ".escapeshellarg("/boot/config/$key_file")." ".escapeshellarg($url), $output, $return_var);
   if ($return_var === 0) {
+    exec("emcmd \"checkRegistration=Apply\"");
     if (parse_ini_file('/var/local/emhttp/var.ini')['mdState'] == 'STARTED') {
       write("Installing ... Please Stop array to complete key installation.\n");
     } else {


### PR DESCRIPTION
- Wrap `installKey` method in `try-catch` for better error handling
- Execute `emcmd "checkRegistration=Apply"` after successful key download
- Add error response for installation failures
- Apply changes to both PHP class and shell script