### PR TITLE
Fix: Update VM page to show memory in GB if > 1024MB

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/include/VMMachines.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/VMMachines.php
@@ -64,7 +64,8 @@ foreach ($vms as $vm) {
   } else {
     $mem = $lv->domain_get_memory($res)/1024;
   }
-  $mem = (round($mem) >= 1024) ? (round($mem) /1024) .'G': round($mem) .'M';
+  $memRounded = round($mem);
+  $mem = ($memRounded >= 1024) ? ($memRounded / 1024) . 'G' : $memRounded . 'M';
   $vcpu = $dom['nrVirtCpu'];
   $template = $lv->_get_single_xpath_result($res, '//domain/metadata/*[local-name()=\'vmtemplate\']/@name');
   if (empty($template)) $template = 'Custom';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual machine memory display: allocations ≥1 GB now show in gigabytes (G), smaller allocations show in megabytes (M), with values rounded for clearer readability.
  * Ensures consistent unit selection for both running and stopped VMs so memory values are displayed uniformly across the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->