### PR TITLE
Fix: Disallow reading settings from share containing apostrophe

### DIFF
--- a/emhttp/plugins/dynamix/SecurityNFS.page
+++ b/emhttp/plugins/dynamix/SecurityNFS.page
@@ -31,7 +31,7 @@ _(Read settings from)_ <i class="fa fa-arrow-left fa-fw"></i>
 		if (isset($disks[$name])) {
 		  foreach (array_filter($disks,'clone_list') as $list) if ($list['name']!=$name) echo mk_option("", $list['name'], _(my_disk($list['name']),3));
 		} else {
-		  foreach ($shares as $list) if ($list['name']!=$name) echo mk_option("", $list['name'], compress($list['name']));
+		  foreach ($shares as $list) if (strpos($list['name'],"'") === false && $list['name']!=$name) echo mk_option("", $list['name'], compress($list['name']));
 		}
 		?>
 	</select>
@@ -48,7 +48,7 @@ _(Write settings to)_ <i class="fa fa-arrow-right fa-fw"></i>
 		if (isset($disks[$name])) {
 		  foreach (array_filter($disks,'clone_list') as $list) if ($list['name']!=$name) $rows[] = mk_option("", $list['name'], _(my_disk($list['name']),3));
 		} else {
-		  foreach ($shares as $list) if ($list['name']!=$name) $rows[] = mk_option("", $list['name'], compress($list['name']));
+		  foreach ($shares as $list) if (strpos($list['name'],"'") === false && $list['name']!=$name) $rows[] = mk_option("", $list['name'], compress($list['name']));
 		}
 		if ($rows) echo "<option>("._('All').")</option>";
 		foreach ($rows as $row) echo $row;

--- a/emhttp/plugins/dynamix/SecuritySMB.page
+++ b/emhttp/plugins/dynamix/SecuritySMB.page
@@ -34,7 +34,7 @@ _(Read settings from)_ <i class="fa fa-arrow-left fa-fw"></i>
 		if (isset($disks[$name])) {
 		  foreach (array_filter($disks,'clone_list') as $list) if ($list['name']!=$name) echo mk_option("", $list['name'], _(my_disk($list['name']),3));
 		} else {
-		  foreach ($shares as $list) if ($list['name']!=$name) echo mk_option("", $list['name'], compress($list['name']));
+		  foreach ($shares as $list) if (strpos($list['name'],"'") === false && $list['name']!=$name) echo mk_option("", $list['name'], compress($list['name']));
 		}
 		?>
 	</select>
@@ -51,7 +51,7 @@ _(Write settings to)_ <i class="fa fa-arrow-right fa-fw"></i>
 		if (isset($disks[$name])) {
 		  foreach (array_filter($disks,'clone_list') as $list) if ($list['name']!=$name) $rows[] = mk_option("", $list['name'], _(my_disk($list['name']),3));
 		} else {
-		  foreach ($shares as $list) if ($list['name']!=$name) $rows[] = mk_option("", $list['name'], compress($list['name']));
+		  foreach ($shares as $list) if (strpos($list['name'],"'") === false && $list['name']!=$name) $rows[] = mk_option("", $list['name'], compress($list['name']));
 		}
 		if ($rows) echo "<option>("._('All').")</option>";
 		foreach ($rows as $row) echo $row;
@@ -154,7 +154,7 @@ _(Read settings from)_ <i class="fa fa-arrow-left fa-fw"></i>
 		if (isset($disks[$name])) {
 		  foreach (array_filter($disks,'clone_list') as $list) if ($list['name']!=$name && $sec[$list['name']]['security']=='secure') echo mk_option("", $list['name'], _(my_disk($list['name']),3));
 		} else {
-		  foreach ($shares as $list) if ($list['name']!=$name && $sec[$list['name']]['security']=='secure') echo mk_option("", $list['name'], compress($list['name']));
+		  foreach ($shares as $list) if (strpos($list['name'],"'") === false && $list['name']!=$name && $sec[$list['name']]['security']=='secure') echo mk_option("", $list['name'], compress($list['name']));
 		}
 		?>
 	</select>
@@ -171,7 +171,7 @@ _(Write settings to)_ <i class="fa fa-arrow-right fa-fw"></i>
 		if (isset($disks[$name])) {
 		  foreach (array_filter($disks,'clone_list') as $list) if ($list['name']!=$name && $sec[$list['name']]['security']=='secure') $rows[] = mk_option("", $list['name'], _(my_disk($list['name']),3));
 		} else {
-		  foreach ($shares as $list) if ($list['name']!=$name && $sec[$list['name']]['security']=='secure') $rows[] = mk_option("", $list['name'], compress($list['name']));
+		  foreach ($shares as $list) if (strpos($list['name'],"'") === false && $list['name']!=$name && $sec[$list['name']]['security']=='secure') $rows[] = mk_option("", $list['name'], compress($list['name']));
 		}
 		if ($rows) echo "<option>("._('All').")</option>";
 		foreach ($rows as $row) echo $row;
@@ -217,7 +217,7 @@ _(Read settings from)_ <i class="fa fa-arrow-left fa-fw"></i>
 		if (isset($disks[$name])) {
 		  foreach (array_filter($disks,'clone_list') as $list) if ($list['name']!=$name && $sec[$list['name']]['security']=='private') echo mk_option("", $list['name'], _(my_disk($list['name']),3));
 		} else {
-		  foreach ($shares as $list) if ($list['name']!=$name && $sec[$list['name']]['security']=='private') echo mk_option("", $list['name'], compress($list['name']));
+		  foreach ($shares as $list) if (strpos($list['name'],"'") === false && $list['name']!=$name && $sec[$list['name']]['security']=='private') echo mk_option("", $list['name'], compress($list['name']));
 		}
 		?>
 	</select>
@@ -234,7 +234,7 @@ _(Write settings to)_ <i class="fa fa-arrow-right fa-fw"></i>
 		if (isset($disks[$name])) {
 		  foreach (array_filter($disks,'clone_list') as $list) if ($list['name']!=$name && $sec[$list['name']]['security']=='private') $rows[] = mk_option("", $list['name'], _(my_disk($list['name']),3));
 		} else {
-		  foreach ($shares as $list) if ($list['name']!=$name && $sec[$list['name']]['security']=='private') $rows[] = mk_option("", $list['name'], compress($list['name']));
+		  foreach ($shares as $list) if (strpos($list['name'],"'") === false && $list['name']!=$name && $sec[$list['name']]['security']=='private') $rows[] = mk_option("", $list['name'], compress($list['name']));
 		}
 		if ($rows) echo "<option>("._('All').")</option>";
 		foreach ($rows as $row) echo $row;

--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -327,7 +327,7 @@ function direction() {
 $myDisks = array_filter(array_diff(array_keys(array_filter($disks,'my_disks')), explode(',',$var['shareUserExclude'])), 'globalInclude');
 
 $filteredShares = array_filter($shares, function($list) use ($name) {
-	return $list['name'] != $name || !$name;
+	return (strpos($list['name'],"'") === false) && ($list['name'] != $name || !$name) ;
 });
 ?>
 :share_edit_global1_help:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning in SMB settings when a share’s security is set to Public, updating automatically on load and when changed.

* **Bug Fixes**
  * NFS and SMB share selectors now exclude shares with apostrophes in their names to avoid display and selection issues.
  * Share editing filters aligned to prevent listing shares with apostrophes, ensuring consistent behavior across read/write and security options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->