### PR TITLE
Move Onboarding Wizard to Tools and add device link

### DIFF
--- a/emhttp/plugins/dynamix/OnboardingWizard.page
+++ b/emhttp/plugins/dynamix/OnboardingWizard.page
@@ -1,4 +1,4 @@
-Menu="UserPreferences:z"
+Menu="Tools:30"
 Type="xmenu"
 Title="Onboarding Wizard"
 Icon="magic"
@@ -22,7 +22,7 @@ function openOnboardingWizard() {
 }
 </script>
 
-<form markdown="1" name="user_onboarding_settings">
+<form markdown="1" name="onboarding_wizard_settings">
 _(Onboarding Wizard)_:
 : <span class="inline-block">
   <input type="button" value="_(Show Onboarding Wizard)_" onclick="openOnboardingWizard()" <?if (_var($var,'fsState')=="Started"):?>disabled<?endif;?>>

--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -1076,6 +1076,13 @@ while (true) {
     $echo[$a][] = "<td class='desc'>$desc</td>";
     $echo[$a][] = "<td colspan='8'></td>";
     $echo[$a][] = "</tr>";
+  } else {
+    $onboardingLink = "<a href=\"/Tools/OnboardingWizard\">"._('Onboarding Wizard')."</a>";
+    $echo[$a][] = "<tr>";
+    $echo[$a][] = "<td><span class='left'><i class='fa fa-magic title'></i> "._('Internal Boot')."</span></td>";
+    $echo[$a][] = "<td class='desc'>".sprintf(_('No internal boot setup detected. Launch %s to configure one.'), $onboardingLink)."</td>";
+    $echo[$a][] = "<td colspan='8'></td>";
+    $echo[$a][] = "</tr>";
   }
   $echo[$a] = implode($echo[$a]);
 


### PR DESCRIPTION
## Summary
- rename `UserOnboarding` to `OnboardingWizard`
- keep the wizard under `Tools`
- add an Internal Boot device-list link to launch the Onboarding Wizard when no internal boot setup is detected

## Testing
- not run (UI change only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added guidance message when no internal boot device is detected, with a link to the Onboarding Wizard.

* **UI Changes**
  * Reorganized Onboarding Wizard menu location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->