### PR TITLE
Chore: Disallow old versions of Date & Time from installing

### DIFF
--- a/etc/rc.d/rc.local
+++ b/etc/rc.d/rc.local
@@ -174,6 +174,8 @@ obsolete "ZFS-companion" "2021.08.24"
 obsolete "folder.view" "2024.10.02"
 # Unraid Connect - requires version "2025.07.15.1837" or higher
 obsolete "dynamix.unraid.net" "2025.07.15.1836"
+# Dynamix Date & Time - Removes options from Settings - Date Time settings block everything older than 2025.08.01 (current 2023.10.28)
+obsolete "dynamix.date.time" "2025.08.01"
 
 # If "unraidsafemode" indicated, skip installing extra packages and plugins
 if [[ -f /boot/unraidsafemode ]] || grep -wq unraidsafemode /proc/cmdline; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Marked older versions of the “Dynamix Date & Time” plugin (<= 2025.08.01) as obsolete. On startup, affected systems will have the plugin disabled and moved to the error area, with a notification displayed. Update to a newer version or remove it to restore normal operation. No other behavioral changes for unaffected plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->