### PR TITLE
fix(Bootinfo):  change tpm id from 03 to 01

### DIFF
--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -14,7 +14,7 @@ Tag="usb"
  * all copies or substantial portions of the Software.
  */
 ?>
-<?$tpmEnabled = !empty($var['flashGUID']) && strpos($var['flashGUID'], '03-') !== 0 && !empty($var['tpmGUID']) ? true : false;?>
+<?$tpmEnabled = !empty($var['flashGUID']) && strpos($var['flashGUID'], '01-') !== 0 && !empty($var['tpmGUID']) ? true : false;?>
 <script>
 function cleanUp(zip) {
   if (document.hasFocus()) {
@@ -55,7 +55,7 @@ _(Active GUID)_:
 
 <?if (!empty($var['flashGUID'])):?>
 _(GUID Type)_:
-: <?=(strpos($var['flashGUID'], '03-') === 0) ? _('TPM') : _('Flash');?>
+: <?=(strpos($var['flashGUID'], '01-') === 0) ? _('TPM') : _('Flash');?>
 <?endif;?>
 
 <?if ($tpmEnabled):?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TPM and Flash storage device identification logic to ensure accurate boot device classification and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->