### PR TITLE
fix: reset Tailscale Funnel state on 7.2 restarts

### DIFF
--- a/share/docker/tailscale_container_hook
+++ b/share/docker/tailscale_container_hook
@@ -298,6 +298,13 @@ while true; do
   sleep 2
 done
 
+# Clear persisted Serve/Funnel state before applying the current template mode.
+# Without this, switching the template from Funnel/Serve to No leaves the old
+# config active in the existing Tailscale state directory after restart.
+echo "Resetting Tailscale Serve/Funnel configuration"
+tailscale funnel reset >/dev/null 2>&1 || true
+tailscale serve reset >/dev/null 2>&1 || true
+
 if [ ! -z "${TAILSCALE_SERVE_PORT}" ] && [ "$(tailscale status --json | jq -r '.CurrentTailnet.MagicDNSEnabled')" != "false" ] && [ -z "$(tailscale status --json | jq -r '.Self.Capabilities[] | select(. == "https")')" ]; then
   echo "ERROR: Enable MagicDNS and HTTPS on your Tailscale account to use Tailscale Serve/Funnel."
   echo "See: https://tailscale.com/kb/1153/enabling-https"


### PR DESCRIPTION
## Summary
- backport PR #2600 to `7.2`
- reset persisted Tailscale Funnel and Serve config after `tailscale up`
- reapply only the currently configured Docker-template-managed Serve/Funnel mode
- prevent containers switched to `Tailscale Serve = No` from keeping stale funnel exposure after restart

## Root cause
The container hook persisted serve/funnel state in the Tailscale state directory. When a user changed the Docker template from `Funnel` or `Serve` to `No`, the related env vars disappeared, but the hook never cleared the old state before startup completed.

## Source
Cherry-picked from `b90ca2f2c9df90bdaca71e3a1a2984b46e83246c` / PR #2600.

## Verification
- `bash -n share/docker/tailscale_container_hook`