### PR TITLE
Fix: Handle CRLF in syslinux and grub configs

### DIFF
--- a/emhttp/plugins/dynamix/scripts/manage_boot_params.sh
+++ b/emhttp/plugins/dynamix/scripts/manage_boot_params.sh
@@ -263,7 +263,8 @@ parse_append_line() {
 
     # Extract append line for specific label
     # Matches from "label $label" to the next "label" or end of file
-    awk -v label="$label" '
+    # Normalize CRLF to LF for parsing (DOS-edited syslinux.cfg)
+    tr -d '\r' < "$cfg_file" | awk -v label="$label" '
         BEGIN { label=tolower(label) }
         /^label / {
             line=tolower($0)
@@ -278,7 +279,7 @@ parse_append_line() {
             print
             exit
         }
-    ' "$cfg_file"
+    '
 }
 
 #############################################
@@ -288,7 +289,8 @@ parse_grub_linux_args() {
     local label="$1"
     local cfg_file="${2:-$GRUB_CFG}"
 
-    awk -v label="$label" '
+    # Normalize CRLF to LF for parsing (DOS-edited grub.cfg)
+    tr -d '\r' < "$cfg_file" | awk -v label="$label" '
         $0 ~ /^menuentry / {
             in_section = (index($0, "\"" label "\"") > 0 || index($0, "\x27" label "\x27") > 0)
         }
@@ -303,7 +305,7 @@ parse_grub_linux_args() {
             }
             exit
         }
-    ' "$cfg_file"
+    '
 }
 
 #############################################
@@ -349,7 +351,7 @@ extract_grub_timeout() {
     local cfg_file="${1:-$GRUB_CFG}"
 
     if [[ -f "$cfg_file" ]]; then
-        grep "^set timeout=" "$cfg_file" | awk -F'=' '{print $2}' | tr -d '\r' | head -n 1
+        tr -d '\r' < "$cfg_file" | grep "^set timeout=" | awk -F'=' '{print $2}' | head -n 1
     else
         echo ""
     fi
@@ -748,16 +750,16 @@ validate_config() {
         return 1
     fi
 
-    # Check required labels exist
-    if ! grep -qi "^label unraid OS$" "$cfg_file"; then
+    # Check required labels exist (strip CR so ^/$ match CRLF files)
+    if ! tr -d '\r' < "$cfg_file" | grep -qi "^label unraid OS$"; then
         return 1
     fi
 
-    if ! grep -qi "^label unraid OS GUI Mode$" "$cfg_file"; then
+    if ! tr -d '\r' < "$cfg_file" | grep -qi "^label unraid OS GUI Mode$"; then
         return 1
     fi
 
-    if ! grep -qi "^label unraid OS Safe Mode" "$cfg_file"; then
+    if ! tr -d '\r' < "$cfg_file" | grep -qi "^label unraid OS Safe Mode"; then
         return 1
     fi
 
@@ -1098,6 +1100,9 @@ write_config_grub() {
 
     local temp_file=$(mktemp -p "$(dirname "$GRUB_CFG")")
     cp "$GRUB_CFG" "$temp_file"
+    # Strip CR from CRLF so awk/grep/sed in update_grub_* match Unix line endings
+    local temp_lf="${temp_file}.lf"
+    tr -d '\r' < "$temp_file" > "$temp_lf" && mv "$temp_lf" "$temp_file"
 
     if [[ "${APPLY_TO_UNRAID_OS}" == "1" ]]; then
         update_grub_entry "Unraid OS" "$new_args" "$temp_file"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed boot parameter management to properly handle configuration files with Windows-style (CRLF) line endings. Improved parsing ensures correct extraction of boot labels, kernel arguments, and boot timeout settings from both syslinux and GRUB configurations. The script now works reliably with files created or edited on Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->