### PR TITLE
fix(styles): exclude unapi from raw element css rules

### DIFF
--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -139,15 +139,15 @@ hr {
     resize: none;
 }
 
-input[type="text"],
-input[type="password"],
-input[type="number"],
-input[type="url"],
-input[type="email"],
-input[type="date"],
-input[type="file"],
-textarea,
-.textarea {
+input[type="text"]:where(:not(.unapi *)),
+input[type="password"]:where(:not(.unapi *)),
+input[type="number"]:where(:not(.unapi *)),
+input[type="url"]:where(:not(.unapi *)),
+input[type="email"]:where(:not(.unapi *)),
+input[type="date"]:where(:not(.unapi *)),
+input[type="file"]:where(:not(.unapi *)),
+textarea:where(:not(.unapi *)),
+.textarea:where(:not(.unapi *)) {
     color: var(--text-color);
     font-family: clear-sans;
     font-size: 1.3rem;
@@ -181,12 +181,12 @@ select:focus {
     }
 }
 
-input[type="button"],
-input[type="reset"],
-input[type="submit"],
-button,
-button[type="button"],
-a.button {
+input[type="button"]:where(:not(.unapi *)),
+input[type="reset"]:where(:not(.unapi *)),
+input[type="submit"]:where(:not(.unapi *)),
+button:where(:not(.unapi *)),
+button[type="button"]:where(:not(.unapi *)),
+a.button:where(:not(.unapi *)) {
     font-family: clear-sans;
     font-size: 1.1rem;
     font-weight: bold;
@@ -250,48 +250,50 @@ input[type="number"]::-webkit-inner-spin-button {
 input[type="number"] {
     -moz-appearance: textfield;
 }
-input:focus[type="text"],
-input:focus[type="password"],
-input:focus[type="number"],
-input:focus[type="url"],
-input:focus[type="email"],
-input:focus[type="file"],
-textarea:focus {
+input:focus[type="text"]:where(:not(.unapi *)),
+input:focus[type="password"]:where(:not(.unapi *)),
+input:focus[type="number"]:where(:not(.unapi *)),
+input:focus[type="url"]:where(:not(.unapi *)),
+input:focus[type="email"]:where(:not(.unapi *)),
+input:focus[type="file"]:where(:not(.unapi *)),
+textarea:focus:where(:not(.unapi *)) {
     background-color: var(--focus-input-bg-color);
     outline: 0;
 }
-input:hover[type="button"],
-input:hover[type="reset"],
-input:hover[type="submit"],
-button:hover,
-button:hover[type="button"],
-a.button:hover {
+input:hover[type="button"]:where(:not(.unapi *)),
+input:hover[type="reset"]:where(:not(.unapi *)),
+input:hover[type="submit"]:where(:not(.unapi *)),
+button:hover:where(:not(.unapi *)),
+button:hover[type="button"]:where(:not(.unapi *)),
+a.button:hover:where(:not(.unapi *)) {
     color: var(--hover-button-text-color);
     background: var(--hover-button-background);
 }
-input[disabled],
-textarea[disabled] {
+input[disabled]:where(:not(.unapi *)),
+textarea[disabled]:where(:not(.unapi *)) {
     color: var(--text-color);
     border-bottom-color: var(--disabled-input-border-color);
     opacity: 0.5;
     cursor: default;
 }
-input[type="button"][disabled],
-input[type="reset"][disabled],
-input[type="submit"][disabled],
-button[disabled],
-button[type="button"][disabled],
-a.button[disabled] input:hover[type="button"][disabled],
-input:hover[type="reset"][disabled],
-input:hover[type="submit"][disabled],
-button:hover[disabled],
-button:hover[type="button"][disabled],
-a.button:hover[disabled] input:active[type="button"][disabled],
-input:active[type="reset"][disabled],
-input:active[type="submit"][disabled],
-button:active[disabled],
-button:active[type="button"][disabled],
-a.button:active[disabled] {
+input[type="button"][disabled]:where(:not(.unapi *)),
+input[type="reset"][disabled]:where(:not(.unapi *)),
+input[type="submit"][disabled]:where(:not(.unapi *)),
+button[disabled]:where(:not(.unapi *)),
+button[type="button"][disabled]:where(:not(.unapi *)),
+a.button[disabled]:where(:not(.unapi *)),
+input:hover[type="button"][disabled]:where(:not(.unapi *)),
+input:hover[type="reset"][disabled]:where(:not(.unapi *)),
+input:hover[type="submit"][disabled]:where(:not(.unapi *)),
+button:hover[disabled]:where(:not(.unapi *)),
+button:hover[type="button"][disabled]:where(:not(.unapi *)),
+a.button:hover[disabled]:where(:not(.unapi *)),
+input:active[type="button"][disabled]:where(:not(.unapi *)),
+input:active[type="reset"][disabled]:where(:not(.unapi *)),
+input:active[type="submit"][disabled]:where(:not(.unapi *)),
+button:active[disabled]:where(:not(.unapi *)),
+button:active[type="button"][disabled]:where(:not(.unapi *)),
+a.button:active[disabled]:where(:not(.unapi *)) {
     opacity: 0.5;
     cursor: default;
     color: var(--disabled-text-color);
@@ -333,7 +335,7 @@ a.button:active[disabled] {
 input::-webkit-input-placeholder {
     color: var(--link-text-color);
 }
-select {
+select:where(:not(.unapi *)) {
     -webkit-appearance: none;
     font-family: clear-sans;
     font-size: 1.3rem;
@@ -356,18 +358,18 @@ select {
     display: inline-block;
     cursor: pointer;
 }
-select option {
+select:where(:not(.unapi *)) option {
     color: var(--text-color);
     background-color: var(--mild-background-color);
 }
-select option:disabled {
+select:where(:not(.unapi *)) option:disabled {
     color: var(--disabled-text-color);
 }
-select:focus {
+select:focus:where(:not(.unapi *)) {
     background-color: var(--focus-input-bg-color);
     outline: 0;
 }
-select[disabled] {
+select[disabled]:where(:not(.unapi *)) {
     color: var(--text-color);
     border-bottom-color: var(--disabled-border-color);
     opacity: 0.5;
@@ -414,7 +416,7 @@ input.trim {
     width: 76px;
     min-width: 76px;
 }
-textarea {
+textarea:where(:not(.unapi *)) {
     resize: none;
     padding: 6px;
     border: 1px solid var(--textarea-border-color);
@@ -951,7 +953,7 @@ div.title span img {
     -webkit-overflow-scrolling: touch;
 }
 
-table {
+table:where(:not(.unapi *)) {
     border-collapse: collapse;
     border-spacing: 0;
     border-style: hidden;
@@ -959,12 +961,12 @@ table {
     width: 100%;
     background-color: var(--background-color);
 }
-table thead td {
+table:where(:not(.unapi *)) thead td {
     line-height: 2.8rem;
     height: 2.8rem;
     white-space: nowrap;
 }
-table tbody td {
+table:where(:not(.unapi *)) tbody td {
     line-height: 2.6rem;
     height: 2.6rem;
     white-space: nowrap;


### PR DESCRIPTION
Uses `:where` to blunt-force prevent style collisions on primitive elements.

## Problem
The default-base theme applies global styles to primitive DOM elements (input, button, textarea, select, table, etc.). When integrating third-party components that provide their own stylesheets, these global rules override the component's intended styling, causing incorrect and unexpected visual behavior.
## Solution
Scope all primitive element selectors using :where(:not(.unapi *)) to exclude any elements that are descendants of containers marked with the .unapi class. This allows third-party components to maintain their own styling while preserving the theme's default styles for the rest of the application.
The :where() pseudo-class ensures these rules maintain zero specificity, preventing unintended specificity conflicts.
## Changes
Added :where(:not(.unapi *)) scoping to all input types (text, password, number, url, email, date, file)
Added scoping to button, textarea, select, and table elements and their states (:focus, :hover, :disabled)
Updated all related pseudo-class and pseudo-element selectors
## Usage
Third-party components can now be wrapped with a .unapi class to opt-out of global theme styles:
```html
<div class="unapi">
  <!-- Third-party component with its own styles -->
</div>
```