### PR TITLE
Bug: Cdrom bus IDE for Q35 is invalid set to SATA

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -2484,6 +2484,13 @@ $(function() {
 	});
 	<?endif?>
 
+	$("#vmform #domain_machine").change(function changeMachineEvent(){
+		// Cdrom Bus: select IDE for i440 and SATA for q35
+		if ($(this).val().indexOf('q35') != -1) {		
+			$('#vmform .cdrom_bus').val('sata');
+		}
+	});
+
 	$("#vmform .domain_vcpu").change(function changeVCPUEvent(){
 		var $cores = $("#vmform .domain_vcpu:checked");
 		if ($cores.length < 1) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Virtual machine domain machine type selection now automatically configures CD-ROM bus settings based on the selected machine type, improving configuration convenience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->