### PR TITLE
fix: wg0 hide keys by default

### DIFF
--- a/emhttp/plugins/dynamix/WG0.page
+++ b/emhttp/plugins/dynamix/WG0.page
@@ -1281,7 +1281,7 @@ _(Local name)_:
 
 :wg_local_name_help:
 
-<div markdown="1" class="keys wg0 key0" style="<?= isset($wgX['PublicKey:0']) ? 'display:none' : '' ?>">
+<div markdown="1" class="keys wg0 key0" style="<?= isset($wg0['PublicKey:0']) ? 'display:none' : '' ?>">
 _(Local private key)_:
 : <input type="text" name="PrivateKey:0" class="wide private-0" maxlength="64" value="<?=_var($wg0,'PrivateKey:0')?>" onchange="highlight($(document.wg0),this,0)" placeholder="(_(mandatory)_)" required>
   <span class="inline-block">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an issue affecting the display of the local private key input for the wg0 tunnel, ensuring it is shown or hidden appropriately based on the presence of the local public key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->