### PR TITLE
7.3 Adjust logging of inline FILE execution

### DIFF
--- a/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
@@ -342,7 +342,9 @@ function plugin($method, $plugin_file, &$error) {
 
   // Process FILE elements in order
   //
+  $current_file = 0;
   foreach ($xml->FILE as $file) {
+    $current_file++;
     // skip if not our $method
     if (isset($file->attributes()->Method)) {
       if (!in_array($method, explode(" ", $file->attributes()->Method))) continue;
@@ -460,10 +462,12 @@ function plugin($method, $plugin_file, &$error) {
         my_logger("running: $command $file->LOCAL", $logger);
         $retval = run("$command $file->LOCAL");
       } elseif ($file->INLINE) {
-        my_logger("running: 'anonymous'", $logger);
-        $name = '/tmp/inline.sh';
+
+        $name = '/tmp/inline'.$current_file.'-'.pathinfo($plugin_file, PATHINFO_FILENAME).'.sh';
         file_put_contents($name, $file->INLINE);
-        $retval = run("$command $name");
+        $exec = $command." ".escapeshellarg($name);
+        my_logger("executing inline script: $exec", $logger);
+        $retval = run($exec);
         unlink($name);
       }
       if ($retval != 0) {


### PR DESCRIPTION
For 7.3. 

Adjust logging during plugin installation / update / removal to indicate the plugin and FILE section being executed.

Support edge case of a plugin installing another plugin via inline FILE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents conflicts when processing multiple FILE elements by generating a unique temporary script for each inline section.
  - Ensures safer execution of inline scripts and consistent cleanup after running.
- Chores
  - Adds clearer logging around inline script execution to aid troubleshooting and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->