### PR TITLE
Chore: Disallow theme engine (and predecessor dark theme) installations

### DIFF
--- a/etc/rc.d/rc.local
+++ b/etc/rc.d/rc.local
@@ -95,7 +95,7 @@ rm -f /boot/plugins/unRAIDServer.plg
 rm -f $CONFIG/plugins/unRAIDServer.plg
 
 # These plugins are now integrated in the OS or obsolete and may interfere
-OBSOLETE="vfio.pci dynamix.wireguard dynamix.ssd.trim dynamix.file.manager gui.search unlimited-width proxy.editor unraid.patch AAA-UnraidPatch-BootLoader-DO_NOT_DELETE"
+OBSOLETE="vfio.pci dynamix.wireguard dynamix.ssd.trim dynamix.file.manager gui.search unlimited-width proxy.editor unraid.patch AAA-UnraidPatch-BootLoader-DO_NOT_DELETE theme.engine dark.theme"
 QUIET="unraid.patch AAA-UnraidPatch-BootLoader-DO_NOT_DELETE"
 
 for PLUGIN in $OBSOLETE; do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the list of obsolete plugins to include `theme.engine` and `dark.theme` for removal or relocation during system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->