### PR TITLE
Fix: Change Windows11 defaults

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -196,11 +196,18 @@ class Array2XML {
 				'domain' => [
 					'ovmf' => 2,
 					'mem' => 4096 * 1024,
-					'maxmem' => 4096 * 1024
+					'maxmem' => 4096 * 1024,
+					'vcpus' => 2,
+					'vcpu' => [0,1],
 				],
 				'disk' => [
 					[
 						'size' => '64G'
+					]
+				],
+				'nic'=>[
+					[
+						'model' => 'e1000'
 					]
 				]
 			]


### PR DESCRIPTION
Set defaults to have
2 vCPUS
and E1000 network driver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Windows 11 VM template now sets a default CPU allocation (2 vCPUs with core pinning) for easier setup and consistent performance.
  - Adds a default network adapter configuration (e1000 model) to the Windows 11 template for improved out-of-the-box compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->