### PR TITLE
Fixed spelling mistake for the scrub/balance message when the pool is unmounted

### DIFF
--- a/emhttp/plugins/dynamix/DeviceInfo.page
+++ b/emhttp/plugins/dynamix/DeviceInfo.page
@@ -1141,7 +1141,7 @@ _(btrfs filesystem usage)_:
 &nbsp;
 : <span class="inline-block">
     <input type="submit" value="_(Balance)_" disabled>
-    <span class="inline-block"><b>_(Balance)_</b> _(is only available when the filesyestem is mounted)_</span>
+    <span class="inline-block"><b>_(Balance)_</b> _(is only available when the filesystem is mounted)_</span>
   </span>
 
 <?endif;?>
@@ -1257,7 +1257,7 @@ _(btrfs scrub status)_:
 &nbsp;
 : <span class="inline-block">
     <input type="submit" value="_(Scrub)_" disabled>
-    <span class="inline-block"><b>_(Scrub)_</b> _(is only available when the filesyestem is mounted)_</span>
+    <span class="inline-block"><b>_(Scrub)_</b> _(is only available when the filesystem is mounted)_</span>
   </span>
 
 <?endif;?>
@@ -1459,7 +1459,7 @@ _(zfs pool status)_:
 : <span class="inline-block">
     <input type="submit" value="_(Scrub)_" disabled>
     <span class="inline-block">
-      <?=!$tag || $tag == prefix($tag) ? "<b>"._('Scrub')."</b> "._('is only available when the filesyestem is mounted') : sprintf(_('See %s Settings'), ucfirst(prefix($tag)))?>
+      <?=!$tag || $tag == prefix($tag) ? "<b>"._('Scrub')."</b> "._('is only available when the filesystem is mounted') : sprintf(_('See %s Settings'), ucfirst(prefix($tag)))?>
     </span>
   </span>
 


### PR DESCRIPTION
<img width="518" height="113" alt="image" src="https://github.com/user-attachments/assets/20cf34b5-cc23-4b18-bbfc-a36571a3c383" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected spelling of "filesystem" in three user-visible text strings across the Device Info interface, including tooltip text for Balance and Scrub actions, and status messaging for ZFS pool scrub controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->