### PR TITLE
fix(INET): fix ip v6 dns issue with ending ::

### DIFF
--- a/etc/rc.d/rc.inet1.conf
+++ b/etc/rc.d/rc.inet1.conf
@@ -34,6 +34,10 @@ unzero(){
 # function to remove leading zeros in IPv6 address
 unzero6(){
   local A M Q
+  if [[ $1 == "::" ]]; then
+    printf "::"
+    return 0
+  fi
   # Replace first :: with sentinel
   A=${1/::/:-:}
   M=
@@ -43,14 +47,14 @@ unzero6(){
       [[ $Q =~ ^[0-9A-Fa-f]{1,4}$ ]] || return 1
       printf "%s%x" "$M" "0x$Q"
     else
-      # Restore colon for sentinel
-      printf "%s:" "$M"
+      # Restore a single colon for sentinel
+      printf ":"
     fi
     M=:
   done
 
-  # Handle trailing ::
-  [[ $1 == *:: ]] && printf ":"
+  # Handle trailing :: (but avoid adding for the special case "::")
+  [[ $1 == *:: && $1 != "::" ]] && printf ":"
 }
 
 # Bergware - use associative format for multi-dimensional arrays


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked IPv6 address parsing to a clearer, component-by-component approach that preserves shorthand notation correctly.
  * Added explicit early handling for the special all-empty address form to ensure consistent output.

* **Bug Fixes**
  * Stricter validation of hexadecimal address segments; invalid segments now produce an error.
  * Correct handling of consecutive and trailing separators to prevent ambiguous or incorrect addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->