### PR TITLE
fix: typo in rc.crond

### DIFF
--- a/etc/rc.d/rc.crond
+++ b/etc/rc.d/rc.crond
@@ -55,7 +55,7 @@ crond_restart(){
 }
 
 crond_status(){
-  if atd_running; then
+  if crond_running; then
     echo "$DAEMON is currently running."
   else
     echo "$DAEMON is not running."


### PR DESCRIPTION
prevented `/etc/rc.d/rc.crond status` from working properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed the crond daemon status reporting to correctly identify the service status and return appropriate exit codes when the daemon is not running, enabling monitoring and management tools to accurately detect service failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->