### PR TITLE
Fix: NFS security, "write settings to" does not work for security modes Public and Secure

### DIFF
--- a/emhttp/plugins/dynamix/SecurityNFS.page
+++ b/emhttp/plugins/dynamix/SecurityNFS.page
@@ -214,7 +214,7 @@ function writeNFS(data, n, i) {
 		var data = [];
 
 		/* Get the setting from the share config. */
-		var hostList = $('textarea[name="shareHostListNFS"]').val().trim();
+                var hostList = $('textarea[name="shareHostListNFS"]').val()?.trim() || "";
 
 		/* Replace all new lines in data.hostList with spaces. */
 		var formattedHostList = <?= json_encode($sec_nfs[$name]['hostList']); ?>.replace(/\n/g, ' ');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NFS host list configuration handling for enhanced stability and error prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->