### PR TITLE
Fix Display issue if schedule set to hourly

### DIFF
--- a/emhttp/plugins/dynamix/MoverSettings.page
+++ b/emhttp/plugins/dynamix/MoverSettings.page
@@ -91,7 +91,8 @@ _(Day of the month)_:
 :mover_day_of_the_month_help:
 
 _(Time of the day)_:
-: <span id="H1"<?if ($move==0):?> style="display:none"<?endif;?>><select name="hour1" class="narrow">
+: <span>
+  <span id="H1"<?if ($move==0):?> style="display:none"<?endif;?>><select name="hour1" class="narrow">
   <?for ($d=0; $d<=23; $d++):?>
   <?=mk_option($cron[1], strval($d), sprintf("%02d", $d))?>
   <?endfor;?>
@@ -101,7 +102,7 @@ _(Time of the day)_:
   <?=mk_option($cron[0], strval($d), sprintf("%02d", $d))?>
   <?endfor;?>
   </select>&nbsp;&nbsp;_(HH:MM)_</span>
-: <span id="H2"<?if ($move!=0):?> style="display:none"<?endif;?>><select name="hour2">
+  <span id="H2"<?if ($move!=0):?> style="display:none"<?endif;?>><select name="hour2">
   <?=mk_option($cron[1], "*/1", _("Every hour"))?>
   <?=mk_option($cron[1], "*/2", _("Every 2 hours"))?>
   <?=mk_option($cron[1], "*/3", _("Every 3 hours"))?>
@@ -109,6 +110,7 @@ _(Time of the day)_:
   <?=mk_option($cron[1], "*/6", _("Every 6 hours"))?>
   <?=mk_option($cron[1], "*/8", _("Every 8 hours"))?>
   </select></span>
+</span>
 
 :mover_time_of_the_day_help:
 

--- a/emhttp/plugins/dynamix/TrimSettings.page
+++ b/emhttp/plugins/dynamix/TrimSettings.page
@@ -97,7 +97,8 @@ _(Day of the month)_:
 :end
 
 _(Time of the day)_:
-: <span id="hour1" style="display:none"><select name="hour1" class="narrow">
+: <span>
+  <span id="hour1" style="display:none"><select name="hour1" class="narrow">
   <?for ($d=0; $d<=23; $d++):?>
   <?=mk_option(_var($ssd,'hour'), strval($d), sprintf("%02d", $d))?>
   <?endfor;?>
@@ -107,7 +108,7 @@ _(Time of the day)_:
   <?=mk_option(_var($ssd,'min'), strval($d), sprintf("%02d", $d))?>
   <?endfor;?>
   </select>&nbsp;&nbsp;_(HH:MM)_</span>
-: <span id="hour2" style="display:none"><select name="hour2">
+  <span id="hour2" style="display:none"><select name="hour2">
   <?=mk_option(_var($ssd,'hour'), "*/1", _("Every hour"))?>
   <?=mk_option(_var($ssd,'hour'), "*/2", _("Every 2 hours"))?>
   <?=mk_option(_var($ssd,'hour'), "*/3", _("Every 3 hours"))?>
@@ -115,6 +116,7 @@ _(Time of the day)_:
   <?=mk_option(_var($ssd,'hour'), "*/6", _("Every 6 hours"))?>
   <?=mk_option(_var($ssd,'hour'), "*/8", _("Every 8 hours"))?>
   </select></span>
+</span>
 
 :trim_time_of_the_day_plug:
 > When an hourly schedule is selected this will set the interval in hours. An interval always starts on the whole hour (minute 0).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the layout structure of the time-of-day hour selectors in Mover and Trim settings by adding an extra container element, improving consistency in how these controls are grouped.
  * Visual presentation may change slightly due to updated nesting; no changes to scheduling options or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->