### PR TITLE
Feat:Add power placeholder and Split physical CPUS

### DIFF
--- a/emhttp/plugins/dynamix/DashStats.page
+++ b/emhttp/plugins/dynamix/DashStats.page
@@ -94,7 +94,7 @@ foreach ($devs as $disk) {
 }
 
 $array_percent = number_format(100*$array_used/($array_size ?: 1),1,$dot,'');
-exec('cat /sys/devices/system/cpu/*/topology/thread_siblings_list|sort -nu', $cpus);
+$cpus=get_cpu_packages();
 $wg_up      = $wireguard ? exec("wg show interfaces") : '';
 $wg_up      = $wg_up ? explode(' ',$wg_up) : [];
 $up         = count($wg_up);
@@ -346,6 +346,9 @@ switch ($themeHelper->getThemeName()) { // $themeHelper set in DefaultPageLayout
                         <td>
                             <span class='flex flex-row flex-wrap items-center gap-4'>
                                 <span class="head_info">
+                                    <span id='cpu-total-power'>_(Total Power)_: N/A</span>
+                                </span>
+                                <span class="head_info">
                                     <span id='cpu-temp'></span>
                                 </span>
                                 <span class="switch">
@@ -395,20 +398,23 @@ switch ($themeHelper->getThemeName()) { // $themeHelper set in DefaultPageLayout
                     </tr>
 
                     <?
-                    foreach ($cpus as $pair) {
-                        [$cpu1, $cpu2] = my_preg_split('/[,-]/',$pair);
-                        echo "<tr class='cpu_open'>";
-                        if ($is_intel_cpu && count($core_types) > 0)
-                            $core_type = "({$core_types[$cpu1]})";
-                        else
-                            $core_type = "";
+                    foreach ($cpus as $cpu_index=>$package)  {
+                      echo "<td><span class='w72'>"._("Physical")." CPU $cpu_index "._("Power").": <span id='cpu-power0'>N/A</span></td></span></tr>";
+                      foreach ($package as $pair) {
+                          [$cpu1, $cpu2] = my_preg_split('/[,-]/',$pair);
+                          echo "<tr class='cpu_open'>";
+                          if ($is_intel_cpu && count($core_types) > 0)
+                              $core_type = "({$core_types[$cpu1]})";
+                          else
+                              $core_type = "";
 
-                        if ($cpu2)
-                            echo "<td><span class='w26'>CPU $cpu1 $core_type - HT $cpu2 </span><span class='dashboard w36'><span class='cpu$cpu1 load resize'>0%</span><div class='usage-disk sys'><span id='cpu$cpu1'></span><span></span></div></span><span class='dashboard w36'><span class='cpu$cpu2 load resize'>0%</span><div class='usage-disk sys'><span id='cpu$cpu2'></span><span></span></div></span></td>";
-                        else
-                            echo "<td><span class='w26'>CPU $cpu1 $core_type</span><span class='w72'><span class='cpu$cpu1 load resize'>0%</span><div class='usage-disk sys'><span id='cpu$cpu1'></span><span></span></div></span></td>";
-                        echo "</tr>";
-                    }
+                          if ($cpu2)
+                              echo "<td><span class='w26'>CPU $cpu1 $core_type - HT $cpu2 </span><span class='dashboard w36'><span class='cpu$cpu1 load resize'>0%</span><div class='usage-disk sys'><span id='cpu$cpu1'></span><span></span></div></span><span class='dashboard w36'><span class='cpu$cpu2 load resize'>0%</span><div class='usage-disk sys'><span id='cpu$cpu2'></span><span></span></div></span></td>";
+                          else
+                              echo "<td><span class='w26'>CPU $cpu1 $core_type</span><span class='w72'><span class='cpu$cpu1 load resize'>0%</span><div class='usage-disk sys'><span id='cpu$cpu1'></span><span></span></div></span></td>";
+                          echo "</tr>";
+                      }
+                  }
                     ?>
                     <tr id='cpu_chart'>
                         <td>

--- a/emhttp/plugins/dynamix/include/Helpers.php
+++ b/emhttp/plugins/dynamix/include/Helpers.php
@@ -857,4 +857,21 @@ HTML;
   
   return $html;
 }
+
+function get_cpu_packages(string $separator = ','): array {
+    $packages = [];
+    foreach (glob("/sys/devices/system/cpu/cpu[0-9]*/topology/thread_siblings_list") as $path) {
+        $pkg_id   = (int)file_get_contents(dirname($path) . "/physical_package_id");
+        $siblings = str_replace(",", $separator, trim(file_get_contents($path)));
+        if (!in_array($siblings, $packages[$pkg_id] ?? [])) {
+            $packages[$pkg_id][] = $siblings;
+        }
+    }
+    foreach ($packages as &$list) {
+        $keys = array_map(fn($s) => (int)explode($separator, $s)[0], $list);
+        array_multisort($keys, SORT_ASC, SORT_NUMERIC, $list);
+    }
+    unset($list);
+    return $packages;
+}
 ?>


### PR DESCRIPTION
Add CPU Total Power place holder
Change CPU layout to split physical CPUs.
Add per physical CPU power placeholder.

<img width="786" height="633" alt="image" src="https://github.com/user-attachments/assets/3fba5293-2fb1-4f6d-8266-b89417f373c5" />

Mockup on 6.12 Dual CPU.

<img width="786" height="1060" alt="image" src="https://github.com/user-attachments/assets/42ca326e-0d37-4328-8076-8b3fb9a6268e" />
