### PR TITLE
7.2: Fix parsing ip addr with peer information

### DIFF
--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -57,7 +57,7 @@ good(){
 show(){
   case $# in
     1) ip -br addr show scope global primary -deprecated to $1 2>/dev/null | awk '{gsub("@.+","",$1);print $1;exit}' ;;
-    2) ip -br addr show scope global primary -deprecated $1 $2 2>/dev/null | awk '{$1=$2="";print;exit}' | sed -r 's/ metric [0-9]+//g' ;;
+    2) ip -br addr show scope global primary -deprecated $1 $2 2>/dev/null | awk '{$1=$2="";print;exit}' | sed -r 's/ metric [0-9]+//g;s/ peer [0-9]+.[0-9]+.[0-9]+.[0-9]+\/[0-9]+//g;s/^ +//g' ;;
   esac
 }
 


### PR DESCRIPTION
When adding tun0 to listening interfaces in settings. Unraid 7+ tries to parse:
`ip addr show scope global primary -deprecated dev tun0`
```
36: tun0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc fq state UNKNOWN group default qlen 500
    link/none 
    inet 10.9.8.66 peer 10.9.8.65/32 scope global tun0
       valid_lft forever preferred_lft forever
```
and gets `10.9.8.66 peer 10.9.8.65/32 scope global tun0` as the "IP" of the interface. This then proceeds to break sshd and nginx config for unraid.

With this fix the peer information is removed and only the interfaces IP (in the example 10.9.8.66) is kept.

Info @wt-io-it