### PR TITLE
Add SSD parity warning for unformatted array devices

### DIFF
--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -105,7 +105,7 @@ function my_power($power) {
 }
 
 function parity_ssd_warning_text() {
-  return _('The array does not support parity with SSDs due to TRIM. For maximum speed, assign SSDs to a pool instead.');
+  return _('The array does not support parity with SSDs due to TRIM.').'<br>'._('For maximum speed, assign SSDs to a pool instead.').'<br>'._('Note: The array is optional - pools can be used without an array.');
 }
 
 function needs_parity_ssd_warning($disk) {
@@ -720,3 +720,4 @@ while (true) {
   sleep(1);
 }
 ?>
+ ?>


### PR DESCRIPTION
### Motivation
- Inform users in the array setup view when an unformatted device is an SSD/NVMe that parity is not supported with SSDs due to TRIM and recommend using a pool for maximum speed.

### Description
- Detect unformatted devices by checking `fsStatus` for values starting with `Unmountable` and detect SSD/NVMe devices by checking `rotational` and `transport == 'nvme'` in `emhttp/plugins/dynamix/nchan/device_list` inside `array_offline()`.
- Build an orange warning string: `The array does not support parity with SSDs due to TRIM. For maximum speed, assign SSDs to a pool instead.` and append it to the existing overwrite/warning message except for devices of type `Cache`.
- The change is limited to presenting the warning in the existing offline/unformatted device rows and does not change parity or device assignment logic.

### Testing
- The patch was applied and the modified file `emhttp/plugins/dynamix/nchan/device_list` was updated successfully; no automated tests were run.
- No runtime or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69798a9700548323af174918949c48a6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSD-specific parity warnings for offline disks — an orange alert advises assigning parity SSDs to a pool for optimal performance.

* **Improvements**
  * Enhanced array/device error tooltips show per-member status and more detailed ZFS-related error lines, plus explicit member ONLINE status when present, improving clarity in offline views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->