### PR TITLE
fix: docker containers table basic & advanced toggle

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/Docker.page
+++ b/emhttp/plugins/dynamix.docker.manager/Docker.page
@@ -3,6 +3,7 @@ Type="xmenu"
 Code="e90b"
 Lock="true"
 Cond="exec(\"grep -o '^DOCKER_ENABLED=.yes' /boot/config/docker.cfg 2>/dev/null\")"
+Tabs="false"
 ---
 <?PHP
 /* Copyright 2005-2023, Lime Technology

--- a/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
@@ -4,6 +4,7 @@ Tag="cubes"
 Cond="is_file('/var/run/dockerd.pid')"
 Markdown="false"
 Nchan="docker_load:stop"
+Tabs="false"
 ---
 <?PHP
 /* Copyright 2005-2023, Lime Technology
@@ -207,7 +208,7 @@ dockerload.on('message', function(msg){
   }
 });
 $(function() {
-  $(".tabs").append('<span class="status"><span><input type="checkbox" class="advancedview"></span></span>');
+  $(".title .right").append('<span class="status"><span><input type="checkbox" class="advancedview"></span></span>');
   $('.advancedview').switchButton({labels_placement:'left', on_label:"_(Advanced View)_", off_label:"_(Basic View)_", checked:$.cookie('docker_listview_mode')=='advanced'});
   $('.advancedview').change(function(){
     $('.advanced').toggle('slow');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Disabled tab display in the Docker and Docker Containers pages for a cleaner interface.
  * Moved the advanced view toggle to a more accessible location within the page header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->