### PR TITLE
Chore: Adjust helptext for reserved share names

### DIFF
--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -542,7 +542,7 @@ The share name can be up to 40 characters, and is case-sensitive with these rest
 
 * must start with a letter
 * subsequent characters can be a letter, digit, period, underscore, or dash, except the last character may not be a period
-* cannot be one of the reserved names: flash, cache, cache2, .., disk1, disk2, ..
+* cannot be one of the reserved names: homes, global, printers, flash, boot, user, user0, dev, remotes, RecycleBin, rootshare, addons, mirror, raidz*, draid, spare, log, disk*, parity*
 :end
 
 :share_edit_comments_help:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced help text for share creation with an expanded list of reserved names that cannot be used
  * Added documentation for available per-share security modes: Public, Secure, and Private access controls
  * Added documentation describing per-disk share security modes and access control options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->