### PR TITLE
Fix nchan regex to prevent intercepting /sub/ in file paths

### DIFF
--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -412,7 +412,7 @@ build_locations(){
 	#
 	# nchan subscriber endpoint
 	#
-	location ~ /sub/(.*)$ {
+	location ~ ^/sub/(.*)$ {
 	    nchan_subscriber;
 	    nchan_subscriber_timeout 0;
 	    # nchan_authorize_request <url here>


### PR DESCRIPTION
The regex pattern `~ /sub/(.*)$` matched `/sub/` anywhere in the path, including file paths like `/mnt/disk2/test/foo/sub/file.iso`. This caused nginx to route these requests to the nchan subscriber endpoint instead of serving the files.

Changed to `~ ^/sub/(.*)$` to only match paths that start with `/sub/`, which is the correct behavior for the nchan websocket endpoint.

Fixes #2493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL path matching precision for subscriber endpoints to prevent unintended route matches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->