### PR TITLE
Feat: Show corrupted ZFS files

### DIFF
--- a/emhttp/plugins/dynamix/scripts/zfs_scrub
+++ b/emhttp/plugins/dynamix/scripts/zfs_scrub
@@ -13,9 +13,9 @@ case "$1" in
 ;;
 'status')
   # first output whatever the status is to stdout
-  /usr/sbin/zpool status -P $2
+  /usr/sbin/zpool status -Pv $2
   # establish retval of this script: 0 running, 1 not running
-  /usr/sbin/zpool status -P $2 | grep -q 'scrub in progress'
+  /usr/sbin/zpool status -Pv $2 | grep -q 'scrub in progress'
 ;;
 'cancel')
   /usr/sbin/zpool scrub -s $2 2>/dev/null


### PR DESCRIPTION
RE: https://github.com/unraid/webgui/pull/2547

This displays the corrupted files if no resilver / scrub / expansion is in progress

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZFS scrub status detection and monitoring to ensure accurate reporting of scrub operation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->