### PR TITLE
Fix rc.sshd: auto-restart SSH daemon after network recovery

### DIFF
--- a/etc/rc.d/rc.sshd
+++ b/etc/rc.d/rc.sshd
@@ -126,6 +126,9 @@ sshd_update(){
   if sshd_running && check && [[ "$(this ListenAddress)" != "${BIND[@]}" ]]; then
     log "Updating $DAEMON..."
     sshd_reload
+  elif ! sshd_running && [[ $USE_SSH == yes ]]; then
+    log "Recovering $DAEMON..."
+    sshd_start
   fi
 }
 


### PR DESCRIPTION
When the network interface goes down temporarily (e.g., switch reboot), the reload_services mechanism calls `rc.sshd update` after 20 seconds:
```
Feb 15 00:33:18 atum kernel: e1000e 0000:00:1f.6 eth0: NIC Link is Down
...
Feb 15 00:33:32 atum rc.sshd: Updating SSH server daemon...
```

If sshd crashed during the network outage, it remained down permanently. Example:

```
Feb 15 00:33:32 atum sshd[1658]: Received signal 15; terminating.
Feb 15 00:33:32 atum sshd[1889648]: error: Bind to port 22 on 192.168.1.129 failed: Cannot assign requested address.
Feb 15 00:33:32 atum sshd[1889648]: fatal: Cannot bind any address.
```

This is because `rc.ssh update` requires a running sshd service:
```
if sshd_running
```

This fix adds an `elif` clause to restart sshd if:
- sshd is not running (`! sshd_running`)
- SSH is enabled (`USE_SSH=yes`)

And it creates a "Recovering" log entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SSH daemon recovery: Improved automatic recovery mechanism to ensure the SSH service restarts when configured to be active but found inactive, strengthening system reliability and availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->