### PR TITLE
Use Asia/Kolkata instead of legacy Asia/Calcutta

### DIFF
--- a/emhttp/plugins/dynamix/include/timezones.key
+++ b/emhttp/plugins/dynamix/include/timezones.key
@@ -60,7 +60,7 @@ Asia/Kabul|(UTC+04:30) Kabul
 Asia/Yekaterinburg|(UTC+05:00) Ekaterinburg
 Asia/Karachi|(UTC+05:00) Islamabad, Karachi
 Asia/Tashkent|(UTC+05:00) Ashgabat, Tashkent
-Asia/Calcutta|(UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi
+Asia/Kolkata|(UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi
 Asia/Colombo|(UTC+05:30) Sri Jayawardenepura
 Asia/Katmandu|(UTC+05:45) Kathmandu
 Asia/Almaty|(UTC+06:00) Astana


### PR DESCRIPTION
## Summary
- replace legacy India timezone ID Asia/Calcutta with canonical Asia/Kolkata in timezone lookup key
- updates the value used when selecting (UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi

## Testing
- verified both include paths resolve to the same updated key entry (Asia/Kolkata)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated timezone identifiers to align with current international naming standards while preserving all UTC offset and location information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes https://github.com/unraid/webgui/issues/2560