### PR TITLE
Fix: PHP error

### DIFF
--- a/emhttp/plugins/dynamix/include/Helpers.php
+++ b/emhttp/plugins/dynamix/include/Helpers.php
@@ -1717,7 +1717,7 @@ function get_block_devices(): array
 function sysfs_read(string $path): ?string
 {
     return is_readable($path)
-        ? (($v = trim(file_get_contents($path))) !== '' ? $v : null)
+        ? (($v = trim(@file_get_contents($path))) !== '' ? $v : null)
         : null;
 }
 


### PR DESCRIPTION
PHP Error if array stopped and pool in degraded state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling robustness to reduce unnecessary warning messages during file read operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->