### PR TITLE
fix(docker): prevent case-duplicate user templates

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -137,8 +137,9 @@ if (isset($_POST['contName'])) {
     // force kill container if still running after 10 seconds
     removeContainer($existing,1);
     // remove old template
-    if (strtolower($filename) != strtolower("$userTmplDir/my-$existing.xml")) {
-      @unlink("$userTmplDir/my-$existing.xml");
+    $oldFilename = $DockerTemplates->getUserTemplatePath($existing);
+    if (strtolower($filename) != strtolower($oldFilename)) {
+      @unlink($oldFilename);
     }
   }
   // Extract real Entrypoint and Cmd from container for Tailscale

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -82,7 +82,11 @@ if (isset($_POST['contName'])) {
   if (!is_dir($userTmplDir)) mkdir($userTmplDir, 0777, true);
   $sourceTemplate = _var($_POST,'sourceTemplate',false);
   if ($sourceTemplate) $sourceTemplate = unscript(urldecode($sourceTemplate));
-  $sourceUserTemplate = $sourceTemplate && is_file($sourceTemplate) && dirname($sourceTemplate)==$userTmplDir && preg_match('/^my-.*\.xml$/', basename($sourceTemplate));
+  $sourceUserTemplate = $sourceTemplate && basename($sourceTemplate)==$sourceTemplate && preg_match('/^my-[^\/\\\\]+\.xml$/', $sourceTemplate);
+  if ($sourceUserTemplate) {
+    $sourceTemplate = "$userTmplDir/$sourceTemplate";
+    $sourceUserTemplate = is_file($sourceTemplate);
+  }
   if ($Name) {
     $filename = ($sourceUserTemplate && $existing === $Name) ? $sourceTemplate : $DockerTemplates->getUserTemplatePath($Name);
     if (is_file($filename)) {
@@ -903,7 +907,7 @@ if (isset($xml["Config"])) {
 <input type="hidden" name="csrf_token" value="<?=$var['csrf_token']?>">
 <input type="hidden" name="contCPUset" value="">
 <?if ($xmlType=='edit' && is_file($xmlTemplate) && dirname($xmlTemplate)==$dockerManPaths['templates-user']):?>
-<input type="hidden" name="sourceTemplate" value="<?=htmlspecialchars($xmlTemplate)?>">
+<input type="hidden" name="sourceTemplate" value="<?=htmlspecialchars(basename($xmlTemplate))?>">
 <?endif;?>
 <?if ($xmlType=='edit'):?>
 <?if ($DockerClient->doesContainerExist($templateName)):?>

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -80,8 +80,11 @@ if (isset($_POST['contName'])) {
   // Saving the generated configuration file.
   $userTmplDir = $dockerManPaths['templates-user'];
   if (!is_dir($userTmplDir)) mkdir($userTmplDir, 0777, true);
+  $sourceTemplate = _var($_POST,'sourceTemplate',false);
+  if ($sourceTemplate) $sourceTemplate = unscript(urldecode($sourceTemplate));
+  $sourceUserTemplate = $sourceTemplate && is_file($sourceTemplate) && dirname($sourceTemplate)==$userTmplDir && preg_match('/^my-.*\.xml$/', basename($sourceTemplate));
   if ($Name) {
-    $filename = $DockerTemplates->getUserTemplatePath($Name);
+    $filename = ($sourceUserTemplate && $existing === $Name) ? $sourceTemplate : $DockerTemplates->getUserTemplatePath($Name);
     if (is_file($filename)) {
       $oldXML = simplexml_load_file($filename);
       if ($oldXML->Icon != $_POST['contIcon']) {
@@ -137,7 +140,7 @@ if (isset($_POST['contName'])) {
     // force kill container if still running after 10 seconds
     removeContainer($existing,1);
     // remove old template
-    $oldFilename = $DockerTemplates->getUserTemplatePath($existing);
+    $oldFilename = $sourceUserTemplate ? $sourceTemplate : $DockerTemplates->getUserTemplatePath($existing);
     if (strtolower($filename) != strtolower($oldFilename)) {
       @unlink($oldFilename);
     }
@@ -899,6 +902,9 @@ if (isset($xml["Config"])) {
 <form markdown="1" method="POST" autocomplete="off" onsubmit="return prepareConfig(this)">
 <input type="hidden" name="csrf_token" value="<?=$var['csrf_token']?>">
 <input type="hidden" name="contCPUset" value="">
+<?if ($xmlType=='edit' && is_file($xmlTemplate) && dirname($xmlTemplate)==$dockerManPaths['templates-user']):?>
+<input type="hidden" name="sourceTemplate" value="<?=htmlspecialchars($xmlTemplate)?>">
+<?endif;?>
 <?if ($xmlType=='edit'):?>
 <?if ($DockerClient->doesContainerExist($templateName)):?>
 <input type="hidden" name="existingContainer" value="<?=$templateName?>">

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -81,7 +81,7 @@ if (isset($_POST['contName'])) {
   $userTmplDir = $dockerManPaths['templates-user'];
   if (!is_dir($userTmplDir)) mkdir($userTmplDir, 0777, true);
   if ($Name) {
-    $filename = sprintf('%s/my-%s.xml', $userTmplDir, $Name);
+    $filename = $DockerTemplates->getUserTemplatePath($Name);
     if (is_file($filename)) {
       $oldXML = simplexml_load_file($filename);
       if ($oldXML->Icon != $_POST['contIcon']) {

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -266,8 +266,23 @@ class DockerTemplates {
 		return $output;
 	}
 
+	private function getXmlName($path) {
+		if (!is_file($path)) return false;
+		$doc = new DOMDocument('1.0', 'utf-8');
+		if (!$doc->load($path)) return false;
+		return $doc->getElementsByTagName('Name')->item(0)->nodeValue??'';
+	}
+
 	public function getTemplateValue($Repository, $field, $scope='all',$name='') {
-		foreach ($this->getTemplates($scope) as $file) {
+		$templates = $this->getTemplates($scope);
+		if ($name && ($scope=='all' || $scope=='user') && ($userTemplate = $this->getUserTemplate($name))) {
+			$ordered = [['path' => $userTemplate, 'prefix' => basename(dirname($userTemplate)), 'name' => basename($userTemplate, '.xml')]];
+			foreach ($templates as $template) {
+				if ($template['path'] != $userTemplate) $ordered[] = $template;
+			}
+			$templates = $ordered;
+		}
+		foreach ($templates as $file) {
 			$doc = new DOMDocument();
 			$doc->load($file['path']);
 			if ($name) {
@@ -283,11 +298,11 @@ class DockerTemplates {
 	}
 
 	public function getUserTemplate($Container) {
+		$userTemplate = $this->getUserTemplatePath($Container);
+		if ($this->getXmlName($userTemplate)===$Container) return $userTemplate;
 		foreach ($this->getTemplates('user') as $file) {
-			$doc = new DOMDocument('1.0', 'utf-8');
-			$doc->load($file['path']);
-			$Name = $doc->getElementsByTagName('Name')->item(0)->nodeValue??'';
-			if ($Name==$Container) return $file['path'];
+			if ($file['path']==$userTemplate) continue;
+			if ($this->getXmlName($file['path'])===$Container) return $file['path'];
 		}
 		return false;
 	}

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -143,6 +143,7 @@ class DockerTemplates {
 		global $dockerManPaths;
 		$dir = $dockerManPaths['templates-user'];
 		if (!is_dir($dir)) @mkdir($dir, 0755, true);
+		$Container = str_replace(['/', '\\'], '', $Container);
 		$target = "my-$Container.xml";
 		$targetLower = strtolower($target);
 		$match = false;
@@ -266,23 +267,8 @@ class DockerTemplates {
 		return $output;
 	}
 
-	private function getXmlName($path) {
-		if (!is_file($path)) return false;
-		$doc = new DOMDocument('1.0', 'utf-8');
-		if (!$doc->load($path)) return false;
-		return $doc->getElementsByTagName('Name')->item(0)->nodeValue??'';
-	}
-
 	public function getTemplateValue($Repository, $field, $scope='all',$name='') {
-		$templates = $this->getTemplates($scope);
-		if ($name && ($scope=='all' || $scope=='user') && ($userTemplate = $this->getUserTemplate($name))) {
-			$ordered = [['path' => $userTemplate, 'prefix' => basename(dirname($userTemplate)), 'name' => basename($userTemplate, '.xml')]];
-			foreach ($templates as $template) {
-				if ($template['path'] != $userTemplate) $ordered[] = $template;
-			}
-			$templates = $ordered;
-		}
-		foreach ($templates as $file) {
+		foreach ($this->getTemplates($scope) as $file) {
 			$doc = new DOMDocument();
 			$doc->load($file['path']);
 			if ($name) {
@@ -298,11 +284,11 @@ class DockerTemplates {
 	}
 
 	public function getUserTemplate($Container) {
-		$userTemplate = $this->getUserTemplatePath($Container);
-		if ($this->getXmlName($userTemplate)===$Container) return $userTemplate;
 		foreach ($this->getTemplates('user') as $file) {
-			if ($file['path']==$userTemplate) continue;
-			if ($this->getXmlName($file['path'])===$Container) return $file['path'];
+			$doc = new DOMDocument('1.0', 'utf-8');
+			$doc->load($file['path']);
+			$Name = $doc->getElementsByTagName('Name')->item(0)->nodeValue??'';
+			if ($Name==$Container) return $file['path'];
 		}
 		return false;
 	}

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -139,6 +139,21 @@ class DockerTemplates {
 		return $tmpls;
 	}
 
+	public function getUserTemplatePath($Container) {
+		global $dockerManPaths;
+		$dir = $dockerManPaths['templates-user'];
+		if (!is_dir($dir)) @mkdir($dir, 0755, true);
+		$target = "my-$Container.xml";
+		$targetLower = strtolower($target);
+		$match = false;
+		foreach (glob("$dir/my-*.xml") ?: [] as $template) {
+			$name = basename($template);
+			if ($name == $target) return $template;
+			if (!$match && strtolower($name) == $targetLower) $match = $template;
+		}
+		return $match ?: "$dir/$target";
+	}
+
 	public function downloadTemplates($Dest=null, $Urls=null) {	
 		/* Don't download any templates.  Leave code in place for future reference. */
 		/* remove existing limetech templates that are all not valid */

--- a/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
+++ b/emhttp/plugins/dynamix.docker.manager/scripts/docker_init
@@ -4,19 +4,33 @@
 $autostart = @file("/var/lib/docker/unraid-autostart",FILE_IGNORE_NEW_LINES);
 if ( ! $autostart ) exit();
 
+function user_template($container) {
+  $dir = "/boot/config/plugins/dockerMan/templates-user";
+  $target = "my-$container.xml";
+  $targetLower = strtolower($target);
+  $match = false;
+  foreach (glob("$dir/my-*.xml") ?: [] as $template) {
+    $name = basename($template);
+    if ($name == $target) return $template;
+    if (!$match && strtolower($name) == $targetLower) $match = $template;
+  }
+  return $match;
+}
+
 $flag = false;
 $newAuto = [];
 foreach ($autostart as $container) {
   if (! trim($container) ) continue;
 
   $cont = explode(" ",$container);
-  if ( ! is_file("/boot/config/plugins/dockerMan/templates-user/my-{$cont[0]}.xml")) {
+  $template = user_template($cont[0]);
+  if (!$template) {
     $newAuto[] = $container;
     continue;
   }
     
   $doc = new DOMDocument();
-  if (!$doc->load("/boot/config/plugins/dockerMan/templates-user/my-{$cont[0]}.xml")) {
+  if (!$doc->load($template)) {
     $newAuto[] = $container;
     continue;
   }

--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -47,6 +47,24 @@ active(){
   fi
 }
 
+# return the user template for a container, preserving legacy case-insensitive
+# matching without returning multiple files on case-sensitive boot devices
+docker_user_template(){
+  local dir=/boot/config/plugins/dockerMan/templates-user
+  local target="my-$1.xml"
+  local target_lc=${target,,}
+  local match=
+  local file
+  local name
+  for file in "$dir"/my-*.xml; do
+    [[ -e $file ]] || continue
+    name=${file##*/}
+    [[ $name == "$target" ]] && echo "$file" && return
+    [[ -z $match && ${name,,} == "$target_lc" ]] && match=$file
+  done
+  [[ -n $match ]] && echo "$match"
+}
+
 # wait for interface to go up
 carrier(){
   local n e
@@ -360,23 +378,22 @@ docker_network_start(){
   # get container settings for custom networks to reconnect later
   declare -A NETRESTORE PRIMARY_NETWORK REBUILD_CONTAINERS USED_SUBNETS4 USED_SUBNETS6 RESTORED_NETWORKS
   for CONTAINER in $(docker container ls -a --format='{{.Names}}'); do
-    # the file case (due to fat32) might be different so use find to match
-    XMLFILE=$(find /boot/config/plugins/dockerMan/templates-user -maxdepth 1 -iname my-${CONTAINER}.xml)
-    if [[ -n $XMLFILE ]]; then
+    XMLFILE=$(docker_user_template "$CONTAINER")
+    if [[ -f $XMLFILE ]]; then
       REBUILD=
       MAIN=
       # update custom network reference (if changed)
       for NIC in $NICS; do
         [[ ${NIC:0:3} == eth ]] && NIC=$(active $NIC)
         X=${NIC//[^0-9]/}
-        REF=$(grep -Pom1 "<Network>\K(br|bond|eth|wlan)$X" $XMLFILE)
+        REF=$(grep -Pom1 "<Network>\K(br|bond|eth|wlan)$X" "$XMLFILE")
         if [[ $X == 0 ]] && ! carrier $NIC 1; then
           continue
         fi
         [[ $X == 0 && $NIC != wlan0 ]] && MAIN=$NIC
         [[ $NIC == wlan0 && -n $MAIN ]] && continue
         if [[ -n $REF && $REF != $NIC ]]; then
-          sed -ri "s/<Network>(br|bond|eth|wlan)$X(\.[0-9]+)?<\/Network>/<Network>$NIC\2<\/Network>/" $XMLFILE
+          sed -ri "s/<Network>(br|bond|eth|wlan)$X(\.[0-9]+)?<\/Network>/<Network>$NIC\2<\/Network>/" "$XMLFILE"
           REBUILD=1
         fi
       done
@@ -385,7 +402,7 @@ docker_network_start(){
         [[ $ENTITY == Network ]] && MY_NETWORK=$CONTENT
         [[ $ENTITY == MyIP ]] && MY_IP=${CONTENT// /,} && MY_IP=$(echo "$MY_IP" | tr -s "," ";")
         [[ $ENTITY == MyMAC ]] && XML_MAC=${CONTENT// /}
-      done <$XMLFILE
+      done <"$XMLFILE"
       # only restore valid networks
       if [[ -n $MY_NETWORK ]]; then
         [[ $MY_NETWORK =~ ^(br|bond|eth|wlan)[0-9]+(\.[0-9]+)?$ ]] && CUSTOM_PRIMARY=1


### PR DESCRIPTION
## Summary
- reuse existing Docker user-template filenames when the requested container name differs only by case
- avoid creating a second XML on case-sensitive boot media during template saves
- preserve the opened user-template basename for unchanged-name edits so saving cannot silently write to a different case-variant file
- reject posted source-template values with path separators and rebuild accepted `my-*.xml` basenames under `templates-user`
- resolve renamed-container old-template paths through the opened source template, or through `DockerTemplates::getUserTemplatePath()` when no source template was posted
- replace startup `find -iname` template lookup with deterministic single-file lookup

## Testing
- `php -l emhttp/plugins/dynamix.docker.manager/include/DockerClient.php`
- `php -l emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php`
- `php -l emhttp/plugins/dynamix.docker.manager/scripts/docker_init`
- `php -d short_open_tag=1 -l emhttp/plugins/dynamix.docker.manager/include/DockerClient.php`
- `php -d short_open_tag=1 -l emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php`
- `php -d short_open_tag=1 -l emhttp/plugins/dynamix.docker.manager/scripts/docker_init`
- `bash -n etc/rc.d/rc.docker`
- `git diff --check`
- focused PHP regression for case-only Docker template lookup and save behavior
- deployed to `root@192.168.0.206` and verified edit/save updates an existing mixed-case template instead of creating a lowercase duplicate
- restarted Docker on `root@192.168.0.206` with a mismatched-case autostart template probe and verified no duplicate template was created
- reproduced duplicate case-variant templates on `root@192.168.0.206` (`my-FIREfox2.xml` plus `my-Firefox2.xml`) and verified unchanged-name save from the opened `my-FIREfox2.xml` basename updates only that opened file
- verified `sourceTemplate=../../my-FIREfox2.xml` is rejected and falls back to normal canonical save behavior rather than traversing paths

## Notes
This PR is intentionally separate from `codex/docker-endpoint-mac-address` and contains only the template case load/save/startup lookup fix plus existing rename-time old-template deletion path correction. It does not add a duplicate cleanup pass and does not remove duplicate template files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Created support for specifying and preserving a source user template when creating or editing containers.

* **Bug Fixes**
  * Improved user-template resolution (exact then case-insensitive) to select the correct template.
  * Fixed template cleanup on rename so the previous template is removed reliably.
  * Deferred autostart containers when their user template cannot be loaded.

* **Stability**
  * Hardened template validation and file handling to reduce startup and editing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->