### PR TITLE
fix: update swal input visibility logic

### DIFF
--- a/emhttp/plugins/dynamix/styles/jquery.sweetalert.css
+++ b/emhttp/plugins/dynamix/styles/jquery.sweetalert.css
@@ -178,11 +178,6 @@ pre#swaltext {
     }
   }
 
-  /* this is a hack to prevent the default SWAL input from being shown, but allow the ones we want to be show */
-  input[type="text"]:not(.swal-input-show) {
-    display: none;
-  }
-
   input:focus {
     outline: none;
     box-shadow: 0px 0px 3px #c4e6f5;
@@ -482,6 +477,11 @@ pre#swaltext {
   pre#swaltext {
     font-size: 1.2rem;
   }
+}
+
+/* this is a hack to prevent the default SWAL input from being shown unless the class show-input is present on the swal or the swal-input-show class is present on the input */
+.sweet-alert:not(.show-input) input[type="text"]:not(.swal-input-show) {
+  display: none;
 }
 
 /* Typography */


### PR DESCRIPTION
- Modified CSS in jquery.sweetalert.css to refine the visibility of the default SweetAlert input fields. The new rule ensures that inputs are hidden unless the class 'show-input' is present on the alert or 'swal-input-show' is applied to the input itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where text input fields across the UI could be hidden unintentionally. Input visibility is now correctly scoped to SweetAlert dialogs.
  * Within SweetAlert, inputs remain hidden by default unless the dialog has the show-input class or the input has swal-input-show, ensuring consistent behavior.

* **Style**
  * Refined CSS rules to limit input-hiding behavior to SweetAlert components, preventing unintended side effects elsewhere in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->