### PR TITLE
fix: allow mover empty action without pools on 7.2

### DIFF
--- a/emhttp/plugins/dynamix/ArrayOperation.page
+++ b/emhttp/plugins/dynamix/ArrayOperation.page
@@ -395,6 +395,10 @@ mymonitor.on('message', function(state) {
     $('#mover-button').prop('disabled',false);
     $('#mover-text').html("<b>_(Move)_</b> _(will immediately invoke the Mover)_.&nbsp;<a href=\"/Main/Settings/Scheduler\"<?if($tabbed):?> onclick=\"$.cookie('one','tab2')\"<?endif;?>>(_(Schedule)_)</a>");
 <?endif;?>
+<?if (_var($var,'shareUser') == 'e' && !$pool_devices):?>
+    $('#mover-button').prop('disabled',false);
+    $('#mover-text').html("<b>_(Empty)_</b> _(will immediately invoke the Mover to Empty a disk)_.&nbsp;<a href=\"/Main/Settings/Scheduler\"<?if($tabbed):?> onclick=\"$.cookie('one','tab2')\"<?endif;?>>(_(Schedule)_)</a>");
+<?endif;?>
     break;
   case '1': // parity running
     $('#stop-button').prop('disabled',true);
@@ -407,6 +411,10 @@ mymonitor.on('message', function(state) {
     $('#mover-button').prop('disabled',true);
     $('#mover-text').html("_(Disabled)_ -- _(Parity operation is running)_");
 <?endif;?>
+<?if (_var($var,'shareUser') == 'e' && !$pool_devices):?>
+    $('#mover-button').prop('disabled',true);
+    $('#mover-text').html("<b>_(Empty)_</b> _(will immediately invoke the Mover to Empty a disk)_.&nbsp;<a href=\"/Main/Settings/Scheduler\"<?if($tabbed):?> onclick=\"$.cookie('one','tab2')\"<?endif;?>>(_(Schedule)_)</a>");
+<?endif;?>
     break;
   case '2': // mover running
     $('#stop-button').prop('disabled',true);
@@ -415,6 +423,10 @@ mymonitor.on('message', function(state) {
     $('#mover-button').prop('disabled',true);
     $('#mover-text').html("_(Disabled)_ - _(Mover is running)_.");
 <?endif;?>
+<?if (_var($var,'shareUser') == 'e' && !$pool_devices):?>
+    $('#mover-button').prop('disabled',true);
+    $('#mover-text').html("<b>_(Empty)_</b> _(will immediately invoke the Mover to Empty a disk)_.&nbsp;<a href=\"/Main/Settings/Scheduler\"<?if($tabbed):?> onclick=\"$.cookie('one','tab2')\"<?endif;?>>(_(Schedule)_)</a>");
+<?endif;?>
     break;
   case '3': // btrfs running
     $('#stop-button').prop('disabled',true);
@@ -422,6 +434,10 @@ mymonitor.on('message', function(state) {
 <?if (_var($var,'shareUser') == 'e' && $pool_devices):?>
     $('#mover-button').prop('disabled',true);
     $('#mover-text').html("_(Disabled)_ -- _(BTRFS operation is running)_");
+<?endif;?>
+<?if (_var($var,'shareUser') == 'e' && !$pool_devices):?>
+    $('#mover-button').prop('disabled',true);
+    $('#mover-text').html("<b>_(Empty)_</b> _(will immediately invoke the Mover to Empty a disk)_.&nbsp;<a href=\"/Main/Settings/Scheduler\"<?if($tabbed):?> onclick=\"$.cookie('one','tab2')\"<?endif;?>>(_(Schedule)_)</a>");
 <?endif;?>
     break;
   }
@@ -829,6 +845,13 @@ endswitch;
 <form name="mover_schedule" method="POST" action="/update.htm" target="progressFrame">
 <table markdown="1" class="ArrayOperation-Table array_status noshift">
 <tr><td></td><td><input type="submit" id="mover-button" name="cmdStartMover" value="_(Move)_"></td><td id="mover-text"></td></tr>
+</table>
+</form>
+<?endif;?>
+<?if (_var($var,'shareUser') == 'e' && !$pool_devices):?>
+<form name="mover_schedule" method="POST" action="/update.htm" target="progressFrame">
+<table markdown="1" class="ArrayOperation-Table array_status noshift">
+<tr><td></td><td><input type="submit" id="mover-button" name="cmdStartMover" value="_(Empty)_"></td><td id="mover-text"></td></tr>
 </table>
 </form>
 <?endif;?>

--- a/emhttp/plugins/dynamix/MoverSettings.page
+++ b/emhttp/plugins/dynamix/MoverSettings.page
@@ -18,13 +18,15 @@ Tag="calendar-check-o"
 $mode = ['Disabled','Hourly','Daily','Weekly','Monthly'];
 $days = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
 $setup = true;
+$buttontext = _('Move now');
 if (!$pool_devices) {
-  echo "<p class='notice'>"._('No Cache device present')."!</p>";
-  $setup = false;
+  echo "<p class='notice'>"._('No Cache device present only empty function will run')."!</p>";
+  $setup = true;
+  $buttontext = _('Empty now');
 } elseif ($var['shareUser']=='-') {
   echo "<p class='notice'>"._('User shares not enabled')."!</p>";
   $setup = false;
-}
+} 
 if (empty($var['shareMoverSchedule'])) {
   $cron = explode(' ', "* * * * *");
   $move = 0;
@@ -32,7 +34,7 @@ if (empty($var['shareMoverSchedule'])) {
   $cron = explode(' ', $var['shareMoverSchedule']);
   $move = $cron[2]!='*' ? 4 : ($cron[4]!='*' ? 3 : (substr($cron[1],0,1)!='*' ? 2 : 1));
 }
-$showMoverButton = $setup && $pool_devices;
+$showMoverButton = $setup;
 $moverRunning = file_exists('/var/run/mover.pid');
 ?>
 <script>
@@ -138,7 +140,7 @@ _(Mover logging)_:
     <input type="submit" name="changeMover" value="_(Apply)_" disabled>
     <input type="button" value="_(Done)_" onclick="done()">
     <?if ($showMoverButton):?>
-      <input type="submit" name="cmdStartMover" value="_(Move now)_"<?if ($moverRunning):?> disabled<?endif;?>>
+      <input type="submit" name="cmdStartMover" value="<?=$buttontext?>"<?if ($moverRunning):?> disabled<?endif;?>>
       <?if ($moverRunning):?><span>_(Mover is running)_</span><?endif;?>
     <?endif;?>
   </span>


### PR DESCRIPTION
## Summary
- backport the mover empty-action fix to `7.2`
- keep mover controls available when user shares are enabled but no pool devices exist
- label the no-pool action as `Empty` / `Empty now` so the UI reflects the supported operation
- preserve disabled behavior while parity, mover, or BTRFS operations are active

## Root cause
The UI treated missing pool devices as a reason to disable or hide mover controls entirely. That blocked the array-disk empty workflow even though emptying an array disk can run without a configured pool.

## Source
Cherry-picked from `fd5251ad4fab628c5ea0800642d6b312da25ade9`.

## Verification
- `php -l emhttp/plugins/dynamix/MoverSettings.page`
- `php -l emhttp/plugins/dynamix/ArrayOperation.page`