### PR TITLE
feat(docker): show container MAC addresses

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
@@ -38,6 +38,7 @@ $cpus    = cpu_list();
                 <th>_(Version)_</th>
                 <th>_(Network)_</th>
                 <th>_(Container IP)_</th>
+                <th class="advanced">_(MAC Address)_</th>
                 <th>_(Container Port)_</th>
                 <th>_(LAN IP:Port)_</th>
                 <th>_(Volume Mappings)_ <small>(_(App to Host)_)</small></th>
@@ -46,7 +47,7 @@ $cpus    = cpu_list();
                 <th class="five">_(Uptime)_</th>
             </tr>
         </thead>
-        <tbody id="docker_list" class="js-fill-available-height"><tr><td colspan='9'></td></tr></tbody>
+        <tbody id="docker_list" class="js-fill-available-height"><tr><td colspan='11'></td></tr></tbody>
     </table>
 </div>
 

--- a/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
@@ -38,7 +38,6 @@ $cpus    = cpu_list();
                 <th>_(Version)_</th>
                 <th>_(Network)_</th>
                 <th>_(Container IP)_</th>
-                <th class="advanced">_(MAC Address)_</th>
                 <th>_(Container Port)_</th>
                 <th>_(LAN IP:Port)_</th>
                 <th>_(Volume Mappings)_ <small>(_(App to Host)_)</small></th>
@@ -47,7 +46,7 @@ $cpus    = cpu_list();
                 <th class="five">_(Uptime)_</th>
             </tr>
         </thead>
-        <tbody id="docker_list" class="js-fill-available-height"><tr><td colspan='11'></td></tr></tbody>
+        <tbody id="docker_list" class="js-fill-available-height"><tr><td colspan='10'></td></tr></tbody>
     </table>
 </div>
 

--- a/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
@@ -37,7 +37,7 @@ $cpus    = cpu_list();
                 <th><a id="resetsort" class="nohand" onclick="resetSorting()" title="_(Reset sorting)_"><i class="fa fa-th-list"></i></a>_(Application)_</th>
                 <th>_(Version)_</th>
                 <th>_(Network)_</th>
-                <th>_(Container IP)_</th>
+                <th>_(Container IP)_ <span class="advanced">/ _(MAC)_</span></th>
                 <th>_(Container Port)_</th>
                 <th>_(LAN IP:Port)_</th>
                 <th>_(Volume Mappings)_ <small>(_(App to Host)_)</small></th>

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -1022,15 +1022,23 @@ class DockerClient {
 				$ports = &$info['Config']['ExposedPorts'];
 			}
 			foreach($ct['NetworkSettings']['Networks'] as $netName => $netVals) {
+				$networkDetails = $info['NetworkSettings']['Networks'][$netName] ?? $netVals;
 				$i = $c['NetworkMode']=='host' ? $host : $netVals['IPAddress'];
-				$c['Networks'][$netName] = [ 'IPAddress' => $i ];
+				$c['Networks'][$netName] = [
+					'IPAddress' => $i,
+					'MacAddress' => $networkDetails['MacAddress'] ?? ''
+				];
 				if ( isset($driver[$netName]) && ($driver[$netName]=='ipvlan' || $driver[$netName]=='macvlan') ) {
 					if (!isset($c['Ports']['vlan'])) $c['Ports']['vlan'] = [];
 					$c['Ports']['vlan']["$i"] = $i;
 				}
 			}
+			$networkDetails = $info['NetworkSettings']['Networks'][$c['NetworkMode']] ?? $ct['NetworkSettings']['Networks'][$c['NetworkMode']] ?? [];
 			$ip = $c['NetworkMode']=='host' ? $host : $ct['NetworkSettings']['Networks'][$c['NetworkMode']]['IPAddress'] ?? null;
