### PR TITLE
refactor: simplify rclone config persistence layout

### DIFF
--- a/sbin/rclone_config_init
+++ b/sbin/rclone_config_init
@@ -86,6 +86,11 @@ seed_boot_config() {
 }
 
 link_root_config_file() {
+  if [[ ! -r "$RCLONE_BOOT_CONFIG" ]]; then
+    log_issue "ERROR: refusing to replace rclone runtime config because $RCLONE_BOOT_CONFIG is missing or unreadable"
+    return 1
+  fi
+
   if [[ -L "$RCLONE_ROOT_CONFIG" ]]; then
     local link_target
     link_target=$(readlink -f "$RCLONE_ROOT_CONFIG" 2>/dev/null || readlink "$RCLONE_ROOT_CONFIG" 2>/dev/null || true)


### PR DESCRIPTION
## Summary
- simplify the existing `rclone_config_init` flow around `/boot/config/rclone/root/rclone.conf` as the canonical persistent config path
- migrate the legacy `/boot/config/rclone/rclone.conf` path into the new root subdirectory
- keep the runtime/default rclone path at `/root/.config/rclone/rclone.conf`, with that runtime location linked back to the persistent copy under `/boot/config/rclone/root`
- keep plugin config support as a one-time seed when present

## Why
The current code on `master` already persists rclone config successfully. This PR does not treat `master` as broken.

Instead, it reduces the amount of migration and backup logic in `rclone_config_init` so the implementation better matches the later preferred direction from the ticket discussion: a simpler symlink-oriented layout rooted at `/boot/config/rclone/root`.

To be explicit about paths:
- persistent canonical file: `/boot/config/rclone/root/rclone.conf`
- runtime/default path used by rclone: `/root/.config/rclone/rclone.conf`

This PR does **not** move persistence to `/root`; `/root/.config/rclone` remains the runtime path only.

## Verification
- ran `bash /Users/elibosley/Code/webgui/tests/rclone_config_init_test.sh` locally
- installed PR plugin on `devgen-dev1.local` and verified both the normal migration path and the failure case where the runtime config must be preserved if the boot config is unavailable

## Notes
- the local verification script was intentionally not included in this PR
- browser smoke on `devgen-dev1.local` was blocked by target certificate trust in the headless browser, but system-level QA for this boot-time script passed
