### PR TITLE
refactor: simplify SSO token validation in login process

### DIFF
--- a/emhttp/plugins/dynamix/include/.login.php
+++ b/emhttp/plugins/dynamix/include/.login.php
@@ -1,7 +1,4 @@
 <?php
-// Included in login.php
-
-require_once "$docroot/plugins/dynamix.my.servers/include/state.php";
 
 // Only start a session to check if they have a cookie that looks like our session
 $server_name = strtok($_SERVER['HTTP_HOST'], ":");
@@ -102,9 +99,8 @@ function verifyUsernamePassword(string $username, string $password): bool
         return true;
     }
 
-    $serverState = new ServerState();
-    // We may have an SSO token - check if SSO is enabled and then validate the token
-    if ($serverState->ssoEnabled && strlen($password) > 500) {
+    // We may have an SSO token - validate it
+    if (strlen($password) > 500) {
         if (!preg_match('/^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/', $password)) {
             my_logger("SSO Login Attempt Failed: Invalid token format");
             return false;


### PR DESCRIPTION
This removes the check to see if SSO Enabled is set, as we can simply validate the token if it is a valid oauth2 token and the API will reject it if it is not valid. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the process for validating SSO tokens during login, removing some internal checks. No changes to the login flow are visible to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->