### PR TITLE
Remove -k flag from notification agents using public APIs

### DIFF
--- a/emhttp/plugins/dynamix/agents/Boxcar.xml
+++ b/emhttp/plugins/dynamix/agents/Boxcar.xml
@@ -14,7 +14,7 @@
       ############
       MESSAGE=$(echo -e "$MESSAGE")
 
-      curl -s -k \
+      curl -s \
       -d "user_credentials=$ACCESS_TOKEN" \
       -d "notification[title]=$TITLE" \
       -d "notification[long_message]=$MESSAGE" \

--- a/emhttp/plugins/dynamix/agents/Join.xml
+++ b/emhttp/plugins/dynamix/agents/Join.xml
@@ -14,7 +14,7 @@
     TITLE=$(echo -e "$TITLE")
     MESSAGE=$(echo -e "$MESSAGE")
   
-    curl -s -k -G \
+    curl -s -G \
     -d "apikey=$API_KEY" \
     --data-urlencode "title=$TITLE" \
     --data-urlencode "text=$MESSAGE" \

--- a/emhttp/plugins/dynamix/agents/Prowl.xml
+++ b/emhttp/plugins/dynamix/agents/Prowl.xml
@@ -28,7 +28,7 @@
       ;;
       esac
 
-      curl -s -k \
+      curl -s \
       -F "apikey=$API_KEY" \
       -F "application=$APP_NAME" \
       -F "event=$TITLE" \

--- a/emhttp/plugins/dynamix/agents/Pushbullet.xml
+++ b/emhttp/plugins/dynamix/agents/Pushbullet.xml
@@ -14,7 +14,7 @@
       ##########
       MESSAGE=$(echo "$MESSAGE" | sed -e 's:<br[ /]*>:\\n:gI' -e 's/<[^>]*>//g')
 
-      curl -s -k \
+      curl -s \
       -X POST --header "Authorization: Bearer $TOKEN" \
       --header  'Content-Type: application/json' \
       -d "{\"type\": \"note\", \"title\": \"$TITLE\", \"body\": \"$MESSAGE\"}" \

--- a/emhttp/plugins/dynamix/agents/Pushover.xml
+++ b/emhttp/plugins/dynamix/agents/Pushover.xml
@@ -25,7 +25,7 @@
       ;;
       esac
 
-      curl -s -k \
+      curl -s \
       -F "token=$APP_TOKEN" \
       -F "user=$USER_KEY" \
       -F "message=$MESSAGE" \

--- a/emhttp/plugins/dynamix/agents/Pushplus.xml
+++ b/emhttp/plugins/dynamix/agents/Pushplus.xml
@@ -25,7 +25,7 @@
       [[ -n "${WEBHOOK}" && "${WEBHOOK}" == "none" ]] && WEBHOOK=""
       [[ -n "${CALLBACKURL}" && "${CALLBACKURL}" == "none" ]] && CALLBACKURL=""
 
-      curl -s -k -X POST \
+      curl -s -X POST \
       -F "token=$TOKEN" \
       -F "title=$TITLE" \
       -F "content=$MESSAGE" \

--- a/emhttp/plugins/dynamix/agents/ServerChan.xml
+++ b/emhttp/plugins/dynamix/agents/ServerChan.xml
@@ -20,7 +20,7 @@
       [[ -n "${CHANNEL}" && "${CHANNEL}" == "none" ]] && CHANNEL=""
       [[ -n "${OPENID}" && "${OPENID}" == "none" ]] && OPENID=""
 
-      curl -s -k -X POST \
+      curl -s -X POST \
       -F "title=$TITLE" \
       -F "desp=$MESSAGE" \
       -F "channel=$CHANNEL" \


### PR DESCRIPTION
The `-k` flag disables TLS certificate validation in curl. Among the existing notification agents, I found 7 that call public APIs with valid SSL certificates but still use `-k` unnecessarily. 

**Affected agents:** Boxcar, Join, Prowl, Pushbullet, Pushover, Pushplus, ServerChan.

I was able to reach all 7 APIs and confirmed that each one presents a valid SSL certificate.
There is therefore no reason to use `-k`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced TLS certificate verification for notification services (Boxcar, Join, Prowl, Pushbullet, Pushover, Pushplus, ServerChan) to enforce valid certificates and improve notification system security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->