### PR TITLE
Prevent rc.docker from trying to start up non-unRAID containers

### DIFF
--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -157,12 +157,12 @@ wait_daemon(){
 
 # All existing containers
 all_containers(){
-  docker ps -a --format='{{.Names}}' 2>/dev/null
+  docker container ls -a --format='{{.Names}} {{.Labels}}' 2>/dev/null | grep 'net.unraid.docker.managed=dockerman' | awk '{print $1}'
 }
 
 # Running containers
 running_containers(){
-  docker ps --format='{{.Names}} {{.Labels}}' 2>/dev/null | grep 'net.unraid.docker.managed=' | awk '{print $1}'
+  docker container ls --format='{{.Names}} {{.Labels}}' 2>/dev/null | grep 'net.unraid.docker.managed=dockerman' | awk '{print $1}'
 }
 
 # Network driver


### PR DESCRIPTION
* Docker Compose handles its own startup
* Both unRAID and Compose use the `net.unraid.docker.managed` label, but with different values
* unRAID trying to start Compose containers may cause them to fail to start
* This commit fixes the behavior above by only attempting to manage dockerman-managed containers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container identification and filtering logic for more accurate recognition of managed containers.
  * Enhanced status detection for container operations including availability checks, start, and stop commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->