### PR TITLE
fix(Bootinfo): Show additional GUIDs

### DIFF
--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -14,6 +14,7 @@ Tag="usb"
  * all copies or substantial portions of the Software.
  */
 ?>
+<?$tpmEnabled = is_dir('/sys/class/tpm/tpm0');?>
 <script>
 function cleanUp(zip) {
   if (document.hasFocus()) {
@@ -53,6 +54,14 @@ _(Flash Product)_:
 
 _(Flash GUID)_:
 : <?=htmlspecialchars($var['flashGUID'] ?? '', ENT_QUOTES, 'UTF-8');?>&nbsp;
+
+<?if ($tpmEnabled):?>
+_(TPM Licensing)_:
+: _(TPM licensing is available.)_
+
+_(TPM GUID)_:
+: <?=htmlspecialchars($var['tpmGUID'] ?? '', ENT_QUOTES, 'UTF-8');?>&nbsp;
+<?endif;?>
 
 
 <?if (strstr($var['regTy'], "blacklisted")):?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added TPM detection to identify when TPM hardware is present on your system.
* TPM Licensing and TPM GUID information now display conditionally based on TPM availability, improving system information clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->