### PR TITLE
fix: standardize on /etc/hostname

### DIFF
--- a/etc/rc.d/rc.M
+++ b/etc/rc.d/rc.M
@@ -31,9 +31,6 @@ if [[ -x /etc/rc.d/rc.setterm ]]; then
   /etc/rc.d/rc.setterm
 fi
 
-# Set the hostname:
-hostname $(cat /etc/HOSTNAME)
-
 # Set the permissions on /var/log/dmesg according to whether the kernel
 # permits non-root users to access kernel dmesg information:
 if [[ -r /proc/sys/kernel/dmesg_restrict ]]; then

--- a/etc/rc.d/rc.S.cont
+++ b/etc/rc.d/rc.S.cont
@@ -225,7 +225,8 @@ if [[ -r /boot/config/ident.cfg ]]; then
   . <(/usr/bin/fromdos </boot/config/ident.cfg)
   NAME=${NAME//[^a-zA-Z\-\.0-9]/\-}
 fi
-/bin/echo "$NAME" >/etc/HOSTNAME
+hostname "$NAME"
+hostname -s >/etc/hostname
 /bin/echo "# Generated" >/etc/hosts
 /bin/echo "127.0.0.1      $NAME localhost" >>/etc/hosts
 

--- a/etc/rc.d/rc.avahidaemon
+++ b/etc/rc.d/rc.avahidaemon
@@ -31,7 +31,7 @@ CALLER="avahi"
 AVAHI="/usr/sbin/avahi-daemon"
 CONF="/etc/avahi/avahi-daemon.conf"
 HOSTS="/etc/hosts"
-NAME=$(</etc/HOSTNAME)
+NAME=$(hostname -s)
 
 # run & log functions
 . /etc/rc.d/rc.runlog


### PR DESCRIPTION
/etc/HOSTNAME is no longer set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hostname initialization now sets the runtime hostname and records the short hostname to the persistent hostname file, replacing prior file-only persistence.
  * Improved robustness and fallback detection during system startup so hostname is more reliably applied.
  * Simplified startup hostname logic to reduce failure modes and inconsistent sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->