### PR TITLE
Wireguard: fix PHP error on import

### DIFF
--- a/emhttp/plugins/dynamix/include/update.wireguard.php
+++ b/emhttp/plugins/dynamix/include/update.wireguard.php
@@ -541,8 +541,9 @@ case 'import':
     $vpn = (in_array($default4,$vpn) || in_array($default6,$vpn)) ? 8 : 0;
     if ($vpn==8) $import["Address:$n"] = '';
     $import["TYPE:$n"] = $vpn;
-    ipfilter(_var($import,"AllowedIPs:$n"));
-    if (_var($import,"TYPE:$n") == 0) $var['subnets1'] = "AllowedIPs="._var($import,"AllowedIPs:$n");
+    $allowedIPs = _var($import,"AllowedIPs:$n")
+    ipfilter($allowedIPs);
+    if (_var($import,"TYPE:$n") == 0) $var['subnets1'] = "AllowedIPs=".$allowedIPs);
   }
   foreach ($import as $key => $val) $sort[] = explode(':',$key)[1];
   array_multisort($sort, $import);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined how AllowedIPs are processed during WireGuard tunnel import/update, reusing computed values for consistent filtering and assignment.
  * Reduced redundant lookups to enhance maintainability and reliability.

* **Bug Fixes**
  * Improved consistency in applying AllowedIPs across tunnels during updates/imports, reducing chances of mismatched filtering or subnet assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->