### PR TITLE
Fix(Warnings): change XFS and ReiserFS messages

### DIFF
--- a/emhttp/plugins/dynamix/include/Helpers.php
+++ b/emhttp/plugins/dynamix/include/Helpers.php
@@ -334,7 +334,7 @@ function check_deprecated_filesystem($disk) {
         $warnings[] = [
           'type' => 'xfs_v4',
           'severity' => 'critical',
-          'message' => _('XFS v4 is deprecated and will not be supported in future Unraid releases. Please migrate to XFS immediately.')
+          'message' => _('XFS v4 is deprecated and will not be supported in future Unraid releases. Please migrate to XFS v5 immediately.')
         ];
       }
     }
@@ -702,7 +702,7 @@ function check_disk_for_deprecated_fs($disk) {
             'name' => $name,
             'fsType' => 'XFS v4',
             'severity' => 'notice',
-            'message' => 'XFS v4 is deprecated and will not be supported in future Unraid releases. You have until 2030 to migrate to XFS.'
+            'message' => 'XFS v4 is deprecated and will not be supported in future Unraid releases. You have until 2030 to migrate to XFS v5.'
           ];
         }
       }
@@ -867,7 +867,7 @@ if (!sessionStorage.getItem('xfs-{$id}-dismissed')) {
                     {$diskList}
                 </ul>
                 <div style="margin-top: 10px;">
-                      <strong>Recommendation:</strong> Plan to migrate to XFS, BTRFS, or ZFS {$timeline}. 
+                      <strong>Recommendation:</strong> Plan to migrate to XFS v5, BTRFS, or ZFS {$timeline}. 
                     <a href="https://docs.unraid.net/go/convert-reiser-and-xfs" 
                        target="_blank" style="color: #0066cc;">View migration guide →</a>
                 </div>


### PR DESCRIPTION
<img width="2922" height="459" alt="image" src="https://github.com/user-attachments/assets/f1c5f278-c62c-4779-884c-d284c2e82a8f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified ReiserFS deprecation warning to note it may require downgrading to Unraid 7.2.
  * Updated XFS v4 deprecation text to reference migration to XFS v5.
  * Added a fixed deadline (2030-10-01) and human-readable timeline (years/months or "less than 1 month") for warnings; if past deadline guidance becomes "as soon as possible."
  * Timeline now appended to array/disk and pool migration recommendations; timeline computed only when before the deadline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->