### PR TITLE
fix: quote ini string values produced by `notify` script

### DIFF
--- a/emhttp/plugins/dynamix/scripts/notify
+++ b/emhttp/plugins/dynamix/scripts/notify
@@ -274,8 +274,8 @@ case 'add':
     ];
     file_put_contents($unread, build_ini_string($unreadData));
   }
-  if (($entity & 2)==2 || $mailtest) generate_email($event, clean_subject($subject), str_replace('<br>','. ',$description), $importance, $message, $recipients, $fqdnlink);
-  if (($entity & 4)==4 && !$mailtest) { if (is_array($agents)) {foreach ($agents as $agent) {exec("TIMESTAMP='$timestamp' EVENT=".escapeshellarg($event)." SUBJECT=".escapeshellarg(clean_subject($subject))." DESCRIPTION=".escapeshellarg($description)." IMPORTANCE=".escapeshellarg($importance)." CONTENT=".escapeshellarg($message)." LINK=".escapeshellarg($fqdnlink)." bash ".$agent);};}};
+  if (($entity & 2)==2 || $mailtest) generate_email($event, $cleanSubject, str_replace('<br>','. ',$description), $importance, $message, $recipients, $fqdnlink);
+  if (($entity & 4)==4 && !$mailtest) { if (is_array($agents)) {foreach ($agents as $agent) {exec("TIMESTAMP='$timestamp' EVENT=".escapeshellarg($event)." SUBJECT=".escapeshellarg($cleanSubject)." DESCRIPTION=".escapeshellarg($description)." IMPORTANCE=".escapeshellarg($importance)." CONTENT=".escapeshellarg($message)." LINK=".escapeshellarg($fqdnlink)." bash ".$agent);};}};
   break;
 
 case 'get':


### PR DESCRIPTION
Resolves the underlying issue of `#` parsing ambiguity in https://github.com/unraid/api/pull/1768 and https://github.com/unraid/api/issues/1770 . Also improves compatibility with other ini parser implementations, making it easier for the api to parse notification data correctly.

Tested via:

- Creating and reading a notification through the API
- Ensuring correct behavior of `notify get`

AI assures me that "mailers, Discord/SNS agents, etc. continue to receive the exact same data."

<img width="542" height="224" alt="image" src="https://github.com/user-attachments/assets/78eefda0-8001-444f-9585-c633c5f6cc05" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved notification storage and handling for enhanced reliability and consistency.
  * Switched to a structured INI-style format for storing notification archives and unread entries.
  * Precomputed and standardized subject handling across storage and email generation.
  * Updated parsing to better preserve and decode values that may contain delimiters, improving data fidelity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->