### PR TITLE
Fix: FF disabled menu item color

### DIFF
--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2333,7 +2333,11 @@ div#title.ud {
         color: var(--text-color);
         background-color: var(--opac-background-color);
     }
-
+    
+    select option:disabled {
+        color: var(--disabled-text-color);
+    }
+    
     select[disabled] {
         color: var(--disabled-text-color);
         border-color: var(--disabled-input-border-color);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved styling for disabled dropdown options, adding consistent disabled text color globally and within the sidebar theme to enhance clarity and visual consistency across the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->