### PR TITLE
Fix fileTree dropdown closing when clicking scrollbar

### DIFF
--- a/emhttp/plugins/dynamix/Browse.page
+++ b/emhttp/plugins/dynamix/Browse.page
@@ -57,6 +57,14 @@ function autoscale(value) {
   return ((Math.round(scale*data)/scale)+' '+unit[base]).replace('.','<?=$display['number'][0]?>')+'/s';
 }
 
+function preventFileTreeClose() {
+  // Prevent fileTree dropdown from closing when clicking inside the dialog
+  // by stopping mousedown events from bubbling to the document handler
+  $('.ui-dfm').off('mousedown.dfmFileTree').on('mousedown.dfmFileTree', function(e) {
+    e.stopPropagation();
+  });
+}
+
 function folderContextMenu(id, button) {
   var opts = [];
   context.settings({button:button});
@@ -482,6 +490,9 @@ function doAction(action, title, id) {
     resizable: false,
     draggable: false,
     modal: true,
+    close: function() {
+      $('.ui-dfm').off('mousedown.dfmFileTree');
+    },
     buttons: {
       "_(Start)_": function(){
         if (dfm.running) return;
@@ -592,6 +603,7 @@ function doAction(action, title, id) {
     }
   });
   dfm_close_button();
+  preventFileTreeClose();
   if (action == 15) $('.ui-dfm .ui-dialog-buttonset button:eq(1)').prop('disabled',true);
   setTimeout(function(){if (dfm.window.find('#dfm_target').length) dfm.window.find('#dfm_target').focus().click(); else $('.ui-dfm .ui-dialog-buttonset button:eq(0)').focus();});
 }
@@ -749,6 +761,9 @@ function doActions(action, title) {
     resizable: false,
     draggable: false,
     modal: true,
+    close: function() {
+      $('.ui-dfm').off('mousedown.dfmFileTree');
+    },
     buttons: {
       "_(Start)_": function(){
         if (dfm.running) return;
@@ -862,6 +877,7 @@ function doActions(action, title) {
     }
   });
   dfm_close_button();
+  preventFileTreeClose();
   if (action == 15) $('.ui-dfm .ui-dialog-buttonset button:eq(1)').prop('disabled',true);
   setTimeout(function(){if (dfm.window.find('#dfm_target').length) dfm.window.find('#dfm_target').focus().click(); else $('.ui-dfm .ui-dialog-buttonset button:eq(0)').focus();});
 }


### PR DESCRIPTION
Prevent fileTree dropdown from closing when clicking inside the file manager dialog by stopping mousedown event propagation. This fixes the issue where clicking the scrollbar would inadvertently close the target folder selection dropdown.

Solution: Added preventFileTreeClose() function that prevents mousedown events inside .ui-dfm dialogs from bubbling to the document-level handler that closes the fileTree dropdown.

Fixes #2487

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where file-tree dropdowns would unexpectedly close when clicking inside action dialogs. The dialogs now consistently prevent this closure both when opened and after actions complete, improving file-management stability and usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->