### PR TITLE
Fix: Prevent nchan scripts from spawning

### DIFF
--- a/emhttp/plugins/dynamix/include/DefaultPageLayout.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout.php
@@ -63,18 +63,17 @@ if (count($pages)) {
     $running = file_exists($nchan_pid) ? file($nchan_pid, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) : [];
     $start   = array_diff($nchan, $running);  // returns any new scripts to be started
     $running = array_merge($start, $running); // update list of current running nchan scripts
-    // start nchan scripts which are new or have been stopped
-    foreach ($running as $row) {
-        $script = explode(':', $row, 2)[0];
-        $output = [];
-        exec('pgrep --ns $$ -f ' . escapeshellarg("$docroot/$script"),$output,$retval);
-        if ($retval !== 0) { // 0=found; 1=none; 2=error
-            exec(escapeshellarg("$docroot/$script") . ' >/dev/null 2>&1 &');
-        }
-    }
-
+    // start nchan scripts which are new or have been terminated but still should be running
     if (count($running)) {
         file_put_contents_atomic($nchan_pid, implode("\n", $running) . "\n");
+        foreach ($running as $row) {
+            $script = explode(':', $row, 2)[0];
+            $output = [];
+            exec('pgrep --ns $$ -f ' . escapeshellarg("$docroot/$script"),$output,$retval);
+            if ($retval !== 0) { // 0=found; 1=none; 2=error
+                exec(escapeshellarg("$docroot/$script") . ' >/dev/null 2>&1 &');
+            }
+        }
     } else {
         @unlink($nchan_pid);
     }

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout.php
@@ -62,13 +62,9 @@ foreach ($allPages as $page) {
 if (count($pages)) {
     $running = file_exists($nchan_pid) ? file($nchan_pid, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) : [];
     $start   = array_diff($nchan, $running);  // returns any new scripts to be started
-    $stop    = array_diff($running, $nchan);  // returns any old scripts to be stopped
     $running = array_merge($start, $running); // update list of current running nchan scripts
     // start nchan scripts which are new or have been stopped
     foreach ($running as $row) {
-        if (in_array($row, $stop, true)) {
-            continue;
-        }
         $script = explode(':', $row, 2)[0];
         $output = [];
         exec('pgrep --ns $$ -f ' . escapeshellarg("$docroot/$script"),$output,$retval);
@@ -77,14 +73,6 @@ if (count($pages)) {
         }
     }
 
-    // stop nchan scripts with the :stop option 
-    foreach ($stop as $row) {
-        [$script, $opt] = my_explode(':', $row);
-        if ($opt == 'stop') {
-            exec('pkill --ns $$ -f '.escapeshellarg($docroot.'/'.$script).' &>/dev/null &');
-            array_splice($running, array_search($row, $running), 1);
-        }
-    }
     if (count($running)) {
         file_put_contents_atomic($nchan_pid, implode("\n", $running) . "\n");
     } else {


### PR DESCRIPTION
Also, if a script is listed as it is supposed to be running and it isn't, then restart it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable background-script management: validates actual processes, (re)starts missing scripts, and keeps runtime state aligned with active processes; no implicit stop handling.
  * Ensures pid/state info is removed when no scripts remain.

* **Chores**
  * Safer, atomic runtime-state updates and hardened shell interactions for improved stability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->