### PR TITLE
fix: clone-settings overlapping share prev/next btns

### DIFF
--- a/emhttp/plugins/dynamix/SecurityNFS.page
+++ b/emhttp/plugins/dynamix/SecurityNFS.page
@@ -22,7 +22,7 @@ $sec_nfs[$name]['hostList']	= str_replace(" ", "\n", $sec_nfs[$name]['hostList']
 :nfs_security_help:
 
 <div markdown="1" class="relative">
-<div markdown="1" class="clone-settings clone-settings-less-padding shade">
+<div markdown="1" class="clone-settings shade">
 _(Read settings from)_ <i class="fa fa-arrow-left fa-fw"></i>
 : <span class="flex flex-row items-center gap-4">
 	<select name="readnfs" onchange="toggleButton('readnfs',false)">

--- a/emhttp/plugins/dynamix/SecuritySMB.page
+++ b/emhttp/plugins/dynamix/SecuritySMB.page
@@ -145,7 +145,7 @@ _(Security)_:
 :smb_secure_access_help:
 
 <div markdown="1" class="relative">
-<div markdown="1" class="clone-settings clone-settings-less-padding shade">
+<div markdown="1" class="clone-settings shade">
 _(Read settings from)_ <i class="fa fa-arrow-left fa-fw"></i>
 : <span class="flex flex-row items-center gap-4">
 	<select name="readusersmb" onchange="toggleButton('readusersmb',false)">
@@ -208,7 +208,7 @@ _(Write settings to)_ <i class="fa fa-arrow-right fa-fw"></i>
 :smb_private_access_help:
 
 <div markdown="1" class="relative">
-<div markdown="1" class="clone-settings clone-settings-less-padding shade">
+<div markdown="1" class="clone-settings shade">
 _(Read settings from)_ <i class="fa fa-arrow-left fa-fw"></i>
 : <span class="flex flex-row items-center gap-4">
 	<select name="readusersmb" onchange="toggleButton('readusersmb',false)">

--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -335,6 +335,7 @@ $filteredShares = array_filter($shares, function($list) use ($name) {
 :share_edit_global2_help:
 <?endif;?>
 
+<form class="relative" markdown="1" name="share_edit" method="POST" action="/update.htm" target="progressFrame" onsubmit="return prepareEdit()"<?=$name?" onchange=\"toggleButton('writeshare',true);$('#s5').dropdownchecklist('disable')\">":">"?>
 <?if ($share['hasCfg']!='similar'):?>
 <?if (!empty($filteredShares)):?>
 <div markdown="1" class="clone-settings shade">
@@ -371,7 +372,6 @@ _(Write settings to)_ <i class="fa fa-arrow-right fa-fw"></i>
 <?endif;?>
 <?endif;?>
 
-<form markdown="1" name="share_edit" method="POST" action="/update.htm" target="progressFrame" onsubmit="return prepareEdit()"<?=$name?" onchange=\"toggleButton('writeshare',true);$('#s5').dropdownchecklist('disable')\">":">"?>
 <input type="hidden" name="shareNameOrig" value="<?=htmlspecialchars($share['nameOrig'])?>">
 <input type="hidden" name="shareUseCache" value="<?=$share['useCache']?>">
 <input type="hidden" name="shareCachePool2" value="<?=$share['cachePool2']?>">

--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -595,7 +595,7 @@ _(Mover action)_:
 	<input type="submit" id="cmdEditShare" name="cmdEditShare" value="_(Apply)_" onclick="if (this.value=='_(Delete)_') this.value='Delete'; else this.value='Apply'; return handleDeleteClick(this)" disabled>
 	<input type="button" value="_(Done)_" onclick="done()">
         <?if ($share['hasCfg']=='similar'):?>
-                <span class="orange-text"><i class="fa fa-warning"></i> _(Case-insensitve Share name is not unique)_</span>
+                <span class="orange-text"><i class="fa fa-warning"></i> _(Case-insensitive Share name is not unique)_</span>
         <?endif;?>
   </span>
 </div>

--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -335,7 +335,7 @@ $filteredShares = array_filter($shares, function($list) use ($name) {
 :share_edit_global2_help:
 <?endif;?>
 
-<form class="relative" markdown="1" name="share_edit" method="POST" action="/update.htm" target="progressFrame" onsubmit="return prepareEdit()"<?=$name?" onchange=\"toggleButton('writeshare',true);$('#s5').dropdownchecklist('disable')\">":">"?>
+<div markdown="1" class="relative">
 <?if ($share['hasCfg']!='similar'):?>
 <?if (!empty($filteredShares)):?>
 <div markdown="1" class="clone-settings shade">
@@ -372,6 +372,7 @@ _(Write settings to)_ <i class="fa fa-arrow-right fa-fw"></i>
 <?endif;?>
 <?endif;?>
 
+<form markdown="1" name="share_edit" method="POST" action="/update.htm" target="progressFrame" onsubmit="return prepareEdit()"<?=$name?" onchange=\"toggleButton('writeshare',true);$('#s5').dropdownchecklist('disable')\">":">"?>
 <input type="hidden" name="shareNameOrig" value="<?=htmlspecialchars($share['nameOrig'])?>">
 <input type="hidden" name="shareUseCache" value="<?=$share['useCache']?>">
 <input type="hidden" name="shareCachePool2" value="<?=$share['cachePool2']?>">
@@ -600,6 +601,7 @@ _(Mover action)_:
 </div>
 <?endif;?>
 </form>
+</div>
 
 <script>
 let form = document.share_edit;

--- a/emhttp/plugins/dynamix/sheets/ShareEdit.css
+++ b/emhttp/plugins/dynamix/sheets/ShareEdit.css
@@ -12,10 +12,3 @@
 i.fa-info.i {
     margin-right: 10px;
 }
-
-.Theme--black,
-.Theme--white {
-    form[name="share_edit"] {
-        margin-top: -20px;
-    }
-}

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2152,17 +2152,13 @@ span#wlan0 {
         right: 0;
         width: 40rem;
         margin: 0;
-        padding: 3rem 1rem 0 0;
+        padding: 1rem;
         background-color: transparent;
 
         dl {
             align-items: center;
             gap: 1.5rem 1rem;
         }
-    }
-
-    .clone-settings-less-padding {
-        padding-top: 1rem;
     }
 }
 


### PR DESCRIPTION
- Moved clone-settings fields into form element with position relative on ShareEdit.page prevent overlapping prev / next shares buttons.
- Removed unnecessary CSS rules from ShareEdit.css to streamline styling.
- Adjusted padding for clone-settings in default-base.css for better layout consistency.
- Simplified clone-settings CSS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted spacing in NFS Security Settings for consistent appearance.
  * Standardized padding in SMB Secure and Private User Access panels for cleaner layout.
  * Unified padding on the wireless status badge for balanced display.
  * Removed theme-specific negative top margin from the Share Edit form for consistent theme layouts.
  * Added a positioning wrapper to the Share Edit form to improve layout alignment without altering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->