### PR TITLE
fix: increase timeout when stopping samba

### DIFF
--- a/etc/rc.d/rc.samba
+++ b/etc/rc.d/rc.samba
@@ -39,7 +39,7 @@ samba_running(){
 
 samba_waitfor_shutdown(){
   local i
-  for i in {1..5}; do
+  for i in {1..10}; do
     if ! samba_running; then break; fi
     sleep 1
   done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended shutdown wait time for the file sharing service to improve reliability when stopping or restarting.
  * Reduces occasional shutdown failures, ensuring the service fully stops before proceeding.
  * Users may notice a slightly longer wait during service stop/restart on busy systems.
  * No configuration changes required; no user action needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->