### PR TITLE
fix: reset stale Tailscale funnel/serve state on restart

### DIFF
--- a/share/docker/tailscale_container_hook
+++ b/share/docker/tailscale_container_hook
@@ -298,6 +298,13 @@ while true; do
   sleep 2
 done
 
+# Clear persisted Serve/Funnel state before applying the current template mode.
+# Without this, switching the template from Funnel/Serve to No leaves the old
+# config active in the existing Tailscale state directory after restart.
+echo "Resetting Tailscale Serve/Funnel configuration"
+tailscale funnel reset >/dev/null 2>&1 || true
+tailscale serve reset >/dev/null 2>&1 || true
+
 if [ ! -z "${TAILSCALE_SERVE_PORT}" ] && [ "$(tailscale status --json | jq -r '.CurrentTailnet.MagicDNSEnabled')" != "false" ] && [ -z "$(tailscale status --json | jq -r '.Self.Capabilities[] | select(. == "https")')" ]; then
   echo "ERROR: Enable MagicDNS and HTTPS on your Tailscale account to use Tailscale Serve/Funnel."
   echo "See: https://tailscale.com/kb/1153/enabling-https"


### PR DESCRIPTION
## Summary
- reset any persisted Tailscale Funnel and Serve config after `tailscale up`
- reapply only the currently configured template-managed mode after the reset
- prevent containers switched to `Tailscale Serve = No` from keeping an old funnel exposure after restart

## Root cause
The container hook persisted serve/funnel state in the Tailscale state directory. When a user changed the Docker template from `Funnel` or `Serve` to `No`, the related env vars disappeared, but the hook never cleared the old state before startup completed.

## Verification
- `bash -n share/docker/tailscale_container_hook`

## Related report
- FeatureOS: https://product.unraid.net/p/tailscale-funnel-does-not-turn-off

## Notes
- I attempted to verify this on the referenced Unraid dev host, but live SSH validation was blocked by hostname resolution and a host-key mismatch for the reachable box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tailscale Serve and Funnel configurations are now automatically reset during container startup, ensuring clean configuration state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
