### PR TITLE
Fix: Agents dropdowns not working in tabbed mode

### DIFF
--- a/emhttp/plugins/dynamix/NotificationAgents.page
+++ b/emhttp/plugins/dynamix/NotificationAgents.page
@@ -25,6 +25,10 @@ var openPage = true;
 
 <? if (!$tabbed): ?>
 $(function(){initDropdown();});
+<? else: ?>
+$(function(){
+  if ( $('#tab3').attr('checked') ) initDropdown();
+});
 <? endif; ?>
 
 if (!String.prototype.format) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted notification agents menu initialization: dropdown now auto-initializes on non-tabbed pages; in tabbed views it initializes only when the relevant tab is active.
  * Removed redundant tab-specific auto-run behavior to prevent unintended initialization.

* **New Features**
  * Added focus attribute to improve dropdown accessibility/behavior.

* **Chores**
  * Updated copyright year to 2005–2025.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->