### PR TITLE
fix(docker): set fixed MACs on network endpoints

### DIFF
--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -2379,6 +2379,10 @@ Generally speaking, it is recommended to leave this setting to its default value
 IMPORTANT NOTE:  If adjusting port mappings, do not modify the settings for the Container port as only the Host port can be adjusted.
 :end
 
+:docker_fixed_mac_help:
+Assigns the container's MAC address on the selected Docker network endpoint. This avoids using the legacy container-level --mac-address option in Extra Parameters.
+:end
+
 :docker_container_network_help:
 This allows your container to utilize the network configuration of another container. Select the appropriate container from the list.<br>This setup can be particularly beneficial if you wish to route your container's traffic through a VPN.
 :end

--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -2380,7 +2380,9 @@ IMPORTANT NOTE:  If adjusting port mappings, do not modify the settings for the 
 :end
 
 :docker_fixed_mac_help:
-Assigns the container's MAC address on the selected Docker network endpoint. This avoids using the legacy container-level --mac-address option in Extra Parameters.
+Assigns the container's MAC address on the selected Docker network endpoint. Use a valid unicast MAC address; the first octet must be even, e.g. 02:42:9a:0d:7e:c0.
+
+This avoids using the legacy container-level --mac-address option in Extra Parameters.
 :end
 
 :docker_container_network_help:

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -1151,6 +1151,9 @@ _(Fixed IP address)_ (_(optional)_):
 
 :docker_fixed_ip_help:
 
+</div>
+
+<div markdown="1" class="myMAC noshow">
 _(Fixed MAC address)_ (_(optional)_):
 : <input type="text" name="contMyMAC" pattern="([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}|[0-9A-Fa-f]{12}">
 
