### PR TITLE
POC: Don't allow emptying disk if conflicting plugin installed

### DIFF
--- a/emhttp/plugins/dynamix/ShareSettings.page
+++ b/emhttp/plugins/dynamix/ShareSettings.page
@@ -75,7 +75,7 @@ async function prepareShare(form) {
 
   /* Don't allow emptying of shares if the Mover Tuning plugin is installed */
   if ( emptying.length > 0 && <?= is_file('/var/log/plugins/ca.mover.tuning.plg') ? "true" : "false" ?>) {
-    event.preventDefault();
+    this.event.preventDefault();
     swal({
       title: "_(Mover Tuning Installed)_",
       text: "_(The Mover Tuning plugin is installed.  This plugin will interfere with emptying of shares.  You will need to uninstall this plugin to be able to set disks to be emptied.)_",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents emptying of shares when the Mover Tuning plugin is installed. Attempting this now blocks the action, stops form submission, and displays an error notification to guide users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->