### PR TITLE
fix: remove unnecessary style attribute from enter_view select elemen…

### DIFF
--- a/emhttp/plugins/dynamix/DashStats.page
+++ b/emhttp/plugins/dynamix/DashStats.page
@@ -505,7 +505,7 @@ switch ($themeHelper->getThemeName()) { // $themeHelper set in DefaultPageLayout
                                                       <?=mk_option("",$port,_($port))?>
                                                   <?endforeach;?>
                                               </select>
-                                              <select name="enter_view" onchange="changeView(this.value)">
+                                              <select name="enter_view" onchange="changeView(this.value)" style="min-width: 100px">
                                                   <?=mk_option("", "0", _("General info"))?>
                                                   <?=mk_option("", "1", _("Counters info"))?>
                                                   <?=mk_option("", "2", _("Errors info"))?>

--- a/emhttp/plugins/dynamix/DashStats.page
+++ b/emhttp/plugins/dynamix/DashStats.page
@@ -505,7 +505,7 @@ switch ($themeHelper->getThemeName()) { // $themeHelper set in DefaultPageLayout
                                                       <?=mk_option("",$port,_($port))?>
                                                   <?endforeach;?>
                                               </select>
-                                              <select name="enter_view" style="min-width: 140px" onchange="changeView(this.value)">
+                                              <select name="enter_view" onchange="changeView(this.value)">
                                                   <?=mk_option("", "0", _("General info"))?>
                                                   <?=mk_option("", "1", _("Counters info"))?>
                                                   <?=mk_option("", "2", _("Errors info"))?>


### PR DESCRIPTION
…t in DashStats.page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced the minimum width of the Interface Information (enter view) dropdown from its previous fixed value to a smaller minimum, allowing a more compact appearance.
  * Improves layout consistency and reduces unnecessary horizontal spacing on narrow screens.
  * No functional changes: selecting options and view switching behave as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->