### PR TITLE
Display warning-text in File Manager dialogbox in orange

### DIFF
--- a/emhttp/plugins/dynamix/Browse.page
+++ b/emhttp/plugins/dynamix/Browse.page
@@ -98,7 +98,7 @@ function addActionWarning(action, isBulk) {
   };
   var warningText = warningTexts[action];
   if (warningText) {
-    var $warning = $('<div class="dfm-warning">').html('<i class="fa fa-warning dfm"></i> ' + warningText);
+    var $warning = $('<div class="dfm-warning warning">').html('<i class="fa fa-warning dfm"></i> ' + warningText);
     $('.ui-dfm .ui-dialog-buttonset').prepend($warning);
   }
 }

--- a/emhttp/plugins/dynamix/styles/default-dynamix.css
+++ b/emhttp/plugins/dynamix/styles/default-dynamix.css
@@ -1525,7 +1525,6 @@ div.icon-zip {
         margin-right: 10px;
         display: inline-block;
         vertical-align: middle;
-        color: var(--alt-text-color);
     }
     
     .ui-dialog-buttonset {


### PR DESCRIPTION
As requested in [this comment](https://github.com/unraid/webgui/pull/2501#issuecomment-3743824925) of @SimonFair 

<img width="1000" height="299" alt="image" src="https://github.com/user-attachments/assets/60558589-796f-4586-876e-b01129a5dbcc" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Updated visual styling for warning elements displayed in File Manager dialogs
* Refined CSS class assignments and color properties affecting warning presentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->