### PR TITLE
fix(notify): avoid fatal in notify get when .notify fields are out of order

### DIFF
--- a/emhttp/plugins/dynamix/scripts/notify
+++ b/emhttp/plugins/dynamix/scripts/notify
@@ -286,17 +286,21 @@ case 'get':
   $i = 0;
   foreach ($files as $file) {
     $fields = file($file,FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES);
-    $time = true;
     $output[$i]['file'] = basename($file);
     $output[$i]['show'] = (fileperms($file) & 0x0FFF)==0400 ? 0 : 1;
     foreach ($fields as $field) {
       if (!$field) continue;
       # limit the explode('=', …) used during reads to two pieces so values containing = remain intact
       [$key,$val] = array_pad(explode('=', $field, 2),2,'');
-      if ($time) {$val = date($notify['date'].' '.$notify['time'], $val); $time = false;}
+      $key = trim($key);
+      if ($key === '') continue;
       # unescape the value before emitting JSON, so the browser UI
       # and any scripts calling `notify get` still see plain strings
-      $output[$i][trim($key)] = ini_decode_value($val);
+      $output[$i][$key] = ini_decode_value($val);
+    }
+    $timestamp = _var($output[$i], 'timestamp');
+    if (is_numeric($timestamp)) {
+      $output[$i]['timestamp'] = date($notify['date'].' '.$notify['time'], (int)$timestamp);
     }
     $i++;
   }


### PR DESCRIPTION
## Summary
- fix `notify get` to parse unread `.notify` fields in an order-independent way
- stop assuming the first line is `timestamp`
- format the timestamp only when a numeric `timestamp` key is present

## Why
Some notification writers can produce valid `.notify` files with `timestamp` not on the first line (for example, `description` first).
The previous parser called `date()` on the first value unconditionally, which can throw:

`TypeError: date(): Argument #2 ($timestamp) must be of type ?int, string given`

This fatal can repeat via `notify_poller` and flood `phplog`.

## Validation
- Reproduced failure using PHP 8.3.26 with a malformed sample (`description` first, `timestamp` last):
  - old behavior: fatal at `notify` line 296
- Re-ran with this patch:
  - `notify get` exits successfully
  - JSON output includes both normal and malformed sample files
  - `timestamp` is formatted when numeric

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how notification timestamps are processed and formatted for display
  * Improved notification data key and value handling for better consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->