### PR TITLE
Fix: GUI Search wouldn't update when plugin uninstalled

### DIFF
--- a/emhttp/plugins/dynamix.plugin.manager/post-hooks/post_plugin_checks
+++ b/emhttp/plugins/dynamix.plugin.manager/post-hooks/post_plugin_checks
@@ -67,6 +67,8 @@ case 'language':
   // nothing defined
   break;
 }
+// unset GUI search cache
+@unlink("/tmp/gui.search/searchResults.json");
 
 // unset pending status
 if ($method != 'check') @unlink("$pending/$name");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper cleanup of temporary search cache files after plugin operations to ensure system resources are properly managed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->