### PR TITLE
Fix: adjust tooltip positioning to account for window scroll offsets

### DIFF
--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -504,9 +504,11 @@ $(document).on('mouseenter', 'a.info', function() {
   const tooltip = $(this).find('span');
   if (tooltip.length) {
     const aInfoPosition = $(this).offset();
+    const scrollTop = $(window).scrollTop();
+    const scrollLeft = $(window).scrollLeft();
     const addtionalOffset = 16;
-    const top = aInfoPosition.top + addtionalOffset;
-    const left = aInfoPosition.left + addtionalOffset;
+    const top = aInfoPosition.top - scrollTop + addtionalOffset;
+    const left = aInfoPosition.left - scrollLeft + addtionalOffset;
     tooltip.css({ top, left });
   }
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected positioning of info tooltips when the page is scrolled. Tooltips now account for scroll offset, preventing them from appearing misaligned or off-screen on long pages.
  * Improves consistency across viewport sizes and scrolling scenarios with no other visual or functional changes.
  * Affects pages using inline help/info icons; no configuration or user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->