### PR TITLE
Fix Docker Advanced View not saving if Compose plugin installed

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
@@ -213,7 +213,7 @@ $(function() {
   $('.advancedview').change(function(){
     $('.advanced').toggle('slow');
     $('.basic').toggle('slow');
-    $.cookie('docker_listview_mode',$('.advancedview').is(':checked')?'advanced':'basic',{expires:3650});
+    $.cookie('docker_listview_mode',$(this).is(':checked')?'advanced':'basic',{expires:3650});
     listview();
   });
   $.removeCookie('lockbutton');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Advanced/Basic view toggle now reliably remembers your preference across sessions.
  * Improved consistency when switching between Advanced and Basic views in the Docker containers page, reducing instances where the selected view did not persist or reflect correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->