### PR TITLE
Feat: Display corrupted files in ZFS

### DIFF
--- a/emhttp/plugins/dynamix/include/FileSystemStatus.php
+++ b/emhttp/plugins/dynamix/include/FileSystemStatus.php
@@ -33,7 +33,7 @@ case 'btrfs-scrub':
 case 'zfs-scrub':
 case 'zfs-resilver':
 case 'zfs-expansion':
-  echo shell_exec("/usr/sbin/zpool status -P $path");
+  echo shell_exec("/usr/sbin/zpool status -Pv $path");
   break;
 default:
   switch ($cmd) {


### PR DESCRIPTION
Changes the output in pool status from 
```
  pool: storage
 state: DEGRADED
status: One or more devices is currently being resilvered.  The pool will
	continue to function, possibly in a degraded state.
action: Wait for the resilver to complete.
  scan: resilver in progress since Thu Feb 19 18:24:38 2026
	68.8T / 104T scanned at 2.81G/s, 48.3T / 104T issued at 1.97G/s
	2.80T resilvered, 46.64% done, 07:58:49 to go
expand: expanded raidz2-0 copied 103T in 4 days 00:32:32, on Sat Feb 14 20:04:35 2026
config:

	NAME                        STATE     READ WRITE CKSUM
	storage                     DEGRADED     0     0     0
	  raidz2-0                  DEGRADED     0     0     0
	    /dev/sdt1               ONLINE       0     0     9  (resilvering)
	    /dev/sdu1               ONLINE       0     0    14  (resilvering)
	    replacing-2             DEGRADED     0     0    26
	      11687508470009778260  UNAVAIL      0     0     0  was /dev/sdv1/old
	      /dev/sdv1             ONLINE       0     0     0  (resilvering)
.
.
.


errors: 1 data errors, use '-v' for a list
```
To instead be
```
  pool: storage
 state: DEGRADED
status: One or more devices is currently being resilvered.  The pool will
	continue to function, possibly in a degraded state.
action: Wait for the resilver to complete.
  scan: resilver in progress since Thu Feb 19 18:24:38 2026
	68.8T / 104T scanned at 2.80G/s, 48.5T / 104T issued at 1.97G/s
	2.81T resilvered, 46.84% done, 07:56:50 to go
expand: expanded raidz2-0 copied 103T in 4 days 00:32:32, on Sat Feb 14 20:04:35 2026
config:

	NAME                        STATE     READ WRITE CKSUM
	storage                     DEGRADED     0     0     0
	  raidz2-0                  DEGRADED     0     0     0
	    /dev/sdt1               ONLINE       0     0     9  (resilvering)
	    /dev/sdu1               ONLINE       0     0    14  (resilvering)
	    replacing-2             DEGRADED     0     0    26
	      11687508470009778260  UNAVAIL      0     0     0  was /dev/sdv1/old
	      /dev/sdv1             ONLINE       0     0     0  (resilvering)
.
.
.


errors: Permanent errors have been detected in the following files:

        /mnt/storage/EBooks/Calibre Library/Nina Planck/Real Food_ What to Eat and Why (3620)/cover.jpg
```


There is no change if there are no files corrupted in display.   If you delete the file, the list will be empty, but stopping and starting will clear the message


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced zpool status reporting to display more detailed information during storage pool maintenance operations (scrub, resilver, and expansion).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->