### PR TITLE
Fix: when stopping Samba, terminate master smbd process first (again)

### DIFF
--- a/etc/rc.d/rc.samba
+++ b/etc/rc.d/rc.samba
@@ -156,8 +156,8 @@ samba_stop(){
   else
     REPLY="Stopped"
     # stop gracefully with SIGTERM the "master" smbd process first
-    master=$(ps -o pid=,ppid= -C smbd | awk '$2==1 {print $1}')
-    [[ -n "master" ]] && run kill "$master"
+    master=$(pgrep --ns $$ -o smbd)
+    [[ -n "$master" ]] && run kill "$master"
     sleep 1
     # stop gracefully with SIGTERM
     run killall --ns $$ smbd nmbd wsdd2 winbindd
@@ -165,7 +165,7 @@ samba_stop(){
     if samba_running; then
       REPLY="Killed"
       # stop forcibly with SIGKILL
-      [[ -n "master" ]] && run kill -SIGKILL "master"
+      [[ -n "$master" ]] && run kill -SIGKILL "$master"
       run killall --ns $$ -SIGKILL smbd nmbd wsdd2 winbindd
       samba_waitfor_shutdown
     fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Samba service termination by enhancing the process identification mechanism for graceful and forced shutdown operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->