### PR TITLE
fix(css): exclude webgui styles from buttons/selects in api components

### DIFF
--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2274,9 +2274,9 @@ div#title.ud {
     input[type="button"],
     input[type="reset"],
     input[type="submit"],
-    button,
-    button[type="button"],
-    a.button {
+    button:where(:not(.unapi *)),
+    button[type="button"]:where(:not(.unapi *)),
+    a.button:where(:not(.unapi *)) {
         font-family: clear-sans;
         font-size: 1.2rem;
         font-weight: normal;
@@ -2346,7 +2346,7 @@ div#title.ud {
         color: var(--blue-700);
     }
 
-    select {
+    select:where(:not(.unapi *)) {
         min-width: 188px;
         max-width: 314px;
         padding: 6px 14px 6px 6px;


### PR DESCRIPTION
For the upcoming onboarding flow in 7.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined button and select element styling to no longer apply within specific content areas, preserving previous appearance for interactive elements outside those regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->