### PR TITLE
Fix: Connectivity check fails with Squid/Strict Proxies (Force CONNECT on port 80)

### DIFF
--- a/emhttp/plugins/dynamix/include/OutgoingProxyLib.php
+++ b/emhttp/plugins/dynamix/include/OutgoingProxyLib.php
@@ -58,12 +58,17 @@ function proxy_online($proxyUrl) {
 	$rc	= true;
 
 	if ($proxyUrl) {
+		/*Define the check URL */
+		$checkurl = "http://www.msftncsi.com/ncsi.txt";
 		/* Initialize cURL session. */
-		$ch = curl_init("http://www.msftncsi.com/ncsi.txt");
-
+		$ch = curl_init($checkurl);
+		
+		/* Determine if tunneling is needed (HTTPS only). */
+		$isHttps = (parse_url($checkurl, PHP_URL_SCHEME) === 'https');
+		
 		/* Set cURL options. */
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 3);	/* Timeout in seconds. */
-		curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL, true);
+		curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL, $isHttps); /* Enable HTTP tunneling only for HTTPS to prevent CONNECT method on port 80. */
 		curl_setopt($ch, CURLOPT_PROXY, $proxyUrl);		/* Url is a proxy. */
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true); /* Return transfer as a string. */
 


### PR DESCRIPTION
### The Issue
The current implementation forces `CURLOPT_HTTPPROXYTUNNEL` to `true` for all connectivity checks. 
The check URL is currently `http://www.msftncsi.com/ncsi.txt` (Plain HTTP).

When `CURLOPT_HTTPPROXYTUNNEL` is enabled on an HTTP URL, cURL sends a `CONNECT` method request on port 80 (instead of a standard `GET`). 
Most strict proxy configurations (like Squid's default `safe_ports`) explicitly block the `CONNECT` method on non-SSL ports to prevent protocol tunneling security risks. 

This causes Unraid to incorrectly report "Offline" status even when connectivity is fine.

### The Fix
This PR refactors `proxy_online` to make the tunneling option conditional:
1. It defines the check URL in a variable `$checkurl`.
2. It checks the scheme:
   - If `https://` -> Enable Tunneling (True).
   - If `http://` -> Disable Tunneling (False).

This ensures compatibility with standard proxy configurations while remaining robust if the check URL is changed to HTTPS in the future.

### References / Community Reports
https://forums.unraid.net/topic/190733-712-outgoing-proxy-how/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outgoing proxy connection handling with dynamic URL detection and scheme-based tunneling configuration for enhanced compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->