### PR TITLE
fix: do not run crowdin workflow on forked repos

### DIFF
--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -10,6 +10,7 @@ on:
 jobs:
     extract-and-upload:
         runs-on: ubuntu-latest
+        if: github.repository == 'unraid/webgui'
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to ensure certain automation tasks only run for the intended repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->