### PR TITLE
Feat: Add port checking for VNC and sane defaults

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -103,8 +103,8 @@ $arrConfigDefaults = [
 			'autoport' => 'yes',
 			'model' => 'qxl',
 			'keymap' => 'none',
-			'port' => -1 ,
-			'wsport' => -1,
+			'port' => 5900,
+			'wsport' => 5901,
 			'copypaste' => 'no',
 			'render' => 'auto',
 			'DisplayOptions' => ""
@@ -1325,9 +1325,9 @@ foreach ($arrConfig['shares'] as $i => $arrShare) {
 			?>
 			</select></span>
 			<span id="Porttext" class="label <?=$hiddenport?>">_(VM Console Port)_:</span>
-			<input id="port" type="number" size="5" maxlength="5" class="trim second <?=$hiddenport?>" name="gpu[<?=$i?>][port]" value="<?=$arrGPU['port']?>">
+			<input id="port" onchange="checkVNCPorts()" min="5900" max="65535" type="number" size="5" maxlength="5" class="trim second <?=$hiddenport?>" name="gpu[<?=$i?>][port]" value="<?=$arrGPU['port']?>">
 			<span id="WSPorttext" class="label <?=$hiddenwsport?>">_(VM Console WS Port)_:</span>
-			<input id="wsport" type="number" size="5" maxlength="5" class="trim second <?=$hiddenwsport?>" name="gpu[<?=$i?>][wsport]" value="<?=$arrGPU['wsport']?>">
+			<input id="wsport" onchange="checkVNCPorts()" min="5900" max="65535" type="number" size="5" maxlength="5" class="trim second <?=$hiddenwsport?>" name="gpu[<?=$i?>][wsport]" value="<?=$arrGPU['wsport']?>">
 		</td>
 		<td></td>
 	</tr>
@@ -2088,6 +2088,18 @@ foreach ($arrConfig['evdev'] as $i => $arrEvdev) {
 var storageType = "<?=get_storage_fstype($arrConfig['template']['storage']);?>";
 var storageLoc  = "<?=$arrConfig['template']['storage']?>";
 
+function checkVNCPorts() {
+	const port = $("#port").val();
+	const wsport = $("#wsport").val();
+	if (port < 5900 || port > 65535 || wsport < 5900 || wsport > 65535 || port == wsport) {
+		swal({
+			title: "_(Invalid Port)_",
+			text: "_(VNC/SPICE ports must be between 5900 and 65535, and cannot be equal to each other)_",
+			type: "error",
+			confirmButtonText: "_(Ok)_"
+		});
+	}
+}
 function updateMAC(index, port) {
 	var wlan0 = '<?=$mac?>'; // mac address of wlan0
 	var mac = $('input[name="nic['+index+'][mac]"');


### PR DESCRIPTION
Check for VNC/Spice ports within range and set default ports to 5900/5901 instead of invalid -1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added port validation ensuring console ports fall within the 5900-65535 range and are not equal to each other.

* **Bug Fixes**
  * Updated default GPU console port values.

* **UI/UX Improvements**
  * Enhanced console port input fields with range constraints and real-time validation alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->