### PR TITLE
style: remove unnecessary margins abort process notice

### DIFF
--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1854,8 +1854,6 @@ span.strong.tour {
 i.abortOps {
     font-size: 2rem;
     float: right;
-    margin-right: 20px;
-    margin-top: 8px;
     cursor: pointer;
 }
 pre#swalbody p {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined visual spacing for the Abort Operations control, removing excess margins to produce cleaner alignment with surrounding elements.
  * Improves visual consistency across pages and reduces unnecessary whitespace without affecting functionality or interactions.
  * Users may notice a closer placement to adjacent controls and a more compact layout in affected sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->