-			$c['Networks'][$c['NetworkMode']] = [ 'IPAddress' => $ip ];
+			$c['Networks'][$c['NetworkMode']] = [
+				'IPAddress' => $ip,
+				'MacAddress' => $networkDetails['MacAddress'] ?? ''
+			];
 			$ports = (isset($ports) && is_array($ports)) ? $ports : [];
 			foreach ($ports as $port => $value) {
 				if (!isset($info['HostConfig']['PortBindings'][$port])) {

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -155,7 +155,7 @@ foreach ($containers as $ct) {
   foreach($ct['Networks'] as $netName => $netVals) {
     $networks[] = $netName;
     $network_ip = $running ? htmlspecialchars((string)$netVals['IPAddress']) : '';
-    $network_mac = htmlspecialchars((string)($netVals['MacAddress'] ?? ''));
+    $network_mac = $running ? htmlspecialchars((string)($netVals['MacAddress'] ?? '')) : '';
     $network_ips[] = $network_mac ? "$network_ip<span class='advanced'><br>$network_mac</span>" : $network_ip;
     if (isset($ct['Networks']['host'])) {
       $ports_external[] = sprintf('%s', $netVals['IPAddress']);

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -156,7 +156,7 @@ foreach ($containers as $ct) {
     $networks[] = $netName;
     $network_ip = $running ? htmlspecialchars((string)$netVals['IPAddress']) : '';
     $network_mac = htmlspecialchars((string)($netVals['MacAddress'] ?? ''));
-    $network_ips[] = $network_mac ? "$network_ip<div class='advanced'>"._('MAC').": $network_mac</div>" : $network_ip;
+    $network_ips[] = $network_mac ? "$network_ip<span class='advanced'> / $network_mac</span>" : $network_ip;
     if (isset($ct['Networks']['host'])) {
       $ports_external[] = sprintf('%s', $netVals['IPAddress']);
       $ports_internal[0] = sprintf('%s', 'all');

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -156,7 +156,7 @@ foreach ($containers as $ct) {
     $networks[] = $netName;
     $network_ip = $running ? htmlspecialchars((string)$netVals['IPAddress']) : '';
     $network_mac = htmlspecialchars((string)($netVals['MacAddress'] ?? ''));
-    $network_ips[] = $network_mac ? "$network_ip<span class='advanced'> / $network_mac</span>" : $network_ip;
+    $network_ips[] = $network_mac ? "$network_ip<span class='advanced'><br>$network_mac</span>" : $network_ip;
     if (isset($ct['Networks']['host'])) {
       $ports_external[] = sprintf('%s', $netVals['IPAddress']);
       $ports_internal[0] = sprintf('%s', 'all');

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -28,7 +28,7 @@ $user_prefs      = $dockerManPaths['user-prefs'];
 $autostart_file  = $dockerManPaths['autostart-file'];
 
 if (!$containers && !$images) {
-  echo "<tr><td colspan='7' style='text-align:center;padding-top:12px'>"._('No Docker containers installed')."</td></tr>";
+  echo "<tr><td colspan='11' style='text-align:center;padding-top:12px'>"._('No Docker containers installed')."</td></tr>";
   return;
 }
 
@@ -144,6 +144,7 @@ foreach ($containers as $ct) {
   $wait = var_split($autostart[array_search($name,$names)]??'',1);
   $networks = [];
   $network_ips = [];
+  $network_macs = [];
   $ports_internal = [];
   $ports_external = [];
   if (isset($ct['Ports']['vlan'])) {
@@ -155,6 +156,7 @@ foreach ($containers as $ct) {
   foreach($ct['Networks'] as $netName => $netVals) {
     $networks[] = $netName;
     $network_ips[] = $running ? $netVals['IPAddress'] : null;
+    $network_macs[] = htmlspecialchars((string)($netVals['MacAddress'] ?? ''));
     if (isset($ct['Networks']['host'])) {
       $ports_external[] = sprintf('%s', $netVals['IPAddress']);
       $ports_internal[0] = sprintf('%s', 'all');
@@ -323,6 +325,7 @@ foreach ($containers as $ct) {
   echo "<div class='advanced'><i class='fa fa-info-circle fa-fw'></i> ".compress(_($version),12,0)."</div></td>";
   echo "<td style='white-space:nowrap'><span class='docker_readmore'> ".implode('<br>',$networks).$TS_status."</span></td>";
   echo "<td style='white-space:nowrap'><span class='docker_readmore'> ".implode('<br>',$network_ips)."</span></td>";
+  echo "<td class='advanced' style='white-space:nowrap'><span class='docker_readmore'> ".implode('<br>',$network_macs)."</span></td>";
   echo "<td style='white-space:nowrap'><span class='docker_readmore'>".implode('<br>',$ports_internal)."</span></td>";
   echo "<td style='white-space:nowrap'><span class='docker_readmore'>".implode('<br>',$ports_external)."</span></td>";
   echo "<td style='word-break:break-all'><span class='docker_readmore'>".implode('<br>',$paths)."</span></td>";
@@ -346,7 +349,7 @@ foreach ($images as $image) {
   $menu = sprintf("onclick=\"addDockerImageContext('%s','%s')\"", $id, implode(',',$image['Tags']));
   echo "<tr class='advanced'><td style='width:220px;padding:8px'>";
   echo "<span class='outer apps'><span id='$id' $menu class='hand'><img src='/webGui/images/disk.png' class='img'></span><span class='inner'>("._('orphan image').")<br><i class='fa fa-square stopped grey-text'></i><span class='state'>"._('stopped')."</span></span></span>";
-  echo "</td><td colspan='6'>"._('Image ID').": $id<br>";
+  echo "</td><td colspan='7'>"._('Image ID').": $id<br>";
   echo implode(', ',$image['Tags']);
   echo "</td><td>"._('Created')." ".htmlspecialchars(_($image['Created'],0))."</td></tr>";
 }

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -28,7 +28,7 @@ $user_prefs      = $dockerManPaths['user-prefs'];
 $autostart_file  = $dockerManPaths['autostart-file'];
 
 if (!$containers && !$images) {
-  echo "<tr><td colspan='11' style='text-align:center;padding-top:12px'>"._('No Docker containers installed')."</td></tr>";
+  echo "<tr><td colspan='10' style='text-align:center;padding-top:12px'>"._('No Docker containers installed')."</td></tr>";
   return;
 }
 
@@ -144,7 +144,6 @@ foreach ($containers as $ct) {
   $wait = var_split($autostart[array_search($name,$names)]??'',1);
   $networks = [];
   $network_ips = [];
-  $network_macs = [];
   $ports_internal = [];
   $ports_external = [];
   if (isset($ct['Ports']['vlan'])) {
@@ -155,8 +154,9 @@ foreach ($containers as $ct) {
   }
   foreach($ct['Networks'] as $netName => $netVals) {
     $networks[] = $netName;
-    $network_ips[] = $running ? $netVals['IPAddress'] : null;
-    $network_macs[] = htmlspecialchars((string)($netVals['MacAddress'] ?? ''));
+    $network_ip = $running ? htmlspecialchars((string)$netVals['IPAddress']) : '';
+    $network_mac = htmlspecialchars((string)($netVals['MacAddress'] ?? ''));
+    $network_ips[] = $network_mac ? "$network_ip<div class='advanced'>"._('MAC').": $network_mac</div>" : $network_ip;
     if (isset($ct['Networks']['host'])) {
       $ports_external[] = sprintf('%s', $netVals['IPAddress']);
       $ports_internal[0] = sprintf('%s', 'all');
@@ -325,7 +325,6 @@ foreach ($containers as $ct) {
   echo "<div class='advanced'><i class='fa fa-info-circle fa-fw'></i> ".compress(_($version),12,0)."</div></td>";
   echo "<td style='white-space:nowrap'><span class='docker_readmore'> ".implode('<br>',$networks).$TS_status."</span></td>";
   echo "<td style='white-space:nowrap'><span class='docker_readmore'> ".implode('<br>',$network_ips)."</span></td>";
-  echo "<td class='advanced' style='white-space:nowrap'><span class='docker_readmore'> ".implode('<br>',$network_macs)."</span></td>";
   echo "<td style='white-space:nowrap'><span class='docker_readmore'>".implode('<br>',$ports_internal)."</span></td>";
   echo "<td style='white-space:nowrap'><span class='docker_readmore'>".implode('<br>',$ports_external)."</span></td>";
   echo "<td style='word-break:break-all'><span class='docker_readmore'>".implode('<br>',$paths)."</span></td>";
@@ -349,7 +348,7 @@ foreach ($images as $image) {
   $menu = sprintf("onclick=\"addDockerImageContext('%s','%s')\"", $id, implode(',',$image['Tags']));
   echo "<tr class='advanced'><td style='width:220px;padding:8px'>";
   echo "<span class='outer apps'><span id='$id' $menu class='hand'><img src='/webGui/images/disk.png' class='img'></span><span class='inner'>("._('orphan image').")<br><i class='fa fa-square stopped grey-text'></i><span class='state'>"._('stopped')."</span></span></span>";
-  echo "</td><td colspan='7'>"._('Image ID').": $id<br>";
+  echo "</td><td colspan='6'>"._('Image ID').": $id<br>";
   echo implode(', ',$image['Tags']);
   echo "</td><td>"._('Created')." ".htmlspecialchars(_($image['Created'],0))."</td></tr>";
 }


### PR DESCRIPTION
## Summary
- Preserve Docker network endpoint MacAddress values from inspect data in DockerClient.
- Update the Container IP heading to show the advanced-only / MAC context.
- Show each MAC address on the line beneath the matching Container IP in advanced view, without adding a separate table column.

## Why
Users running containers on macvlan need the container MAC address for router and network configuration. Before this change, the UI did not expose that value, so users had to SSH into Unraid and run docker inspect manually.

## Testing
- php -l emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
- php -l emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
- php -l emhttp/plugins/dynamix.docker.manager/DockerContainers.page
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show per-network MAC addresses alongside container IPs in the advanced network view and update the column header to reflect "IP / MAC".

* **Bug Fixes**
  * Fix empty-state and loading placeholder column alignment to match the updated column count.
  * Improve handling and safe rendering when network or MAC information is absent to avoid null/undefined output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->