### PR TITLE
feat: add new notification positions for upcoming Unraid API notification refactor

### DIFF
--- a/emhttp/plugins/dynamix/Notifications.page
+++ b/emhttp/plugins/dynamix/Notifications.page
@@ -118,7 +118,8 @@ _(Display position)_:
   <?=mk_option($notify['position'], "top-right", _("top-right"))?>
   <?=mk_option($notify['position'], "bottom-left", _("bottom-left"))?>
   <?=mk_option($notify['position'], "bottom-right", _("bottom-right"))?>
-  <?=mk_option($notify['position'], "center", _("center"))?>
+  <?=mk_option($notify['position'], "bottom-center", _("bottom-center"))?>
+  <?=mk_option($notify['position'], "top-center", _("top-center"))?>
   </select>
 
 :notifications_display_position_help:


### PR DESCRIPTION
# Purpose
Unraid API is refactoring the notification pane to use NuxtUI in an upcoming release **(not ready yet)**. 

NuxtUI allows notification toasts to be[ positioned ](https://ui.nuxt.com/docs/components/toast#change-global-position)in the `bottom-center` and `top-center`positions. 

In order to give Unraid users the most flexibility, we're requesting these changes are applied to the webgui. 
<img width="661" height="156" alt="image" src="https://github.com/user-attachments/assets/debdebb9-bb43-4a4a-b8a0-f12db62050ee" />

# Please Note
These changes are not ready to be merged yet. Please coordinate with the API team. @zackspear is aware of both the API and Webgui changes. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated notification display position options: replaced the single center option with bottom-center and top-center choices for improved positioning flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->