### PR TITLE
fix: prevent services from starting before emhttpd

### DIFF
--- a/emhttp/plugins/dynamix/scripts/reload_services
+++ b/emhttp/plugins/dynamix/scripts/reload_services
@@ -8,6 +8,12 @@ queue(){
   atq | grep -Pom1 '^\d+'
 }
 
+if [[ ! -r /usr/local/emhttp/state/var.ini ]]; then
+    # sanity check - exit if no var.ini file, implies emhttpd is not running yet
+    log "/usr/local/emhttp/state/var.ini does not exist, aborting."
+    exit 1
+fi
+
 JOB=$(queue)
 if [[ -n $JOB ]]; then
   atrm $JOB 2>/dev/null

--- a/etc/rc.d/rc.avahidaemon
+++ b/etc/rc.d/rc.avahidaemon
@@ -39,6 +39,12 @@ NAME=$(</etc/HOSTNAME)
 # library functions
 . /etc/rc.d/rc.library.source
 
+if [[ ! -r /usr/local/emhttp/state/var.ini ]]; then
+    # sanity check - exit if no var.ini file, implies emhttpd is not running yet
+    log "/usr/local/emhttp/state/var.ini does not exist, aborting."
+    exit 1
+fi
+
 allow(){
   sed -ri "s/^#?(allow-interfaces)=.*/\1=$*/" $CONF
 }

--- a/etc/rc.d/rc.nfsd
+++ b/etc/rc.d/rc.nfsd
@@ -29,6 +29,12 @@ NFS_CFG="/boot/config/default/nfs"
 # library functions
 . /etc/rc.d/rc.library.source
 
+if [[ ! -r /usr/local/emhttp/state/var.ini ]]; then
+    # sanity check - exit if no var.ini file, implies emhttpd is not running yet
+    log "/usr/local/emhttp/state/var.ini does not exist, aborting."
+    exit 1
+fi
+
 # source default settings
 [[ -r $RPC ]] && . $RPC
 [[ -r $RPC_CFG ]] && . $RPC_CFG

--- a/etc/rc.d/rc.samba
+++ b/etc/rc.d/rc.samba
@@ -27,6 +27,12 @@ PRIVATE="/var/lib/samba/private"
 # library functions
 . /etc/rc.d/rc.library.source
 
+if [[ ! -r /usr/local/emhttp/state/var.ini ]]; then
+    # sanity check - exit if no var.ini file, implies emhttpd is not running yet
+    log "/usr/local/emhttp/state/var.ini does not exist, aborting."
+    exit 1
+fi
+
 # read Unraid settings
 [[ -r $IDENT ]] && . <(fromdos <$IDENT)
 # disable ipv6 when netbios is used


### PR DESCRIPTION
rc.nginx handled in #2414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of service start and reload by adding pre-start sanity checks for system readiness.
  - Prevents services from starting or reloading when the management service isn’t available, reducing false starts and race conditions.
  - Provides clearer logging and exit statuses when aborting early.
  - Safely cancels any queued background jobs during service reload to avoid conflicts.

- Documentation
  - Clarified operational behavior through more informative log messages during startup and reload conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->