### PR TITLE
Fix: PHP Errors when editing share

### DIFF
--- a/emhttp/plugins/dynamix/SecurityNFS.page
+++ b/emhttp/plugins/dynamix/SecurityNFS.page
@@ -1,7 +1,7 @@
 Menu="Disk Share"
 Title="NFS Security Settings"
 Tag="linux"
-Cond="(($var['shareNFSEnabled']!='no') && (isset($name)?array_key_exists($name,$sec_nfs)&&$shares[$name]['hasCfg']!='similar':0))"
+Cond="(($var['shareNFSEnabled']!='no') && (isset($name)?array_key_exists($name,$sec_nfs)&&($shares[$name]['hasCfg']??false)!='similar':0))"
 ---
 <?PHP
 /* Copyright 2005-2023, Lime Technology

--- a/emhttp/plugins/dynamix/SecuritySMB.page
+++ b/emhttp/plugins/dynamix/SecuritySMB.page
@@ -1,7 +1,7 @@
 Menu="Disk Share Flash"
 Title="SMB Security Settings"
 Tag="windows"
-Cond="(($var['shareSMBEnabled']!='no') && (isset($name)?array_key_exists($name,$sec)&&$shares[$name]['hasCfg']!='similar':0))"
+Cond="(($var['shareSMBEnabled']!='no') && (isset($name)?array_key_exists($name,$sec)&&($shares[$name]['hasCfg']??false)!='similar':0))"
 ---
 <?PHP
 /* Copyright 2005-2023, Lime Technology

--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -336,7 +336,7 @@ $filteredShares = array_filter($shares, function($list) use ($name) {
 <?endif;?>
 
 <div markdown="1" class="relative">
-<?if ($share['hasCfg']!='similar'):?>
+<?if (($share['hasCfg']??false)!='similar'):?>
 <?if (!empty($filteredShares)):?>
 <div markdown="1" class="clone-settings shade">
 _(Read settings from)_ <i class="fa fa-arrow-left fa-fw"></i>
@@ -594,7 +594,7 @@ _(Mover action)_:
 : <span class="inline-flex flex-row items-center gap-2">
 	<input type="submit" id="cmdEditShare" name="cmdEditShare" value="_(Apply)_" onclick="if (this.value=='_(Delete)_') this.value='Delete'; else this.value='Apply'; return handleDeleteClick(this)" disabled>
 	<input type="button" value="_(Done)_" onclick="done()">
-        <?if ($share['hasCfg']=='similar'):?>
+        <?if (($share['hasCfg']??false)=='similar'):?>
                 <span class="orange-text"><i class="fa fa-warning"></i> _(Case-insensitive Share name is not unique)_</span>
         <?endif;?>
   </span>
@@ -1440,7 +1440,7 @@ $(function() {
 	updateScreen(form.shareUseCache.value);
 	if ($.cookie('autosize-' + $('#shareName').val())) $('#autosize').show();
 	checkName($('#shareName').val());
-	<?if ($share['hasCfg']=='similar'):?>
+	<?if (($share['hasCfg']??false)=='similar'):?>
 		form.shareComment.disabled = true;
 		form.shareFloor.disabled = true;
 		form.shareCachePool.disabled = true;


### PR DESCRIPTION
Not sure of the chain of events that resulted in this, but fixed.  (Possibly arose from a purposely corrupted share.cfg file where $share['hasCFG'] wasn't defined


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated intermittent warning notices on SMB/NFS security pages and the Share Edit screen when certain configuration fields are missing.
  * Improved robustness of share configuration checks to prevent errors and maintain expected behavior.
  * Ensures a cleaner, more reliable UI experience across shares with incomplete metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->