### PR TITLE
fix: disable rc.avahidnsconfd by default

### DIFF
--- a/etc/rc.d/rc.M
+++ b/etc/rc.d/rc.M
@@ -246,7 +246,7 @@ fi
 # Start avahi:
 if [[ -x /etc/rc.d/rc.avahidaemon ]]; then
   /etc/rc.d/rc.avahidaemon start
-  # disable by default, users can start manualy if needed
+  # disable by default, users can start manually if needed
   # /etc/rc.d/rc.avahidnsconfd start
 fi
 


### PR DESCRIPTION
rc.avahidaemon remains active

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled automatic startup of the avahidnsconfd service by default; it will no longer start during system boot. If needed, start the service manually.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->