### PR TITLE
Feat: Add note if PR appears to have been merged

### DIFF
--- a/.github/scripts/generate-pr-plugin.sh
+++ b/.github/scripts/generate-pr-plugin.sh
@@ -271,7 +271,14 @@ Link='nav-user'
 <script>
   $(function() {
     // Check for updates (non-dismissible)
-    caPluginUpdateCheck("webgui-pr-PR_PLACEHOLDER.plg", {noDismiss: true});
+    caPluginUpdateCheck("webgui-pr-PR_PLACEHOLDER.plg", {noDismiss: true},function(result){
+      try {
+        let json = JSON.parse(result);
+        if ( ! json.version ) {
+          addBannerWarning("Note: webgui-pr-PR_PLACEHOLDER has either been merged or removed");
+        }
+      } catch(e) {}
+    });
 
     // Create banner with uninstall link (nondismissible)
     let bannerMessage = "Modified GUI installed via <b>webgui-pr-PR_PLACEHOLDER</b> plugin. " +


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Update check now displays a clear banner warning when the response is missing expected version information, helping users understand if a plugin may have been merged or removed.
  * Improved resilience of the update process by safely handling malformed or non-JSON responses, reducing the likelihood of silent failures or console errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->