### PR TITLE
fix: removed unused notifications settings fields

### DIFF
--- a/emhttp/plugins/dynamix/Notifications.page
+++ b/emhttp/plugins/dynamix/Notifications.page
@@ -112,14 +112,6 @@ $(function(){
 <input type="hidden" name="language_notify">
 <input type="hidden" name="report">
 
-_(Notifications display)_:
-: <select name="display">
-  <?=mk_option($notify['display'], "0", _("Detailed"))?>
-  <?=mk_option($notify['display'], "1", _("Summarized"))?>
-  </select>
-
-:notifications_display_help:
-
 _(Display position)_:
 : <select name="position">
   <?=mk_option($notify['position'], "top-left", _("top-left"))?>

--- a/emhttp/plugins/dynamix/Notifications.page
+++ b/emhttp/plugins/dynamix/Notifications.page
@@ -123,12 +123,6 @@ _(Display position)_:
 
 :notifications_display_position_help:
 
-_(Auto-close)_ (_(seconds)_):
-: <input type="number" name="life" min="0" max="60" value="<?=$notify['life']?>">
-  <span class="input-instructions">_(a value of zero means no automatic closure)_</span>
-
-:notifications_auto_close_help:
-
 _(Date format)_:
 : <select name="date">
   <?=mk_option($notify['date'], "d-m-Y", _("DD-MM-YYYY"))?>

--- a/emhttp/plugins/dynamix/default.cfg
+++ b/emhttp/plugins/dynamix/default.cfg
@@ -45,8 +45,6 @@ day="0"
 cron=""
 write="NOCORRECT"
 [notify]
-display="0"
-life="5"
 date="d-m-Y"
 time="H:i"
 position="top-right"

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/Favicon.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/Favicon.php
@@ -1,5 +1,4 @@
-<link type="image/png" rel="shortcut icon" href="/webGui/images/<?= _var($var, 'mdColor', 'red-on') ?>.png">
-<link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
+<link type="image/png" rel="icon" href="/webGui/images/<?= _var($var, 'mdColor', 'red-on') ?>.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
 <meta name="apple-mobile-web-app-title" content="<?= _var($var, 'NAME') ?>" />
 <link rel="manifest" href="/manifest.json" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Notifications settings by removing options for display mode, position, auto-close duration, date/time formats, storage path, and several update/status toggles, resulting in a cleaner, simpler page.
* **Style**
  * Modernized favicon handling for better browser compatibility by consolidating to a single PNG icon with an updated relation attribute.
* **Chores**
  * Aligned default notification configuration with the simplified Notifications settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->