### PR TITLE
Fix: Memory reporting.

### DIFF
--- a/emhttp/plugins/dynamix/DashStats.page
+++ b/emhttp/plugins/dynamix/DashStats.page
@@ -169,11 +169,16 @@ foreach ($memory_array as $device) {
   if ($base>=1) $memory_maximum += $size*pow(1024,$base);
   if (!$ecc && isset($device['Error Correction Type']) && $device['Error Correction Type']!='None') $ecc = "{$device['Error Correction Type']} ";
 }
+if ($memory_installed >= 1048576) {
+  $memory_installed = round($memory_installed/1048576);
+  $memory_maximum = round($memory_maximum/1048576);
+  $unit = 'TiB';
+} else { 
 if ($memory_installed >= 1024) {
   $memory_installed = round($memory_installed/1024);
   $memory_maximum = round($memory_maximum/1024);
-  $unit = 'GiB';
-} else $unit = 'MiB';
+  $unit = 'GiB';}
+else $unit = 'MiB'; }
 
 // get system resources size
 exec("df --output=size /boot /var/log /var/lib/docker 2>/dev/null|awk '(NR>1){print $1*1024}'",$df);


### PR DESCRIPTION
Memory incorrect for > 1TiB, Unit incorrectly displayed

<img width="418" height="307" alt="image" src="https://github.com/user-attachments/assets/5569223a-6ed5-49fa-b723-4e8b4e7af263" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Large-memory systems now display installed/maximum memory in TiB for clearer readability.
  * Charts dynamically adjust smoothing/scale based on available width and selected time window, improving visibility across different screen sizes.
  * CPU and network charts respond more smoothly to layout changes and window resizing for a better real-time monitoring experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->