### PR TITLE
Fix: Don't report dynamix.cfg as corrupt if 0 byte file

### DIFF
--- a/emhttp/plugins/dynamix/include/Report.php
+++ b/emhttp/plugins/dynamix/include/Report.php
@@ -24,8 +24,9 @@ case 'config':
     $filename = $plugin ? "$config/plugins/$name/$name.cfg" : "$config/$name.cfg";
     for ( $i=0;$i<2;$i++) {
       if (($need && !file_exists($filename)) || (file_exists($filename) && !@parse_ini_file($filename))) {
-        if ( ! $need && $plugin && @filesize($filename) == 0) {
-          continue;
+        if ( ! $need && $plugin && @filesize($filename) === 0) {
+          $flag = 0;
+          break;
         }
         $flag = 1;
         sleep(1);

--- a/emhttp/plugins/dynamix/include/Report.php
+++ b/emhttp/plugins/dynamix/include/Report.php
@@ -24,6 +24,9 @@ case 'config':
     $filename = $plugin ? "$config/plugins/$name/$name.cfg" : "$config/$name.cfg";
     for ( $i=0;$i<2;$i++) {
       if (($need && !file_exists($filename)) || (file_exists($filename) && !@parse_ini_file($filename))) {
+        if ( ! $need && $plugin && @filesize($filename) == 0) {
+          continue;
+        }
         $flag = 1;
         sleep(1);
       } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents false “missing/invalid” plugin configuration alerts by tolerating temporarily empty plugin config files during processing.
  * Reduces unnecessary delays and intermittent pauses during plugin checks, leading to a smoother experience during system startup and plugin install/update cycles.
  * Improves reliability of plugin status reporting, minimizing spurious warnings and retries when plugin configurations are in transient states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->