### PR TITLE
Dashboard: fix network speed calculation

### DIFF
--- a/emhttp/plugins/dynamix/nchan/update_3
+++ b/emhttp/plugins/dynamix/nchan/update_3
@@ -161,7 +161,8 @@ while (true) {
 
   publish_noDupe('update3',json_encode($echo));
   ping('dashboardPing');
-  
+
   sleep(1);
+  $time0 = $time1;
   $time1 = microtime(true);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected per-update timing to compute accurate interval deltas.
  * Network RX/TX speeds now display true real-time rates instead of startup-based values.
  * Removes spurious zero/placeholder readings on the first update for more consistent output.
  * Improves stability of displayed throughput across consecutive updates without changing layout or data fields.
  * Results in smoother, more reliable dashboard/network statistics visible to end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->