### PR TITLE
Add TLS certificate verification option for self-hosted notification agents

### DIFF
--- a/emhttp/plugins/dynamix/NotificationAgents.page
+++ b/emhttp/plugins/dynamix/NotificationAgents.page
@@ -190,6 +190,7 @@ foreach ($xml_files as $xml_file) {
         $vHelp = preg_replace('#\[([^\]]*)\]#', '<$1>', $v->attributes()->Help);
         $currentValue = isset($values[$vName]) ? $values[$vName] : $vDefault;
         $isTitleOrMessage = preg_match('/title|message/', $vDesc);
+        $isVerify = preg_match('/verify/i', $vDesc);
         ?>
         <dl>
             <dt><?= $vDesc ?>:</dt>
@@ -201,6 +202,11 @@ foreach ($xml_files as $xml_file) {
                         <?php foreach ($fields as $field): ?>
                             <?= mk_option_check($value, '$'.strtoupper($field), _($field)) ?>
                         <?php endforeach; ?>
+                    </select>
+                <?php elseif ($isVerify): ?>
+                    <select name="<?= $vName ?>" class="variable">
+                        <?= mk_option($currentValue, 'yes', _('Yes')) ?>
+                        <?= mk_option($currentValue, 'no', _('No')) ?>
                     </select>
                 <?php else: ?>
                     <input type="text" name="<?= $vName ?>" class="variable" required value="<?= $currentValue ?>">

--- a/emhttp/plugins/dynamix/agents/Gotify.xml
+++ b/emhttp/plugins/dynamix/agents/Gotify.xml
@@ -3,7 +3,7 @@
     <Name>Gotify</Name>
     <Variables>
       <Variable Help="The full server base URL including protocol and port. eg: https://example.com:8888/" Desc="Full Server Base URL" Default="">SERVER_URL</Variable>
-      <Variable Help="Enable TLS certificate verification for the server URL. Disable only if your server uses a self-signed certificate." Desc="Verify TLS certificate" Default="yes">VERIFY_TLS</Variable>
+      <Variable Help="Enable TLS certificate verification for the server URL. Disable if your server does not use TLS or uses a self-signed certificate." Desc="Verify TLS certificate" Default="yes">VERIFY_TLS</Variable>
       <Variable Help="The App Token to use." Desc="App Token" Default="">APP_TOKEN</Variable>
       <Variable Help="Specify the fields which are included in the title of the notification." Desc="Notification Title" Default="$SUBJECT">TITLE</Variable>
       <Variable Help="Specify the fields which are included in the message body of the notification." Desc="Notification Message" Default="$DESCRIPTION">MESSAGE</Variable>

--- a/emhttp/plugins/dynamix/agents/Gotify.xml
+++ b/emhttp/plugins/dynamix/agents/Gotify.xml
@@ -3,6 +3,7 @@
     <Name>Gotify</Name>
     <Variables>
       <Variable Help="The full server base URL including protocol and port. eg: https://example.com:8888/" Desc="Full Server Base URL" Default="">SERVER_URL</Variable>
+      <Variable Help="Enable TLS certificate verification for the server URL. Disable only if your server uses a self-signed certificate." Desc="Verify TLS certificate" Default="yes">VERIFY_TLS</Variable>
       <Variable Help="The App Token to use." Desc="App Token" Default="">APP_TOKEN</Variable>
       <Variable Help="Specify the fields which are included in the title of the notification." Desc="Notification Title" Default="$SUBJECT">TITLE</Variable>
       <Variable Help="Specify the fields which are included in the message body of the notification." Desc="Notification Message" Default="$DESCRIPTION">MESSAGE</Variable>
@@ -29,7 +30,8 @@
       # Remove any trailing slash
       SERVER_URL=${SERVER_URL%/}
 
-      curl -s -k -X POST \
+      [[ "$VERIFY_TLS" == "no" ]] && K_FLAG="-k" || K_FLAG=""
+      curl -s $K_FLAG -X POST \
       -F "title=$TITLE" \
       -F "message=$MESSAGE" \
       -F "priority=$PRIORITY" \

--- a/emhttp/plugins/dynamix/agents/PushBits.xml
+++ b/emhttp/plugins/dynamix/agents/PushBits.xml
@@ -3,7 +3,7 @@
     <Name>PushBits</Name>
     <Variables>
       <Variable Help="The full server base URL including protocol and port. eg: https://example.com:8080/" Desc="Full Server Base URL" Default="FULL PUSHBITS URL">SERVER_URL</Variable>
-      <Variable Help="Enable TLS certificate verification for the server URL. Disable only if your server uses a self-signed certificate." Desc="Verify TLS certificate" Default="yes">VERIFY_TLS</Variable>
+      <Variable Help="Enable TLS certificate verification for the server URL. Disable if your server does not use TLS or uses a self-signed certificate." Desc="Verify TLS certificate" Default="yes">VERIFY_TLS</Variable>
       <Variable Help="The App Token to use." Desc="App Token" Default="YOUR APP TOKEN">APP_TOKEN</Variable>
       <Variable Help="Specify the fields which are included in the title of the notification." Desc="Notification Title" Default="$SUBJECT">TITLE</Variable>
       <Variable Help="Specify the fields which are included in the message body of the notification." Desc="Notification Message" Default="$DESCRIPTION">MESSAGE</Variable>

--- a/emhttp/plugins/dynamix/agents/PushBits.xml
+++ b/emhttp/plugins/dynamix/agents/PushBits.xml
@@ -3,6 +3,7 @@
     <Name>PushBits</Name>
     <Variables>
       <Variable Help="The full server base URL including protocol and port. eg: https://example.com:8080/" Desc="Full Server Base URL" Default="FULL PUSHBITS URL">SERVER_URL</Variable>
+      <Variable Help="Enable TLS certificate verification for the server URL. Disable only if your server uses a self-signed certificate." Desc="Verify TLS certificate" Default="yes">VERIFY_TLS</Variable>
       <Variable Help="The App Token to use." Desc="App Token" Default="YOUR APP TOKEN">APP_TOKEN</Variable>
       <Variable Help="Specify the fields which are included in the title of the notification." Desc="Notification Title" Default="$SUBJECT">TITLE</Variable>
       <Variable Help="Specify the fields which are included in the message body of the notification." Desc="Notification Message" Default="$DESCRIPTION">MESSAGE</Variable>
@@ -29,7 +30,8 @@
       # Remove any trailing slash
       SERVER_URL=${SERVER_URL%/}
 
-      curl -s -k -X POST \
+      [[ "$VERIFY_TLS" == "no" ]] && K_FLAG="-k" || K_FLAG=""
+      curl -s $K_FLAG -X POST \
       -F "title=$TITLE" \
       -F "message=$MESSAGE" \
       -F "priority=$PRIORITY" \


### PR DESCRIPTION
Gotify and PushBits are self-hosted services where users may run their own servers with self-signed certificates. Previously, these agents always used `-k` to disable TLS certificate validation, which is a potential security risk. In the age of Let's Encrypt, valid certificates are easy to obtain even for self-hosted services.

This PR adds a "Verify TLS certificate" dropdown (Yes/No) to both agents, allowing users to choose whether certificate validation should be enforced. The default is "Yes" to encourage secure connections.
<img width="1208" height="575" alt="image" src="https://github.com/user-attachments/assets/d22d9297-10b0-4001-bf35-2833f99fe26e" />

To support this, `NotificationAgents.page` has been extended to render a Yes/No dropdown when a variable's description contains the word "verify". This makes the feature available to any future agent that needs the same option.

No further changes were made. 

I successfully tested the entire flow from the UI, through the VERIFY_TLS flag in the generated .sh script, all the way to the actual curl call both with "yes" and "no".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TLS certificate verification toggle for Gotify and PushBits notification agents (enabled by default)
  * Enhanced user interface for verification settings with binary Yes/No dropdown controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->