### PR TITLE
Added speed and width to the PCI Devices and IOMMU Groups section of the System Devices page.

### DIFF
--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -2527,6 +2527,8 @@ Devices you select will be bound to the vfio-pci driver at boot, which makes the
 &nbsp;<i class="fa fa-retweet grey-orb middle"></i>&nbsp;&nbsp;&nbsp;This symbol indicates the device supports FLR (Function Level Reset).
 
 <input type="checkbox" value="" disabled>&nbsp;&nbsp;If a checkbox is greyed out it means the device is in use by Unraid OS and can not be passed through.
+
+The right two columns display the current and maximum speeds and widths (or PCIe lanes). Downgraded speeds and widths will appear in orange.
 :end
 
 :sysdevs_thread_pairings_help:


### PR DESCRIPTION
This adds some additional data from `lspci` to the System Devices page. It includes columns for the PCIe speed and width. I was having issues with a VM and was seeking a way to verify what speeds my PCIe devices were actually using. My goal was to add the additional information without making the page too busy or messy. With that in mind, I kept it to a minimum and just included these two additional pieces of information. Here is an example screenshot of the change:

<img width="1566" height="212" alt="image" src="https://github.com/user-attachments/assets/2b53afa3-ef6c-4684-bb92-7e74e724d9ad" />

Where applicable, the current and maximum speeds are displayed, as are the widths (or number of lanes). In the screenshot, it shows some devices are 16GT/s of the maximum 16GT/s for that device (which is PCIe 4.0). For devices that have been downgraded according to `lspci`, the current speed is shown in orange. Speeds that are not running at the maximum but have not been downgraded stay white. The same applies to the width.

Here are some of the benefits I believe this gives users:

- Aiding in troubleshooting hardware
- Aiding VM performance tuning
- Verifying PCIe UEFI settings without rebooting or complex CLI commands
- Verifying PCIe hardware capabilities without consulting motherboard manuals

I think this will be especially useful with GPUs, as GPU issues seem to be one of the more common topics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - PCIe devices now display current and maximum link speed and width information
  - Downgraded link speeds and widths are highlighted in orange for quick identification

* **Documentation**
  - Enhanced IOMMU help section with explanatory text describing speed/width column information
  - Expanded Security Modes documentation for User Shares and Disk Shares with detailed mode entries

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->