### PR TITLE
refactor: use shared nchan publish function

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/scripts/container_size
+++ b/emhttp/plugins/dynamix.docker.manager/scripts/container_size
@@ -14,6 +14,7 @@
 <?
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/Wrappers.php";
+require_once "$docroot/webGui/include/publish.php";
 extract(parse_plugin_cfg('dynamix',true));
 
 // add translations
@@ -25,18 +26,9 @@ $units = ['B','kB','MB','GB','TB','PB','EB','ZB','YB'];
 $list = [];
 
 function write(...$messages){
-  $com = curl_init();
-  curl_setopt_array($com,[
-    CURLOPT_URL => 'http://localhost/pub/plugins?buffer_length=1',
-    CURLOPT_UNIX_SOCKET_PATH => '/var/run/nginx.socket',
-    CURLOPT_POST => 1,
-    CURLOPT_RETURNTRANSFER => true
-  ]);
   foreach ($messages as $message) {
-    curl_setopt($com, CURLOPT_POSTFIELDS, $message);
-    curl_exec($com);
+    publish('plugins', $message);
   }
-  curl_close($com);
 }
 function autoscale($value) {
   global $units;

--- a/emhttp/plugins/dynamix.docker.manager/scripts/update_container
+++ b/emhttp/plugins/dynamix.docker.manager/scripts/update_container
@@ -20,6 +20,7 @@ extract(parse_plugin_cfg('dynamix',true));
 $_SERVER['REQUEST_URI'] = '';
 $login_locale = _var($display,'locale');
 require_once "$docroot/plugins/dynamix.docker.manager/include/DockerClient.php";
+require_once "$docroot/webGui/include/publish.php";
 
 $var = parse_ini_file('/var/local/emhttp/var.ini');
 $DockerClient = new DockerClient();
@@ -31,18 +32,9 @@ $subnet = DockerUtil::network($custom);
 $cpus   = DockerUtil::cpus();
 
 function write(...$messages){
-  $com = curl_init();
-  curl_setopt_array($com,[
-    CURLOPT_URL => 'http://localhost/pub/docker?buffer_length=1',
-    CURLOPT_UNIX_SOCKET_PATH => '/var/run/nginx.socket',
-    CURLOPT_POST => 1,
-    CURLOPT_RETURNTRANSFER => true
-  ]);
   foreach ($messages as $message) {
-    curl_setopt($com, CURLOPT_POSTFIELDS, $message);
-    curl_exec($com);
+    publish('docker', $message);
   }
-  curl_close($com);
 }
 function stopContainer_nchan($name) {
   global $DockerClient;

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/checkall
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/checkall
@@ -20,24 +20,16 @@ extract(parse_plugin_cfg('dynamix',true));
 $_SERVER['REQUEST_URI'] = 'plugins';
 $login_locale = _var($display,'locale');
 require_once "$docroot/webGui/include/Translations.php";
+require_once "$docroot/webGui/include/publish.php";
 
 $nchan = $argv[$argc-1] == 'nchan'; // console or nchan output
 
 function write(...$messages){
   global $nchan;
   if ($nchan) {
-    $com = curl_init();
-    curl_setopt_array($com,[
-      CURLOPT_URL => 'http://localhost/pub/plugins?buffer_length=1',
-      CURLOPT_UNIX_SOCKET_PATH => '/var/run/nginx.socket',
-      CURLOPT_POST => 1,
-      CURLOPT_RETURNTRANSFER => true
-    ]);
     foreach ($messages as $message) {
-      curl_setopt($com, CURLOPT_POSTFIELDS, $message);
-      curl_exec($com);
+      publish('plugins', $message);
     }
-    curl_close($com);
   } else {
     foreach ($messages as $message) echo $message;
   }

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/language
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/language
@@ -8,6 +8,7 @@
 
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/Wrappers.php";
+require_once "$docroot/webGui/include/publish.php";
 $logger = 'language-manager';
 
 $usage = <<<EOF
@@ -69,18 +70,9 @@ function done($code) {
 function write(...$messages){
   global $nchan;
   if ($nchan) {
-    $com = curl_init();
-    curl_setopt_array($com,[
-      CURLOPT_URL => 'http://localhost/pub/plugins?buffer_length=1',
-      CURLOPT_UNIX_SOCKET_PATH => '/var/run/nginx.socket',
-      CURLOPT_POST => 1,
-      CURLOPT_RETURNTRANSFER => true
-    ]);
     foreach ($messages as $message) {
-      curl_setopt($com, CURLOPT_POSTFIELDS, $message);
-      curl_exec($com);
+      publish('plugins', $message);
     }
-    curl_close($com);
   } else {
     foreach ($messages as $message) echo $message;
   }

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/multiplugin
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/multiplugin
@@ -12,6 +12,9 @@
  */
 ?>
 <?
+$docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
+require_once "$docroot/webGui/include/publish.php";
+
 $method  = $argv[1]??'';
 $plugins = explode('*',$argv[2]??'');
 $nchan   = $argv[$argc-1] == 'nchan'; // console or nchan output
@@ -20,18 +23,9 @@ $call    = ['plg' => 'plugin', 'xml' => 'language', '' => 'language'];
 function write(...$messages){
   global $nchan;
   if ($nchan) {
-    $com = curl_init();
-    curl_setopt_array($com,[
-      CURLOPT_URL => 'http://localhost/pub/plugins?buffer_length=1',
-      CURLOPT_UNIX_SOCKET_PATH => '/var/run/nginx.socket',
-      CURLOPT_POST => 1,
-      CURLOPT_RETURNTRANSFER => true
-    ]);
     foreach ($messages as $message) {
-      curl_setopt($com, CURLOPT_POSTFIELDS, $message);
-      curl_exec($com);
+      publish('plugins', $message);
     }
-    curl_close($com);
   } else {
     foreach ($messages as $message) echo $message;
   }

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
@@ -8,6 +8,7 @@
 
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/Wrappers.php";
+require_once "$docroot/webGui/include/publish.php";
 $logger = 'plugin-manager';
 
 $usage = <<<EOF
@@ -180,18 +181,9 @@ function done($code) {
 function write(...$messages){
   global $nchan;
   if ($nchan) {
-    $com = curl_init();
-    curl_setopt_array($com,[
-      CURLOPT_URL => 'http://localhost/pub/plugins?buffer_length=1',
-      CURLOPT_UNIX_SOCKET_PATH => '/var/run/nginx.socket',
-      CURLOPT_POST => 1,
-      CURLOPT_RETURNTRANSFER => true
-    ]);
     foreach ($messages as $message) {
-      curl_setopt($com, CURLOPT_POSTFIELDS, $message);
-      curl_exec($com);
+      publish('plugins', $message);
     }
-    curl_close($com);
   } else {
     foreach ($messages as $message) echo $message;
   }

--- a/emhttp/plugins/dynamix.vm.manager/scripts/VMAjaxCall.php
+++ b/emhttp/plugins/dynamix.vm.manager/scripts/VMAjaxCall.php
@@ -21,20 +21,12 @@ require_once "$docroot/plugins/dynamix.docker.manager/include/DockerClient.php";
 $_SERVER['REQUEST_URI'] = '';
 $login_locale = _var($display,'locale');
 require_once "$docroot/webGui/include/Translations.php";
+require_once "$docroot/webGui/include/publish.php";
 
 function write(...$messages) {
-  $com = curl_init();
-  curl_setopt_array($com,[
-    CURLOPT_URL => 'http://localhost/pub/vmaction?buffer_length=1',
-    CURLOPT_UNIX_SOCKET_PATH => '/var/run/nginx.socket',
-    CURLOPT_POST => 1,
-    CURLOPT_RETURNTRANSFER => true
-  ]);
   foreach ($messages as $message) {
-    curl_setopt($com, CURLOPT_POSTFIELDS, $message);
-    curl_exec($com);
+    publish('vmaction', $message);
   }
-  curl_close($com);
 }
 
 function execCommand_nchan($command,$idx) {

--- a/emhttp/plugins/dynamix.vm.manager/scripts/VMClone.php
+++ b/emhttp/plugins/dynamix.vm.manager/scripts/VMClone.php
@@ -21,20 +21,12 @@ require_once "$docroot/plugins/dynamix.vm.manager/include/libvirt_helpers.php";
 $_SERVER['REQUEST_URI'] = '';
 $login_locale = _var($display,'locale');
 require_once "$docroot/webGui/include/Translations.php";
+require_once "$docroot/webGui/include/publish.php";
 
 function write(...$messages) {
-  $com = curl_init();
-  curl_setopt_array($com,[
-    CURLOPT_URL => 'http://localhost/pub/vmaction?buffer_length=1',
-    CURLOPT_UNIX_SOCKET_PATH => '/var/run/nginx.socket',
-    CURLOPT_POST => 1,
-    CURLOPT_RETURNTRANSFER => true
-  ]);
   foreach ($messages as $message) {
-    curl_setopt($com, CURLOPT_POSTFIELDS, $message);
-    curl_exec($com);
+    publish('vmaction', $message);
   }
-  curl_close($com);
 }
 
 function execCommand_nchan_clone($command,$idx,$refcmd=false) {

--- a/emhttp/plugins/dynamix/scripts/install_key
+++ b/emhttp/plugins/dynamix/scripts/install_key
@@ -11,19 +11,13 @@
  */
 ?>
 <?
+$docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
+require_once "$docroot/webGui/include/publish.php";
+
 function write(...$messages){
-  $com = curl_init();
-  curl_setopt_array($com,[
-    CURLOPT_URL => 'http://localhost/pub/plugins?buffer_length=1',
-    CURLOPT_UNIX_SOCKET_PATH => '/var/run/nginx.socket',
-    CURLOPT_POST => 1,
-    CURLOPT_RETURNTRANSFER => true
-  ]);
   foreach ($messages as $message) {
-    curl_setopt($com, CURLOPT_POSTFIELDS, $message);
-    curl_exec($com);
+    publish('plugins', $message);
   }
-  curl_close($com);
 }
 
 $url = rawurldecode($argv[1]??'');

--- a/emhttp/plugins/dynamix/scripts/newperms
+++ b/emhttp/plugins/dynamix/scripts/newperms
@@ -17,24 +17,18 @@
 #  u-x     Clear the 'x' bit in the user permissions (leaves rw as-is)
 #  go+u    Copy the user permissions to group and other
 
+$docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 $nchan = $argv[$argc-1] == 'nchan'; // console or nchan output
 if ($nchan) unset($argv[$argc-1]);  // remove nchan parameter
+
+require_once "$docroot/webGui/include/publish.php";
 
 function write(...$messages){
   global $nchan;
   if ($nchan) {
-    $com = curl_init();
-    curl_setopt_array($com,[
-      CURLOPT_URL => 'http://localhost/pub/plugins?buffer_length=1',
-      CURLOPT_UNIX_SOCKET_PATH => '/var/run/nginx.socket',
-      CURLOPT_POST => 1,
-      CURLOPT_RETURNTRANSFER => true
-    ]);
     foreach ($messages as $message) {
-      curl_setopt($com, CURLOPT_POSTFIELDS, $message);
-      curl_exec($com);
+      publish('plugins', $message);
     }
-    curl_close($com);
   } else {
     foreach ($messages as $message) echo $message;
   }

--- a/emhttp/plugins/dynamix/scripts/ssd_trim
+++ b/emhttp/plugins/dynamix/scripts/ssd_trim
@@ -29,20 +29,12 @@ if ($argc==2 && $argv[1]=='cron') {
 $_SERVER['REQUEST_URI'] = 'settings';
 $login_locale = _var($display,'locale');
 require_once "$docroot/webGui/include/Translations.php";
+require_once "$docroot/webGui/include/publish.php";
 
 function write(...$messages){
-  $com = curl_init();
-  curl_setopt_array($com,[
-    CURLOPT_URL => 'http://localhost/pub/plugins?buffer_length=1',
-    CURLOPT_UNIX_SOCKET_PATH => '/var/run/nginx.socket',
-    CURLOPT_POST => 1,
-    CURLOPT_RETURNTRANSFER => true
-  ]);
   foreach ($messages as $message) {
-    curl_setopt($com, CURLOPT_POSTFIELDS, $message);
-    curl_exec($com);
+    publish('plugins', $message);
   }
-  curl_close($com);
 }
 
 /*  Check if the disk is an HDD based on rotational flag */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined message publishing across multiple scripts by replacing manual HTTP POST requests with a unified publish mechanism. This results in more efficient and maintainable message handling for plugin and VM operations.
* **Chores**
  * Updated scripts to include a shared publish module, improving internal consistency and reducing code duplication. No changes to user-facing functionality or command outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->