### PR TITLE
fix(docker): filter ghost containers from WebGUI

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -960,11 +960,22 @@ class DockerClient {
 		if (is_array($this::$containersCache)) return $this::$containersCache;
 		$this::$containersCache = [];
 		foreach ($this->getDockerJSON("/containers/json?all=1") as $ct) {
+			if (!is_array($ct) || empty($ct['Id'])) {
+				continue;
+			}
+			// Docker can leave stale "dead" entries after shutdown races; filter them from the UI list.
+			if (($ct['State'] ?? '') === 'dead' || stripos($ct['Status'] ?? '', 'dead') === 0) {
+				continue;
+			}
 			$info = $this->getContainerDetails($ct['Id']);
+			// If inspect fails for a stale entry, skip it from the UI list.
+			if (empty($info) || !is_array($info) || !empty($info['message']) || empty($info['Config']) || empty($info['State'])) {
+				continue;
+			}
 			$c = [];
 			$c['Image']       = DockerUtil::ensureImageTag($info['Config']['Image']);
 			$c['ImageId']     = $this->extractID($ct['ImageID']);
-			$c['Name']        = substr($info['Name'], 1);
+			$c['Name']        = ltrim(($info['Name'] ?? $ct['Names'][0] ?? ''), '/');
 			$c['Status']      = $ct['Status'] ?: 'None';
 			$c['Running']     = $info['State']['Running'];
 			$c['Paused']      = $info['State']['Paused'];


### PR DESCRIPTION
## Summary
- Backports the Docker ghost/dead container filtering behavior from #2577 to `7.2`.
- Filters invalid, `dead`, and uninspectable Docker container entries out of the WebGUI Docker list.
- Preserves normal container listing behavior and does not auto-delete or mutate Docker/container state.

## Why
Docker engine/containerd shutdown races can leave orphaned dead container metadata. Those entries can appear as ghost rows in `docker ps -a` and in the WebGUI, but users cannot act on them from the UI.

## References
- Original merged PR: https://github.com/unraid/webgui/pull/2577
- Upstream root cause/fix discussion: https://github.com/moby/moby/pull/51692
- Docker 29.x backport: https://github.com/moby/moby/pull/51693
- Visibility change context: https://github.com/moby/moby/commit/9f5f4f5a4273e920d5d77c1e73db8bebe65982bb

## Test plan
- [x] `php -l emhttp/plugins/dynamix.docker.manager/include/DockerClient.php`
- [x] `git diff --check origin/7.2...HEAD`