@@ -1607,10 +1610,17 @@ subnet['<?=$network?>'] = '<?=$value?>';
 <?endforeach;?>
 
 function showSubnet(bridge) {
-  if (bridge.match(/^(bridge|host|none)$/i) !== null) {
+  if (bridge.match(/^(host|none)$/i) !== null) {
     $('.myIP').hide();
     $('input[name="contMyIP"]').val('');
+    $('.myMAC').hide();
     $('input[name="contMyMAC"]').val('');
+    $('.netCONT').hide();
+    $('#netCONT').val('');
+  } else if (bridge.match(/^(bridge)$/i) !== null) {
+    $('.myIP').hide();
+    $('input[name="contMyIP"]').val('');
+    $('.myMAC').show();
     $('.netCONT').hide();
     $('#netCONT').val('');
   } else if (bridge.match(/^(container)$/i) !== null) {
@@ -1618,10 +1628,12 @@ function showSubnet(bridge) {
     $('#netCONT').val('<?php echo (isset($xml) && isset($xml['Network'][1])) ? $xml['Network'][1] : ''; ?>');
     $('.myIP').hide();
     $('input[name="contMyIP"]').val('');
+    $('.myMAC').hide();
     $('input[name="contMyMAC"]').val('');
   } else {
     $('.myIP').show();
     $('#myIP').html('<?=_('Subnet')?>: '+subnet[bridge]);
+    $('.myMAC').show();
     $('.netCONT').hide();
     $('#netCONT').val('');
   }

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -57,13 +57,6 @@ function cpu_pinning() {
   }
 }
 
-function dockerFormError($message) {
-  global $docroot;
-  readfile("$docroot/plugins/dynamix.docker.manager/log.htm");
-  echo '<p><span class="error"><b>',_('Error'),':</b> ',$message,'</span></p>';
-  echo '<div style="text-align:center"><button type="button" onclick="history.back()">',_('Back'),'</button></div><br>';
-}
-
 #    ██████╗ ██████╗ ██████╗ ███████╗
 #   ██╔════╝██╔═══██╗██╔══██╗██╔════╝
 #   ██║     ██║   ██║██║  ██║█████╗
@@ -76,16 +69,6 @@ function dockerFormError($message) {
 ##########################
 
 if (isset($_POST['contName'])) {
-  $extraNetwork = hasNetworkParam($_POST['contExtraParams'] ?? '');
-  if ($extraNetwork && trim($_POST['contMyMAC'] ?? '') !== '') {
-    dockerFormError(_('Fixed MAC address cannot be used when Extra Parameters specify --network or --net. Add mac-address to the Extra Parameters network option instead.'));
-    goto END;
-  }
-  $submittedMAC = trim($_POST['contMyMAC'] ?? '') ?: extractMacAddressParam($_POST['contExtraParams'] ?? '');
-  if ($submittedMAC !== '' && !isValidUnicastMacAddress($submittedMAC)) {
-    dockerFormError(_('Fixed MAC address must be a valid unicast MAC address. The first octet must be even, for example 02:42:9a:0d:7e:c0.'));
-    goto END;
-  }
   $postXML = postToXML($_POST, true);
   $dry_run = isset($_POST['dryRun']) && $_POST['dryRun']=='true';
   $existing = _var($_POST,'existingContainer',false);
@@ -753,15 +736,6 @@ function removeConfig(num) {
 function prepareConfig(form) {
   var types = [], values = [], targets = [], vcpu = [];
   var myMAC = $(form).find('input[name="contMyMAC"]').val().trim().replaceAll('-', ':').toLowerCase();
-  var extraParams = $(form).find('input[name="contExtraParams"]').val();
-  if (myMAC && hasNetworkParam(extraParams)) {
-    swal({title:"_(Invalid network settings)_",text:"_(Fixed MAC address cannot be used when Extra Parameters specify --network or --net. Add mac-address to the Extra Parameters network option instead.)_",type:"error",html:true});
-    return false;
-  }
-  if (myMAC && !isValidUnicastMacAddress(myMAC)) {
-    swal({title:"_(Invalid MAC address)_",text:"_(Fixed MAC address must be a valid unicast MAC address. The first octet must be even, for example 02:42:9a:0d:7e:c0.)_",type:"error",html:true});
-    return false;
-  }
   $(form).find('input[name="contMyMAC"]').val(myMAC);
   if ($('select[name="contNetwork"]').val()=='host') {
     $(form).find('input[name="confType[]"]').each(function(){types.push($(this).val());});
@@ -772,20 +746,6 @@ function prepareConfig(form) {
   $(form).find('input[id^="box"]').each(function(){if ($(this).prop('checked')) vcpu.push($('#'+$(this).prop('id').replace('box','cpu')).text());});
   form.contCPUset.value = vcpu.join(',');
   return true;
-}
-
-function isValidUnicastMacAddress(mac) {
-  if (mac.match(/^[0-9a-f]{12}$/i)) {
-    mac = mac.match(/.{1,2}/g).join(':');
-  }
-  if (!mac.match(/^([0-9a-f]{2}:){5}[0-9a-f]{2}$/i)) {
-    return false;
-  }
-  return (parseInt(mac.substring(0, 2), 16) & 1) === 0;
-}
-
-function hasNetworkParam(extraParams) {
-  return /(^|\s)--net(work)?(=|\s+)/.test(extraParams || '');
 }
 
 function makeName(type) {

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -69,7 +69,7 @@ function cpu_pinning() {
 ##########################
 
 if (isset($_POST['contName'])) {
-  $extraNetwork = preg_match('/\-\-net(work)?=/', $_POST['contExtraParams'] ?? '');
+  $extraNetwork = hasNetworkParam($_POST['contExtraParams'] ?? '');
   if ($extraNetwork && trim($_POST['contMyMAC'] ?? '') !== '') {
     readfile("$docroot/plugins/dynamix.docker.manager/log.htm");
     echo '<p><span class="error"><b>',_('Error'),':</b> ',_('Fixed MAC address cannot be used when Extra Parameters specify --network or --net. Add mac-address to the Extra Parameters network option instead.'),'</span></p>';
@@ -216,10 +216,9 @@ if (isset($_GET['updateContainer'])){
     if (preg_match('/^container:(.*)/', $Network)) {
       $Net_Container = str_replace("container:", "", $Network);
     } else {
-      preg_match("/--(net|network)=container:[^\s]+/", $ExtraParams, $NetworkParam);
-      if (!empty($NetworkParam[0])) {
-        $Net_Container = explode(':', $NetworkParam[0])[1];
-        $Net_Container = str_replace(['"', "'"], '', $Net_Container);
+      preg_match("/--(?:net|network)(?:=|\s+)(['\"]?)container:([^'\"\s]+)\\1/", $ExtraParams, $NetworkParam);
+      if (!empty($NetworkParam[2])) {
+        $Net_Container = $NetworkParam[2];
       }
     }
     // check if the container still exists from which the network should be used, if it doesn't exist any more recreate container with network none and don't start it
@@ -227,7 +226,7 @@ if (isset($_GET['updateContainer'])){
       $Net_Container_ID = $DockerClient->getContainerID($Net_Container);
       if (empty($Net_Container_ID)) {
         $cmd = str_replace('/docker run -d ', '/docker create ', $cmd);
-        $cmd = preg_replace("/--(net|network)=(['\"]?)container:[^'\"]+\\2/", "--network=none ", $cmd);
+        $cmd = preg_replace("/--(?:net|network)(?:=|\s+)(['\"]?)container:[^'\"\s]+\\1/", "--network=none ", $cmd);
       }
     }
     // force kill container if still running after time-out
@@ -751,6 +750,11 @@ function removeConfig(num) {
 function prepareConfig(form) {
   var types = [], values = [], targets = [], vcpu = [];
   var myMAC = $(form).find('input[name="contMyMAC"]').val().trim().replaceAll('-', ':').toLowerCase();
+  var extraParams = $(form).find('input[name="contExtraParams"]').val();
+  if (myMAC && hasNetworkParam(extraParams)) {
+    swal({title:"_(Invalid network settings)_",text:"_(Fixed MAC address cannot be used when Extra Parameters specify --network or --net. Add mac-address to the Extra Parameters network option instead.)_",type:"error",html:true});
+    return false;
+  }
   if (myMAC && !isValidUnicastMacAddress(myMAC)) {
     swal({title:"_(Invalid MAC address)_",text:"_(Fixed MAC address must be a valid unicast MAC address. The first octet must be even, for example 02:42:9a:0d:7e:c0.)_",type:"error",html:true});
     return false;
@@ -775,6 +779,10 @@ function isValidUnicastMacAddress(mac) {
     return false;
   }
   return (parseInt(mac.substring(0, 2), 16) & 1) === 0;
+}
+
+function hasNetworkParam(extraParams) {
+  return /(^|\s)--net(work)?(=|\s+)/.test(extraParams || '');
 }
 
 function makeName(type) {

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -57,6 +57,13 @@ function cpu_pinning() {
   }
 }
 
+function dockerFormError($message) {
+  global $docroot;
+  readfile("$docroot/plugins/dynamix.docker.manager/log.htm");
+  echo '<p><span class="error"><b>',_('Error'),':</b> ',$message,'</span></p>';
+  echo '<div style="text-align:center"><button type="button" onclick="history.back()">',_('Back'),'</button></div><br>';
+}
+
 #    ██████╗ ██████╗ ██████╗ ███████╗
 #   ██╔════╝██╔═══██╗██╔══██╗██╔════╝
 #   ██║     ██║   ██║██║  ██║█████╗
@@ -71,16 +78,12 @@ function cpu_pinning() {
 if (isset($_POST['contName'])) {
   $extraNetwork = hasNetworkParam($_POST['contExtraParams'] ?? '');
   if ($extraNetwork && trim($_POST['contMyMAC'] ?? '') !== '') {
-    readfile("$docroot/plugins/dynamix.docker.manager/log.htm");
-    echo '<p><span class="error"><b>',_('Error'),':</b> ',_('Fixed MAC address cannot be used when Extra Parameters specify --network or --net. Add mac-address to the Extra Parameters network option instead.'),'</span></p>';
-    echo '<div style="text-align:center"><button type="button" onclick="history.back()">',_('Back'),'</button></div><br>';
+    dockerFormError(_('Fixed MAC address cannot be used when Extra Parameters specify --network or --net. Add mac-address to the Extra Parameters network option instead.'));
     goto END;
   }
   $submittedMAC = trim($_POST['contMyMAC'] ?? '') ?: extractMacAddressParam($_POST['contExtraParams'] ?? '');
   if ($submittedMAC !== '' && !isValidUnicastMacAddress($submittedMAC)) {
-    readfile("$docroot/plugins/dynamix.docker.manager/log.htm");
-    echo '<p><span class="error"><b>',_('Error'),':</b> ',_('Fixed MAC address must be a valid unicast MAC address. The first octet must be even, for example 02:42:9a:0d:7e:c0.'),'</span></p>';
-    echo '<div style="text-align:center"><button type="button" onclick="history.back()">',_('Back'),'</button></div><br>';
+    dockerFormError(_('Fixed MAC address must be a valid unicast MAC address. The first octet must be even, for example 02:42:9a:0d:7e:c0.'));
     goto END;
   }
   $postXML = postToXML($_POST, true);

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -1109,6 +1109,11 @@ _(Fixed IP address)_ (_(optional)_):
 
 :docker_fixed_ip_help:
 
+_(Fixed MAC address)_ (_(optional)_):
+: <input type="text" name="contMyMAC">
+
+:docker_fixed_mac_help:
+
 </div>
 
 <div markdown="1" class="netCONT noshow">
@@ -1563,6 +1568,7 @@ function showSubnet(bridge) {
   if (bridge.match(/^(bridge|host|none)$/i) !== null) {
     $('.myIP').hide();
     $('input[name="contMyIP"]').val('');
+    $('input[name="contMyMAC"]').val('');
     $('.netCONT').hide();
     $('#netCONT').val('');
   } else if (bridge.match(/^(container)$/i) !== null) {
@@ -1570,6 +1576,7 @@ function showSubnet(bridge) {
     $('#netCONT').val('<?php echo (isset($xml) && isset($xml['Network'][1])) ? $xml['Network'][1] : ''; ?>');
     $('.myIP').hide();
     $('input[name="contMyIP"]').val('');
+    $('input[name="contMyMAC"]').val('');
   } else {
     $('.myIP').show();
     $('#myIP').html('<?=_('Subnet')?>: '+subnet[bridge]);
@@ -1932,4 +1939,3 @@ if (window.location.href.indexOf("/Apps/") > 0  && <? if (is_file($xmlTemplate))
 }
 </script>
 <?END:?>
-

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -69,6 +69,20 @@ function cpu_pinning() {
 ##########################
 
 if (isset($_POST['contName'])) {
+  $extraNetwork = preg_match('/\-\-net(work)?=/', $_POST['contExtraParams'] ?? '');
+  if ($extraNetwork && trim($_POST['contMyMAC'] ?? '') !== '') {
+    readfile("$docroot/plugins/dynamix.docker.manager/log.htm");
+    echo '<p><span class="error"><b>',_('Error'),':</b> ',_('Fixed MAC address cannot be used when Extra Parameters specify --network or --net. Add mac-address to the Extra Parameters network option instead.'),'</span></p>';
+    echo '<div style="text-align:center"><button type="button" onclick="history.back()">',_('Back'),'</button></div><br>';
+    goto END;
+  }
+  $submittedMAC = trim($_POST['contMyMAC'] ?? '') ?: extractMacAddressParam($_POST['contExtraParams'] ?? '');
+  if ($submittedMAC !== '' && !isValidUnicastMacAddress($submittedMAC)) {
+    readfile("$docroot/plugins/dynamix.docker.manager/log.htm");
+    echo '<p><span class="error"><b>',_('Error'),':</b> ',_('Fixed MAC address must be a valid unicast MAC address. The first octet must be even, for example 02:42:9a:0d:7e:c0.'),'</span></p>';
+    echo '<div style="text-align:center"><button type="button" onclick="history.back()">',_('Back'),'</button></div><br>';
+    goto END;
+  }
   $postXML = postToXML($_POST, true);
   $dry_run = isset($_POST['dryRun']) && $_POST['dryRun']=='true';
   $existing = _var($_POST,'existingContainer',false);
@@ -736,6 +750,12 @@ function removeConfig(num) {
 
 function prepareConfig(form) {
   var types = [], values = [], targets = [], vcpu = [];
+  var myMAC = $(form).find('input[name="contMyMAC"]').val().trim().replaceAll('-', ':').toLowerCase();
+  if (myMAC && !isValidUnicastMacAddress(myMAC)) {
+    swal({title:"_(Invalid MAC address)_",text:"_(Fixed MAC address must be a valid unicast MAC address. The first octet must be even, for example 02:42:9a:0d:7e:c0.)_",type:"error",html:true});
+    return false;
+  }
+  $(form).find('input[name="contMyMAC"]').val(myMAC);
   if ($('select[name="contNetwork"]').val()=='host') {
     $(form).find('input[name="confType[]"]').each(function(){types.push($(this).val());});
     $(form).find('input[name="confValue[]"]').each(function(){values.push($(this));});
@@ -744,6 +764,17 @@ function prepareConfig(form) {
   }
   $(form).find('input[id^="box"]').each(function(){if ($(this).prop('checked')) vcpu.push($('#'+$(this).prop('id').replace('box','cpu')).text());});
   form.contCPUset.value = vcpu.join(',');
+  return true;
+}
+
+function isValidUnicastMacAddress(mac) {
+  if (mac.match(/^[0-9a-f]{12}$/i)) {
+    mac = mac.match(/.{1,2}/g).join(':');
+  }
+  if (!mac.match(/^([0-9a-f]{2}:){5}[0-9a-f]{2}$/i)) {
+    return false;
+  }
+  return (parseInt(mac.substring(0, 2), 16) & 1) === 0;
 }
 
 function makeName(type) {
@@ -893,7 +924,7 @@ if (isset($xml["Config"])) {
 ?>
 
 <div id="canvas">
-<form markdown="1" method="POST" autocomplete="off" onsubmit="prepareConfig(this)">
+<form markdown="1" method="POST" autocomplete="off" onsubmit="return prepareConfig(this)">
 <input type="hidden" name="csrf_token" value="<?=$var['csrf_token']?>">
 <input type="hidden" name="contCPUset" value="">
 <?if ($xmlType=='edit'):?>
@@ -1110,7 +1141,7 @@ _(Fixed IP address)_ (_(optional)_):
 :docker_fixed_ip_help:
 
 _(Fixed MAC address)_ (_(optional)_):
-: <input type="text" name="contMyMAC">
+: <input type="text" name="contMyMAC" pattern="([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}|[0-9A-Fa-f]{12}">
 
 :docker_fixed_mac_help:
 

--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -32,116 +32,51 @@ function xml_decode($string) {
   return strval(html_entity_decode($string, ENT_XML1, 'UTF-8'));
 }
 
-function extraParamsTokens($extraParams) {
-  if (!is_string($extraParams) || $extraParams === '') {
-    return [];
-  }
-  $tokens = [];
-  $leading = '';
-  $raw = '';
-  $value = '';
-  $quote = '';
-  $escaped = false;
-  $inToken = false;
-  $length = strlen($extraParams);
+function extraParamsWithQuotedValuesMasked($extraParams) {
+  return preg_replace('/"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"|\'[^\']*\'/', '""', $extraParams);
+}
 
-  for ($i = 0; $i < $length; $i++) {
-    $char = $extraParams[$i];
-    if (!$inToken && ctype_space($char)) {
-      $leading .= $char;
-      continue;
-    }
-    if (!$inToken) {
-      $inToken = true;
-      $raw = '';
-      $value = '';
-    }
-    $raw .= $char;
-    if ($escaped) {
-      $value .= $char;
-      $escaped = false;
-      continue;
-    }
-    if ($quote) {
-      if ($char === $quote) {
-        $quote = '';
-      } elseif ($quote === '"' && $char === '\\') {
-        $escaped = true;
-      } else {
-        $value .= $char;
-      }
-      continue;
-    }
-    if ($char === '\\') {
-      $escaped = true;
-      continue;
-    }
-    if ($char === '"' || $char === "'") {
-      $quote = $char;
-      continue;
-    }
-    if (ctype_space($char)) {
-      $tokens[] = ['leading' => $leading, 'raw' => substr($raw, 0, -1), 'value' => $value];
-      $leading = $char;
-      $raw = '';
-      $value = '';
-      $inToken = false;
-      continue;
-    }
-    $value .= $char;
+function replaceUnquotedExtraParams($extraParams, $callback) {
+  $parts = preg_split('/("[^"\\\\]*(?:\\\\.[^"\\\\]*)*"|\'[^\']*\')/', $extraParams, -1, PREG_SPLIT_DELIM_CAPTURE);
+  if ($parts === false) {
+    return $extraParams;
   }
-  if ($inToken) {
-    $tokens[] = ['leading' => $leading, 'raw' => $raw, 'value' => $value];
+  foreach ($parts as $i => $part) {
+    if ($part === '' || $part[0] === '"' || $part[0] === "'") {
+      continue;
+    }
+    $parts[$i] = $callback($part);
   }
-  return $tokens;
+  return implode('', $parts);
 }
 
 function extractMacAddressParam($extraParams) {
-  $tokens = extraParamsTokens($extraParams);
-  for ($i = 0, $count = count($tokens); $i < $count; $i++) {
-    $value = $tokens[$i]['value'];
-    if ($value === '--mac-address') {
-      return trim($tokens[$i + 1]['value'] ?? '');
-    }
-    if (strpos($value, '--mac-address=') === 0) {
-      return trim(substr($value, strlen('--mac-address=')));
-    }
+  if (!is_string($extraParams)) {
+    return '';
+  }
+  $extraParams = extraParamsWithQuotedValuesMasked($extraParams);
+  if (preg_match('/(?:^|\s)--mac-address=([^\s\'"]+)/', $extraParams, $match)) {
+    return trim($match[1]);
+  }
+  if (preg_match('/(?:^|\s)--mac-address\s+([^\s\'"]+)/', $extraParams, $match)) {
+    return trim($match[1]);
   }
   return '';
 }
 
 function removeMacAddressParam($extraParams) {
-  $tokens = extraParamsTokens($extraParams);
-  if (!$tokens) {
+  if (!is_string($extraParams) || $extraParams === '') {
     return '';
   }
-  $out = '';
-  $skipNext = false;
-  foreach ($tokens as $token) {
-    if ($skipNext) {
-      $skipNext = false;
-      continue;
-    }
-    if ($token['value'] === '--mac-address') {
-      $skipNext = true;
-      continue;
-    }
-    if (strpos($token['value'], '--mac-address=') === 0) {
-      continue;
-    }
-    $out .= $token['leading'].$token['raw'];
-  }
-  return trim($out);
+  $extraParams = replaceUnquotedExtraParams($extraParams, function($part) {
+    $part = preg_replace('/(^|\s)--mac-address=[^\s\'"]+/', '$1', $part);
+    return preg_replace('/(^|\s)--mac-address\s+[^\s\'"]+/', '$1', $part);
+  });
+  return trim($extraParams);
 }
 
 function hasNetworkParam($extraParams) {
-  foreach (extraParamsTokens($extraParams) as $token) {
-    $value = $token['value'];
-    if ($value === '--net' || $value === '--network' || strpos($value, '--net=') === 0 || strpos($value, '--network=') === 0) {
-      return true;
-    }
-  }
-  return false;
+  return is_string($extraParams) && preg_match('/(?:^|\s)--net(?:work)?(?:=|\s+)[^\s\'"]+/', extraParamsWithQuotedValuesMasked($extraParams));
 }
 
 function normalizeMacAddress($mac) {

--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -49,6 +49,10 @@ function removeMacAddressParam($extraParams) {
   return trim(preg_replace('/(^|\s)--mac-address(?:=|\s+)(?:"[^"]+"|\'[^\']+\'|[^\s]+)/', '$1', $extraParams));
 }
 
+function hasNetworkParam($extraParams) {
+  return is_string($extraParams) && preg_match('/(?:^|\s)--net(?:work)?(?:=|\s+)/', $extraParams);
+}
+
 function normalizeMacAddress($mac) {
   $mac = strtolower(trim($mac ?? ''));
   if ($mac === '') {
@@ -114,7 +118,7 @@ function postToXML($post, $setOwnership=false) {
     $xml->Network                  = xml_encode($post['contNetwork']);
   }
   $xml->MyIP                       = xml_encode($post['contMyIP']);
-  $extraNetwork                    = preg_match('/\-\-net(work)?=/', $post['contExtraParams'] ?? '');
+  $extraNetwork                    = hasNetworkParam($post['contExtraParams'] ?? '');
   $myMAC                           = $extraNetwork ? '' : normalizeMacAddress(trim($post['contMyMAC'] ?? '') ?: extractMacAddressParam($post['contExtraParams'] ?? ''));
   $xml->MyMAC                      = xml_encode($myMAC);
   $xml->Shell                      = xml_encode($post['contShell']);
@@ -192,7 +196,7 @@ function xmlToVar($xml) {
   $out['Network']                      = xml_decode($xml->Network);
   $out['MyIP']                         = xml_decode($xml->MyIP ?? '');
   $extraParams                         = xml_decode($xml->ExtraParams ?? '');
-  $extraNetwork                        = preg_match('/\-\-net(work)?=/', $extraParams);
+  $extraNetwork                        = hasNetworkParam($extraParams);
   $out['MyMAC']                        = $extraNetwork ? '' : normalizeMacAddress(xml_decode($xml->MyMAC ?? '') ?: extractMacAddressParam($extraParams));
   $out['Shell']                        = xml_decode($xml->Shell ?? 'sh');
   $out['Privileged']                   = xml_decode($xml->Privileged);
@@ -370,7 +374,7 @@ function xmlToCommand($xml, $create_paths=false) {
   $xml           = xmlToVar($xml);
   $cmdName       = strlen($xml['Name']) ? '--name='.escapeshellarg($xml['Name']) : '';
   $cmdPrivileged = strtolower($xml['Privileged'])=='true' ? '--privileged=true' : '';
-  $extraNetwork  = preg_match('/\-\-net(work)?=/',$xml['ExtraParams']);
+  $extraNetwork  = hasNetworkParam($xml['ExtraParams']);
   $cmdMyIP       = '';
   if (preg_match('/^container:(.*)/', $xml['Network'])) {
     $cmdNetwork  = $extraNetwork ? "" : '--net='.escapeshellarg($xml['Network']);

--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -32,25 +32,116 @@ function xml_decode($string) {
   return strval(html_entity_decode($string, ENT_XML1, 'UTF-8'));
 }
 
-function extractMacAddressParam($extraParams) {
-  if (!is_string($extraParams) || !preg_match('/(?:^|\s)--mac-address(?:=|\s+)(?:"([^"]+)"|\'([^\']+)\'|([^\s]+))/', $extraParams, $match)) {
-    return '';
+function extraParamsTokens($extraParams) {
+  if (!is_string($extraParams) || $extraParams === '') {
+    return [];
   }
-  foreach (array_slice($match, 1) as $value) {
-    if (strlen($value ?? '')) return trim($value);
+  $tokens = [];
+  $leading = '';
+  $raw = '';
+  $value = '';
+  $quote = '';
+  $escaped = false;
+  $inToken = false;
+  $length = strlen($extraParams);
+
+  for ($i = 0; $i < $length; $i++) {
+    $char = $extraParams[$i];
+    if (!$inToken && ctype_space($char)) {
+      $leading .= $char;
+      continue;
+    }
+    if (!$inToken) {
+      $inToken = true;
+      $raw = '';
+      $value = '';
+    }
+    $raw .= $char;
+    if ($escaped) {
+      $value .= $char;
+      $escaped = false;
+      continue;
+    }
+    if ($quote) {
+      if ($char === $quote) {
+        $quote = '';
+      } elseif ($quote === '"' && $char === '\\') {
+        $escaped = true;
+      } else {
+        $value .= $char;
+      }
+      continue;
+    }
+    if ($char === '\\') {
+      $escaped = true;
+      continue;
+    }
+    if ($char === '"' || $char === "'") {
+      $quote = $char;
+      continue;
+    }
+    if (ctype_space($char)) {
+      $tokens[] = ['leading' => $leading, 'raw' => substr($raw, 0, -1), 'value' => $value];
+      $leading = $char;
+      $raw = '';
+      $value = '';
+      $inToken = false;
+      continue;
+    }
+    $value .= $char;
+  }
+  if ($inToken) {
+    $tokens[] = ['leading' => $leading, 'raw' => $raw, 'value' => $value];
+  }
+  return $tokens;
+}
+
+function extractMacAddressParam($extraParams) {
+  $tokens = extraParamsTokens($extraParams);
+  for ($i = 0, $count = count($tokens); $i < $count; $i++) {
+    $value = $tokens[$i]['value'];
+    if ($value === '--mac-address') {
+      return trim($tokens[$i + 1]['value'] ?? '');
+    }
+    if (strpos($value, '--mac-address=') === 0) {
+      return trim(substr($value, strlen('--mac-address=')));
+    }
   }
   return '';
 }
 
 function removeMacAddressParam($extraParams) {
-  if (!is_string($extraParams) || $extraParams === '') {
+  $tokens = extraParamsTokens($extraParams);
+  if (!$tokens) {
     return '';
   }
-  return trim(preg_replace('/(^|\s)--mac-address(?:=|\s+)(?:"[^"]+"|\'[^\']+\'|[^\s]+)/', '$1', $extraParams));
+  $out = '';
+  $skipNext = false;
+  foreach ($tokens as $token) {
+    if ($skipNext) {
+      $skipNext = false;
+      continue;
+    }
+    if ($token['value'] === '--mac-address') {
+      $skipNext = true;
+      continue;
+    }
+    if (strpos($token['value'], '--mac-address=') === 0) {
+      continue;
+    }
+    $out .= $token['leading'].$token['raw'];
+  }
+  return trim($out);
 }
 
 function hasNetworkParam($extraParams) {
-  return is_string($extraParams) && preg_match('/(?:^|\s)--net(?:work)?(?:=|\s+)/', $extraParams);
+  foreach (extraParamsTokens($extraParams) as $token) {
+    $value = $token['value'];
+    if ($value === '--net' || $value === '--network' || strpos($value, '--net=') === 0 || strpos($value, '--network=') === 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function normalizeMacAddress($mac) {

--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -32,6 +32,23 @@ function xml_decode($string) {
   return strval(html_entity_decode($string, ENT_XML1, 'UTF-8'));
 }
 
+function extractMacAddressParam($extraParams) {
+  if (!is_string($extraParams) || !preg_match('/(?:^|\s)--mac-address(?:=|\s+)(?:"([^"]+)"|\'([^\']+)\'|([^\s]+))/', $extraParams, $match)) {
+    return '';
+  }
+  foreach (array_slice($match, 1) as $value) {
+    if (strlen($value ?? '')) return trim($value);
+  }
+  return '';
+}
+
+function removeMacAddressParam($extraParams) {
+  if (!is_string($extraParams) || $extraParams === '') {
+    return '';
+  }
+  return trim(preg_replace('/(^|\s)--mac-address(?:=|\s+)(?:"[^"]+"|\'[^\']+\'|[^\s]+)/', '$1', $extraParams));
+}
+
 function generateTSwebui($url, $serve, $webUI) {
   if (!isset($webUI)) {
     return '';
@@ -75,6 +92,9 @@ function postToXML($post, $setOwnership=false) {
     $xml->Network                  = xml_encode($post['contNetwork']);
   }
   $xml->MyIP                       = xml_encode($post['contMyIP']);
+  $extraNetwork                    = preg_match('/\-\-net(work)?=/', $post['contExtraParams'] ?? '');
+  $myMAC                           = trim($post['contMyMAC'] ?? '') ?: ($extraNetwork ? '' : extractMacAddressParam($post['contExtraParams'] ?? ''));
+  $xml->MyMAC                      = xml_encode($myMAC);
   $xml->Shell                      = xml_encode($post['contShell']);
   $xml->Privileged                 = strtolower($post['contPrivileged']??'')=='on' ? 'true' : 'false';
   $xml->Support                    = xml_encode($post['contSupport']);
@@ -85,7 +105,7 @@ function postToXML($post, $setOwnership=false) {
   $xml->WebUI                      = xml_encode(trim($post['contWebUI']));
   $xml->TemplateURL                = xml_encode($post['contTemplateURL']);
   $xml->Icon                       = xml_encode(trim($post['contIcon']));
-  $xml->ExtraParams                = xml_encode($post['contExtraParams']);
+  $xml->ExtraParams                = xml_encode($myMAC && !$extraNetwork ? removeMacAddressParam($post['contExtraParams']) : $post['contExtraParams']);
   $xml->PostArgs                   = xml_encode($post['contPostArgs']);
   $xml->CPUset                     = xml_encode($post['contCPUset']);
   $xml->DateInstalled              = xml_encode(time());
@@ -149,6 +169,7 @@ function xmlToVar($xml) {
   $out['Registry']                     = xml_decode($xml->Registry);
   $out['Network']                      = xml_decode($xml->Network);
   $out['MyIP']                         = xml_decode($xml->MyIP ?? '');
+  $out['MyMAC']                        = xml_decode($xml->MyMAC ?? '') ?: extractMacAddressParam(xml_decode($xml->ExtraParams ?? ''));
   $out['Shell']                        = xml_decode($xml->Shell ?? 'sh');
   $out['Privileged']                   = xml_decode($xml->Privileged);
   $out['Support']                      = xml_decode($xml->Support);
@@ -325,13 +346,29 @@ function xmlToCommand($xml, $create_paths=false) {
   $xml           = xmlToVar($xml);
   $cmdName       = strlen($xml['Name']) ? '--name='.escapeshellarg($xml['Name']) : '';
   $cmdPrivileged = strtolower($xml['Privileged'])=='true' ? '--privileged=true' : '';
-  if (preg_match('/^container:(.*)/', $xml['Network'])) {
-    $cmdNetwork  = preg_match('/\-\-net(work)?=/',$xml['ExtraParams']) ? "" : '--net='.escapeshellarg($xml['Network']);
-  } else {
-    $cmdNetwork  = preg_match('/\-\-net(work)?=/',$xml['ExtraParams']) ? "" : '--net='.escapeshellarg(strtolower($xml['Network']));
-  }
+  $extraNetwork  = preg_match('/\-\-net(work)?=/',$xml['ExtraParams']);
   $cmdMyIP       = '';
-  foreach (explode(' ',str_replace(',',' ',$xml['MyIP'])) as $myIP) if ($myIP) $cmdMyIP .= (strpos($myIP,':')?'--ip6=':'--ip=').escapeshellarg($myIP).' ';
+  if (preg_match('/^container:(.*)/', $xml['Network'])) {
+    $cmdNetwork  = $extraNetwork ? "" : '--net='.escapeshellarg($xml['Network']);
+  } else {
+    $networkName = strtolower($xml['Network']);
+    if ($extraNetwork) {
+      $cmdNetwork = "";
+    } elseif (strlen($xml['MyMAC']) && !in_array($networkName, ['host','none'])) {
+      $xml['ExtraParams'] = removeMacAddressParam($xml['ExtraParams']);
+      $networkEndpoint = ['name='.$networkName];
+      foreach (explode(' ',str_replace(',',' ',$xml['MyIP'])) as $myIP) {
+        if ($myIP) $networkEndpoint[] = (strpos($myIP,':')?'ip6=':'ip=').$myIP;
+      }
+      $networkEndpoint[] = 'mac-address='.$xml['MyMAC'];
+      $cmdNetwork = '--network='.escapeshellarg(implode(',', $networkEndpoint));
+    } else {
+      $cmdNetwork  = '--net='.escapeshellarg($networkName);
+    }
+  }
+  if (!strlen($xml['MyMAC']) || preg_match('/^container:(.*)/', $xml['Network']) || $extraNetwork) {
+    foreach (explode(' ',str_replace(',',' ',$xml['MyIP'])) as $myIP) if ($myIP) $cmdMyIP .= (strpos($myIP,':')?'--ip6=':'--ip=').escapeshellarg($myIP).' ';
+  }
   $cmdCPUset     = strlen($xml['CPUset']) ? '--cpuset-cpus='.escapeshellarg($xml['CPUset']) : '';
   $Volumes       = [''];
   $Ports         = [''];

--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -403,7 +403,7 @@ function xmlToCommand($xml, $create_paths=false) {
       $xml['ExtraParams'] = removeMacAddressParam($xml['ExtraParams']);
       $networkEndpoint = ['name='.$networkName];
       foreach (explode(' ',str_replace(',',' ',$xml['MyIP'])) as $myIP) {
-        if ($myIP) $networkEndpoint[] = (strpos($myIP,':')?'ip6=':'ip=').$myIP;
+        if ($myIP) $networkEndpoint[] = (strpos($myIP,':') !== false ? 'ip6=' : 'ip=').$myIP;
       }
       $networkEndpoint[] = 'mac-address='.$xml['MyMAC'];
       $cmdNetwork = '--network='.escapeshellarg(implode(',', $networkEndpoint));
@@ -412,7 +412,7 @@ function xmlToCommand($xml, $create_paths=false) {
     }
   }
   if (!strlen($xml['MyMAC']) || preg_match('/^container:(.*)/', $xml['Network']) || $extraNetwork) {
-    foreach (explode(' ',str_replace(',',' ',$xml['MyIP'])) as $myIP) if ($myIP) $cmdMyIP .= (strpos($myIP,':')?'--ip6=':'--ip=').escapeshellarg($myIP).' ';
+    foreach (explode(' ',str_replace(',',' ',$xml['MyIP'])) as $myIP) if ($myIP) $cmdMyIP .= (strpos($myIP,':') !== false ? '--ip6=' : '--ip=').escapeshellarg($myIP).' ';
   }
   $cmdCPUset     = strlen($xml['CPUset']) ? '--cpuset-cpus='.escapeshellarg($xml['CPUset']) : '';
   $Volumes       = [''];

--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -49,6 +49,28 @@ function removeMacAddressParam($extraParams) {
   return trim(preg_replace('/(^|\s)--mac-address(?:=|\s+)(?:"[^"]+"|\'[^\']+\'|[^\s]+)/', '$1', $extraParams));
 }
 
+function normalizeMacAddress($mac) {
+  $mac = strtolower(trim($mac ?? ''));
+  if ($mac === '') {
+    return '';
+  }
+  if (preg_match('/^[0-9a-f]{12}$/', $mac)) {
+    $mac = implode(':', str_split($mac, 2));
+  } else {
+    $mac = str_replace('-', ':', $mac);
+  }
+  return preg_match('/^([0-9a-f]{2}:){5}[0-9a-f]{2}$/', $mac) ? $mac : '';
+}
+
+function isValidUnicastMacAddress($mac) {
+  $mac = normalizeMacAddress($mac);
+  if ($mac === '') {
+    return false;
+  }
+  $firstOctet = hexdec(substr($mac, 0, 2));
+  return ($firstOctet & 1) === 0;
+}
+
 function generateTSwebui($url, $serve, $webUI) {
   if (!isset($webUI)) {
     return '';
@@ -93,7 +115,7 @@ function postToXML($post, $setOwnership=false) {
   }
   $xml->MyIP                       = xml_encode($post['contMyIP']);
   $extraNetwork                    = preg_match('/\-\-net(work)?=/', $post['contExtraParams'] ?? '');
-  $myMAC                           = trim($post['contMyMAC'] ?? '') ?: ($extraNetwork ? '' : extractMacAddressParam($post['contExtraParams'] ?? ''));
+  $myMAC                           = $extraNetwork ? '' : normalizeMacAddress(trim($post['contMyMAC'] ?? '') ?: extractMacAddressParam($post['contExtraParams'] ?? ''));
   $xml->MyMAC                      = xml_encode($myMAC);
   $xml->Shell                      = xml_encode($post['contShell']);
   $xml->Privileged                 = strtolower($post['contPrivileged']??'')=='on' ? 'true' : 'false';
@@ -169,7 +191,9 @@ function xmlToVar($xml) {
   $out['Registry']                     = xml_decode($xml->Registry);
   $out['Network']                      = xml_decode($xml->Network);
   $out['MyIP']                         = xml_decode($xml->MyIP ?? '');
-  $out['MyMAC']                        = xml_decode($xml->MyMAC ?? '') ?: extractMacAddressParam(xml_decode($xml->ExtraParams ?? ''));
+  $extraParams                         = xml_decode($xml->ExtraParams ?? '');
+  $extraNetwork                        = preg_match('/\-\-net(work)?=/', $extraParams);
+  $out['MyMAC']                        = $extraNetwork ? '' : normalizeMacAddress(xml_decode($xml->MyMAC ?? '') ?: extractMacAddressParam($extraParams));
   $out['Shell']                        = xml_decode($xml->Shell ?? 'sh');
   $out['Privileged']                   = xml_decode($xml->Privileged);
   $out['Support']                      = xml_decode($xml->Support);
@@ -180,7 +204,7 @@ function xmlToVar($xml) {
   $out['WebUI']                        = xml_decode($xml->WebUI);
   $out['TemplateURL']                  = xml_decode($xml->TemplateURL);
   $out['Icon']                         = xml_decode($xml->Icon);
-  $out['ExtraParams']                  = xml_decode($xml->ExtraParams);
+  $out['ExtraParams']                  = $extraParams;
   $out['PostArgs']                     = xml_decode($xml->PostArgs);
   $out['CPUset']                       = xml_decode($xml->CPUset);
   $out['DonateText']                   = xml_decode($xml->DonateText);

--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -66,15 +66,6 @@ function normalizeMacAddress($mac) {
   return preg_match('/^([0-9a-f]{2}:){5}[0-9a-f]{2}$/', $mac) ? $mac : '';
 }
 
-function isValidUnicastMacAddress($mac) {
-  $mac = normalizeMacAddress($mac);
-  if ($mac === '') {
-    return false;
-  }
-  $firstOctet = hexdec(substr($mac, 0, 2));
-  return ($firstOctet & 1) === 0;
-}
-
 function generateTSwebui($url, $serve, $webUI) {
   if (!isset($webUI)) {
     return '';

--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -347,20 +347,25 @@ docker_network_start(){
           REBUILD=1
         fi
       done
-      MY_NETWORK= MY_IP= MY_MAC= TEMPLATE_MAC= CUSTOM_PRIMARY=
+      MY_NETWORK= MY_IP= MY_MAC= XML_MAC= TEMPLATE_MAC= CUSTOM_PRIMARY=
       while read_dom; do
         [[ $ENTITY == Network ]] && MY_NETWORK=$CONTENT
         [[ $ENTITY == MyIP ]] && MY_IP=${CONTENT// /,} && MY_IP=$(echo "$MY_IP" | tr -s "," ";")
+        [[ $ENTITY == MyMAC ]] && XML_MAC=${CONTENT// /}
       done <$XMLFILE
       # only restore valid networks
       if [[ -n $MY_NETWORK ]]; then
         [[ $MY_NETWORK =~ ^(br|bond|eth|wlan)[0-9]+(\.[0-9]+)?$ ]] && CUSTOM_PRIMARY=1
         TEMPLATE_MAC=$(sed -nE 's@.*<ExtraParams>.*--mac-address(=|[[:space:]]+)([^ <]+).*@\2@p' "$XMLFILE" | head -n1)
-        MY_MAC=$(docker inspect --format="{{with index .NetworkSettings.Networks \"$MY_NETWORK\"}}{{.MacAddress}}{{end}}" $CONTAINER 2>/dev/null)
-        [[ -n $MY_MAC ]] || MY_MAC=$TEMPLATE_MAC
+        if [[ -n $XML_MAC ]]; then
+          MY_MAC=$XML_MAC
+        else
+          MY_MAC=$(docker inspect --format="{{with index .NetworkSettings.Networks \"$MY_NETWORK\"}}{{.MacAddress}}{{end}}" $CONTAINER 2>/dev/null)
+          [[ -n $MY_MAC ]] || MY_MAC=$TEMPLATE_MAC
+        fi
         netrestore_add "$MY_NETWORK" "$CONTAINER" "$MY_IP" "$MY_MAC"
         PRIMARY_NETWORK[$CONTAINER]=$MY_NETWORK
-        [[ -n $REBUILD || (-n $TEMPLATE_MAC && -n $CUSTOM_PRIMARY) ]] && REBUILD_CONTAINERS[$CONTAINER]=1
+        [[ -n $REBUILD || (-z $XML_MAC && -n $TEMPLATE_MAC && -n $CUSTOM_PRIMARY) ]] && REBUILD_CONTAINERS[$CONTAINER]=1
       fi
     fi
     # restore user defined networks

--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -248,6 +248,7 @@ netrestore_connect(){
   local MY_OPTS=
   local IP=
   local ENDPOINT_ID=
+  local ENDPOINT_MAC=
   local OUT=
 
   container_exist "$CONTAINER" || return 0
@@ -263,9 +264,6 @@ netrestore_connect(){
     return 1
   fi
 
-  ENDPOINT_ID=$(docker inspect --format="{{with index .NetworkSettings.Networks \"$NETWORK\"}}{{.EndpointID}}{{end}}" "$CONTAINER" 2>/dev/null)
-  [[ -n $ENDPOINT_ID ]] && return 0
-
   for IP in ${MY_TT//;/ }; do
     [[ -n $IP ]] || continue
     if [[ $IP =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
@@ -278,6 +276,18 @@ netrestore_connect(){
   done
 
   [[ -n $MY_MAC ]] && MY_OPTS="--driver-opt=com.docker.network.endpoint.macaddress=$MY_MAC"
+  ENDPOINT_ID=$(docker inspect --format="{{with index .NetworkSettings.Networks \"$NETWORK\"}}{{.EndpointID}}{{end}}" "$CONTAINER" 2>/dev/null)
+  if [[ -n $ENDPOINT_ID ]]; then
+    [[ -n $MY_MAC ]] || return 0
+    ENDPOINT_MAC=$(docker inspect --format="{{with index .NetworkSettings.Networks \"$NETWORK\"}}{{.MacAddress}}{{end}}" "$CONTAINER" 2>/dev/null)
+    [[ ${ENDPOINT_MAC,,} == ${MY_MAC,,} ]] && return 0
+    log "reconnecting $CONTAINER to network $NETWORK to restore MAC $MY_MAC"
+    if ! OUT=$(docker network disconnect -f "$NETWORK" "$CONTAINER" 2>&1); then
+      log "failed to disconnect $CONTAINER from network $NETWORK: $OUT"
+      return 1
+    fi
+  fi
+
   log "connecting $CONTAINER to network $NETWORK"
   if ! OUT=$(docker network connect $MY_OPTS $MY_IP $NETWORK $CONTAINER 2>&1); then
     log "failed to connect $CONTAINER to network $NETWORK: $OUT"

--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -245,8 +245,14 @@ netrestore_connect(){
   local MY_TT=$3
   local MY_MAC=$4
   local MY_IP=
-  local MY_OPTS=
+  local MY_IPV4=
+  local MY_IPV6=
   local IP=
+  local IPAM_JSON=
+  local ENDPOINT_JSON=
+  local CONNECT_JSON=
+  local CODE=
+  local BODY=
   local ENDPOINT_ID=
   local ENDPOINT_MAC=
   local OUT=
@@ -267,15 +273,16 @@ netrestore_connect(){
   for IP in ${MY_TT//;/ }; do
     [[ -n $IP ]] || continue
     if [[ $IP =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+      MY_IPV4=$IP
       MY_IP="$MY_IP --ip $IP"
     elif [[ $IP =~ : ]]; then
+      MY_IPV6=$IP
       MY_IP="$MY_IP --ip6 $IP"
     else
       log "skipping invalid stored IP for $CONTAINER on network $NETWORK: $IP"
     fi
   done
 
-  [[ -n $MY_MAC ]] && MY_OPTS="--driver-opt=com.docker.network.endpoint.macaddress=$MY_MAC"
   ENDPOINT_ID=$(docker inspect --format="{{with index .NetworkSettings.Networks \"$NETWORK\"}}{{.EndpointID}}{{end}}" "$CONTAINER" 2>/dev/null)
   if [[ -n $ENDPOINT_ID ]]; then
     [[ -n $MY_MAC ]] || return 0
@@ -288,8 +295,24 @@ netrestore_connect(){
     fi
   fi
 
+  if [[ -n $MY_MAC ]]; then
+    [[ -n $MY_IPV4 ]] && IPAM_JSON="\"IPv4Address\":\"$MY_IPV4\""
+    [[ -n $MY_IPV6 ]] && IPAM_JSON="${IPAM_JSON:+$IPAM_JSON,}\"IPv6Address\":\"$MY_IPV6\""
+    ENDPOINT_JSON="\"MacAddress\":\"$MY_MAC\""
+    [[ -n $IPAM_JSON ]] && ENDPOINT_JSON="\"IPAMConfig\":{$IPAM_JSON},$ENDPOINT_JSON"
+    CONNECT_JSON="{\"Container\":\"$CONTAINER\",\"EndpointConfig\":{$ENDPOINT_JSON}}"
+    OUT=$(curl --unix-socket /var/run/docker.sock -sS -w $'\n%{http_code}' -X POST -H "Content-Type: application/json" --data "$CONNECT_JSON" "http://localhost/networks/$NETWORK/connect" 2>&1)
+    CODE=${OUT##*$'\n'}
+    BODY=${OUT%$'\n'$CODE}
+    if [[ $CODE != 2* ]]; then
+      log "failed to connect $CONTAINER to network $NETWORK: $BODY"
+      return 1
+    fi
+    return 0
+  fi
+
   log "connecting $CONTAINER to network $NETWORK"
-  if ! OUT=$(docker network connect $MY_OPTS $MY_IP $NETWORK $CONTAINER 2>&1); then
+  if ! OUT=$(docker network connect $MY_IP $NETWORK $CONTAINER 2>&1); then
     log "failed to connect $CONTAINER to network $NETWORK: $OUT"
     return 1
   fi


### PR DESCRIPTION
## Summary
- Add a first-class Fixed MAC address field for Docker templates alongside Fixed IP address.
- Show the Fixed MAC address field for Bridge and custom networks while keeping Fixed IP custom-network only.
- Emit Docker's endpoint-level `--network=name=...,ip=...,mac-address=...` syntax when the GUI owns the network setting.
- Migrate eligible legacy `--mac-address` values out of Extra Parameters while preserving ExtraParams-owned `--network`/`--net` cases.
- Keep Extra Parameters parsing conservative: only simple top-level unquoted `--mac-address`, `--network`, and `--net` forms are interpreted, while quoted values are left untouched.
- Restore stored template MACs during Docker custom network recreation and reconnect mismatched existing endpoints after Docker daemon/network restart.
- Use Docker's network connect API with `EndpointConfig.MacAddress` for fixed-MAC restores, because Docker 29.3.1 stores but does not apply the equivalent CLI driver option on macvlan.
- Normalize fixed MAC values from hyphenated or compact input to Docker's colon-separated lowercase form.
- Detect Extra Parameters networking with both equals and space-separated Docker CLI syntax, such as `--network=br0` and `--network br0`.
- Classify Fixed IP values containing a colon as IPv6 even when the address begins with `::`.

## Verification
- `php -d short_open_tag=1 -l emhttp/plugins/dynamix.docker.manager/include/Helpers.php`
- `php -d short_open_tag=1 -l emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php`
- `bash -n etc/rc.d/rc.docker`
- `git diff --check`
- Generated sample commands for GUI-owned and ExtraParams-owned network configurations.
- Generated a Bridge-mode sample command: `--network='name=bridge,mac-address=02:42:9a:0d:7e:c0'`.
- Checked MAC normalization example: `02-42-9A-0D-7E-C0` normalizes to `02:42:9a:0d:7e:c0`.
- Checked network option detection for `--network=br0`, `--network br0`, `--net=host`, and `--net host` in PHP paths.
- Checked conservative Extra Parameters parsing leaves quoted values such as `--env "FOO=bar --network br0"` and `--label '--mac-address 11:22:33:44:55:66'` untouched.
- Checked `::1` emits `ip6=::1` for endpoint options and `--ip6='::1'` for legacy IP flags.
- Checked the restart restore path with `bash -n etc/rc.d/rc.docker`; it now compares current endpoint MACs before returning and reconnects only when the stored MAC differs.
- Reproduced the Docker 29.3.1/macvlan restart issue on `root@192.168.0.206`: CLI `--driver-opt=com.docker.network.endpoint.macaddress=...` persisted in `DriverOpts` but still produced a random endpoint MAC.
- Verified the Docker socket API `/networks/br0/connect` with `EndpointConfig.MacAddress` restores the live Firefox endpoint MAC to `02:42:9a:0d:7e:c0`.
- Reboot-tested `root@192.168.0.206` with Firefox in autostart; after boot, Firefox was running on `br0` with template MAC `02:42:9a:0d:7e:c0`, live endpoint MAC `02:42:9a:0d:7e:c0`, and IP `192.168.0.6`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional "Fixed MAC address" field to Docker container settings with automatic format normalization and validation.
* **Bug Fixes**
  * Improved handling of container-network references and more reliable MAC restoration/reconnect behavior to avoid incorrect endpoint assignments.
  * Cleaner handling so legacy per-container MAC parameters are no longer duplicated.
* **Documentation**
  * Added help text describing the fixed MAC option, format requirements, and its relation to legacy settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->