### PR TITLE
Fix: Remote view and RDP if no user shares are set.

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/include/VMajax.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/VMajax.php
@@ -20,9 +20,8 @@ require_once "$docroot/plugins/dynamix.vm.manager/include/libvirt_helpers.php";
 $_SERVER['REQUEST_URI'] = 'vms';
 require_once "$docroot/webGui/include/Translations.php";
 
-if (preg_match('#^(.*?/system/)#', $domain_cfg['IMAGE_FILE'], $matches)) {
-    $domain_system_path = $matches[1];
-}
+$domain_system_path = $domain_cfg['IMAGE_FILE'] ?? "/mnt/user/system/";
+if (is_file($domain_system_path)) $domain_system_path = pathinfo($domain_system_path,PATHINFO_DIRNAME)."/";
 
 function requireLibvirt() {
 	global $lv;


### PR DESCRIPTION
If system is set with no user shares. For VMs the remote view and rdp options fail. This PR resolve the issue,

<img width="747" height="471" alt="image" src="https://github.com/user-attachments/assets/a434a180-d5bc-4b27-9b46-5f633b0d6303" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of remote viewer file paths to ensure compatibility with custom system directory configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->