### PR TITLE
[codex] Normalize offline/online spelling in array copy

### DIFF
--- a/emhttp/plugins/dynamix/ArrayOperation.page
+++ b/emhttp/plugins/dynamix/ArrayOperation.page
@@ -598,7 +598,7 @@ window.onunload = function(){
   case "Started":?>
     <tr><td><?status_indicator()?>**_(Started)_<?=((_var($var,'startMode')=='Maintenance')?' - _(Maintenance Mode)_':'')?>**</td>
     <td><input type="button" id="stop-button" value="_(Stop)_" onclick="stopArray(this.form)"></td>
-    <td>**_(Stop)_** _(will take the array off-line)_.<span id="stop-text"></span></td></tr>
+    <td>**_(Stop)_** _(will take the array offline)_.<span id="stop-text"></span></td></tr>
 <?  if (_var($var,'fsNumUnmountable',0) > 0):?>
       <tr><td>**<?=_('Unmountable disk'.(_var($var,'fsNumUnmountable',0) == 1 ? '' : 's').' present')?>:**<br>
 <?    $cache = [];

--- a/emhttp/plugins/dynamix/ArrayOperation.page
+++ b/emhttp/plugins/dynamix/ArrayOperation.page
@@ -598,7 +598,7 @@ window.onunload = function(){
   case "Started":?>
     <tr><td><?status_indicator()?>**_(Started)_<?=((_var($var,'startMode')=='Maintenance')?' - _(Maintenance Mode)_':'')?>**</td>
     <td><input type="button" id="stop-button" value="_(Stop)_" onclick="stopArray(this.form)"></td>
-    <td>**_(Stop)_** _(will take the array offline)_.<span id="stop-text"></span></td></tr>
+    <td>**_(Stop)_** _(will take the array off-line)_.<span id="stop-text"></span></td></tr>
 <?  if (_var($var,'fsNumUnmountable',0) > 0):?>
       <tr><td>**<?=_('Unmountable disk'.(_var($var,'fsNumUnmountable',0) == 1 ? '' : 's').' present')?>:**<br>
 <?    $cache = [];

--- a/emhttp/plugins/dynamix/ArrayOperation.page
+++ b/emhttp/plugins/dynamix/ArrayOperation.page
@@ -753,7 +753,7 @@ window.onunload = function(){
       switch (_var($var,'mdState')):
       case "STARTED":
 ?>      <tr><td><?status_indicator()?>**_(Stopped)_**. _(Configuration valid)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-        <td>**_(Start)_** _(will bring the array online)_.</td></tr>
+        <td>**_(Start)_** _(will bring the array on-line)_.</td></tr>
 <?      maintenance_mode();
         check_encryption();
         break;
@@ -762,24 +762,24 @@ window.onunload = function(){
         if ($action[0] == "recon"):
           $resync = resync($action[1]);
 ?>        <tr><td><?status_indicator()?>**_(Stopped)_**. _(Configuration valid)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**<?=_('Start')?>** <?=_("will bring the array online and start **$resync**")?>.</td></tr>
+          <td>**<?=_('Start')?>** <?=_("will bring the array on-line and start **$resync**")?>.</td></tr>
 <?      elseif ($action[0] == "clear"):?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(New data disk(s) detected)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**_(Start)_** _(will bring the array online and start **Disk-Clear** of new data disk(s))_.</td></tr>
+          <td>**_(Start)_** _(will bring the array on-line and start **Disk-Clear** of new data disk(s))_.</td></tr>
 <?      elseif (_var($var,'sbClean') != "yes" && $action[0] == "check" && count($action) > 1):?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Unclean shutdown detected)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**_(Start)_** _(will bring the array online and start **Parity-Check**)_.
+          <td>**_(Start)_** _(will bring the array on-line and start **Parity-Check**)_.
           <br><input type="checkbox" name="optionCorrect" value="correct" checked><small>_(Write corrections to parity)_</small></td></tr>
 <?      elseif (_var($var,'sbClean') != "yes" && $action[0] == "check"):?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Unclean shutdown detected)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**_(Start)_** _(will bring the array online)_.</td></tr>
+          <td>**_(Start)_** _(will bring the array on-line)_.</td></tr>
 <?      elseif (missing_cache()):?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Missing pool disk)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)" disabled></td>
-          <td>**_(Start)_** _(will remove the missing pool disk and then bring the array online)_.
+          <td>**_(Start)_** _(will remove the missing pool disk and then bring the array on-line)_.
           <br><input type="checkbox" name="confirmStart" value="OFF" onclick="$('#cmdStart').prop('disabled',!arrayOps.confirmStart.checked)"><small>_(Yes, I want to do this)_</small></td></tr>
 <?      else:?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Configuration valid)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**_(Start)_** _(will bring the array online)_.</td></tr>
+          <td>**_(Start)_** _(will bring the array on-line)_.</td></tr>
 <?      endif;
         maintenance_mode();
         check_encryption();
@@ -787,11 +787,11 @@ window.onunload = function(){
       case "NEW_ARRAY":
         if (strpos(_var($disks['parity'],'status'),"DISK_NP") === 0 && strpos(_var($disks['parity2'],'status'),"DISK_NP") === 0):?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Configuration valid)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**_(Start)_** _(will record all disk information and bring the array online)_.
+          <td>**_(Start)_** _(will record all disk information and bring the array on-line)_.
           <br>_(The array will be immediately available, but **unprotected** since *parity* has not been assigned)_.</td></tr>
 <?      else:?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Configuration valid)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this,true)"></td>
-          <td>**_(Start)_** _(will record all disk information, bring the array online, and start Parity-Sync)_.
+          <td>**_(Start)_** _(will record all disk information, bring the array on-line, and start Parity-Sync)_.
           <br>_(The array will be immediately available, but **unprotected** until Parity-Sync completes)_.
           <br><input type="checkbox" name="md_invalidslot" value="99">_(Parity is already valid)_.</td></tr>
 <?      endif;
@@ -800,7 +800,7 @@ window.onunload = function(){
         break;
       case "DISABLE_DISK":?>
         <tr><td><?status_indicator()?>**_(Stopped)_**. _(Missing disk)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)" disabled></td>
-        <td>**_(Start)_** _(will disable the missing disk and then bring the array online. Install a replacement disk as soon as possible)_.
+        <td>**_(Start)_** _(will disable the missing disk and then bring the array on-line. Install a replacement disk as soon as possible)_.
         <br><input type="checkbox" name="confirmStart" value="OFF" onclick="$('#cmdStart').prop('disabled',!arrayOps.confirmStart.checked)"><small>_(Yes, I want to do this)_</small></td></tr>
 <?      maintenance_mode();
         check_encryption();
@@ -814,7 +814,7 @@ window.onunload = function(){
       case "SWAP_DSBL":
         if (_var($var,'fsCopyPrcnt') == "100"):?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Upgrading disk/swapping parity)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**_(Start)_** _(will expand the file system of the data disk (if possible); then bring the array online and start Data-Rebuild)_.</td></tr>
+          <td>**_(Start)_** _(will expand the file system of the data disk (if possible); then bring the array on-line and start Data-Rebuild)_.</td></tr>
 <?        maintenance_mode();
           check_encryption();
         else:?>

--- a/emhttp/plugins/dynamix/ArrayOperation.page
+++ b/emhttp/plugins/dynamix/ArrayOperation.page
@@ -753,7 +753,7 @@ window.onunload = function(){
       switch (_var($var,'mdState')):
       case "STARTED":
 ?>      <tr><td><?status_indicator()?>**_(Stopped)_**. _(Configuration valid)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-        <td>**_(Start)_** _(will bring the array on-line)_.</td></tr>
+        <td>**_(Start)_** _(will bring the array online)_.</td></tr>
 <?      maintenance_mode();
         check_encryption();
         break;
@@ -762,24 +762,24 @@ window.onunload = function(){
         if ($action[0] == "recon"):
           $resync = resync($action[1]);
 ?>        <tr><td><?status_indicator()?>**_(Stopped)_**. _(Configuration valid)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**<?=_('Start')?>** <?=_("will bring the array on-line and start **$resync**")?>.</td></tr>
+          <td>**<?=_('Start')?>** <?=_("will bring the array online and start **$resync**")?>.</td></tr>
 <?      elseif ($action[0] == "clear"):?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(New data disk(s) detected)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**_(Start)_** _(will bring the array on-line and start **Disk-Clear** of new data disk(s))_.</td></tr>
+          <td>**_(Start)_** _(will bring the array online and start **Disk-Clear** of new data disk(s))_.</td></tr>
 <?      elseif (_var($var,'sbClean') != "yes" && $action[0] == "check" && count($action) > 1):?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Unclean shutdown detected)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**_(Start)_** _(will bring the array on-line and start **Parity-Check**)_.
+          <td>**_(Start)_** _(will bring the array online and start **Parity-Check**)_.
           <br><input type="checkbox" name="optionCorrect" value="correct" checked><small>_(Write corrections to parity)_</small></td></tr>
 <?      elseif (_var($var,'sbClean') != "yes" && $action[0] == "check"):?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Unclean shutdown detected)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**_(Start)_** _(will bring the array on-line)_.</td></tr>
+          <td>**_(Start)_** _(will bring the array online)_.</td></tr>
 <?      elseif (missing_cache()):?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Missing pool disk)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)" disabled></td>
-          <td>**_(Start)_** _(will remove the missing pool disk and then bring the array on-line)_.
+          <td>**_(Start)_** _(will remove the missing pool disk and then bring the array online)_.
           <br><input type="checkbox" name="confirmStart" value="OFF" onclick="$('#cmdStart').prop('disabled',!arrayOps.confirmStart.checked)"><small>_(Yes, I want to do this)_</small></td></tr>
 <?      else:?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Configuration valid)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**_(Start)_** _(will bring the array on-line)_.</td></tr>
+          <td>**_(Start)_** _(will bring the array online)_.</td></tr>
 <?      endif;
         maintenance_mode();
         check_encryption();
@@ -787,11 +787,11 @@ window.onunload = function(){
       case "NEW_ARRAY":
         if (strpos(_var($disks['parity'],'status'),"DISK_NP") === 0 && strpos(_var($disks['parity2'],'status'),"DISK_NP") === 0):?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Configuration valid)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**_(Start)_** _(will record all disk information and bring the array on-line)_.
+          <td>**_(Start)_** _(will record all disk information and bring the array online)_.
           <br>_(The array will be immediately available, but **unprotected** since *parity* has not been assigned)_.</td></tr>
 <?      else:?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Configuration valid)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this,true)"></td>
-          <td>**_(Start)_** _(will record all disk information, bring the array on-line, and start Parity-Sync)_.
+          <td>**_(Start)_** _(will record all disk information, bring the array online, and start Parity-Sync)_.
           <br>_(The array will be immediately available, but **unprotected** until Parity-Sync completes)_.
           <br><input type="checkbox" name="md_invalidslot" value="99">_(Parity is already valid)_.</td></tr>
 <?      endif;
@@ -800,7 +800,7 @@ window.onunload = function(){
         break;
       case "DISABLE_DISK":?>
         <tr><td><?status_indicator()?>**_(Stopped)_**. _(Missing disk)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)" disabled></td>
-        <td>**_(Start)_** _(will disable the missing disk and then bring the array on-line. Install a replacement disk as soon as possible)_.
+        <td>**_(Start)_** _(will disable the missing disk and then bring the array online. Install a replacement disk as soon as possible)_.
         <br><input type="checkbox" name="confirmStart" value="OFF" onclick="$('#cmdStart').prop('disabled',!arrayOps.confirmStart.checked)"><small>_(Yes, I want to do this)_</small></td></tr>
 <?      maintenance_mode();
         check_encryption();
@@ -814,7 +814,7 @@ window.onunload = function(){
       case "SWAP_DSBL":
         if (_var($var,'fsCopyPrcnt') == "100"):?>
           <tr><td><?status_indicator()?>**_(Stopped)_**. _(Upgrading disk/swapping parity)_.</td><td><input type="button" id="cmdStart" value="_(Start)_" onclick="prepareInput(this.form,this)"></td>
-          <td>**_(Start)_** _(will expand the file system of the data disk (if possible); then bring the array on-line and start Data-Rebuild)_.</td></tr>
+          <td>**_(Start)_** _(will expand the file system of the data disk (if possible); then bring the array online and start Data-Rebuild)_.</td></tr>
 <?        maintenance_mode();
           check_encryption();
         else:?>

--- a/emhttp/plugins/dynamix/include/Helpers.php
+++ b/emhttp/plugins/dynamix/include/Helpers.php
@@ -154,7 +154,7 @@ function my_usage() {
     $used = $arraysize ? 100-round(100*$arrayfree/$arraysize) : 0;
     echo "<div class='usage-bar'><span style='width:{$used}%' class='".usage_color($display,$used,false)."'>{$used}%</span></div>";
   } else {
-    echo "<div class='usage-bar'><span style='text-align:center'>".($var['fsState']=='Started'?'Maintenance':'offline')."</span></div>";
+    echo "<div class='usage-bar'><span style='text-align:center'>".($var['fsState']=='Started'?'Maintenance':'off-line')."</span></div>";
   }
 }
 

--- a/emhttp/plugins/dynamix/include/Helpers.php
+++ b/emhttp/plugins/dynamix/include/Helpers.php
@@ -154,7 +154,7 @@ function my_usage() {
     $used = $arraysize ? 100-round(100*$arrayfree/$arraysize) : 0;
     echo "<div class='usage-bar'><span style='width:{$used}%' class='".usage_color($display,$used,false)."'>{$used}%</span></div>";
   } else {
-    echo "<div class='usage-bar'><span style='text-align:center'>".($var['fsState']=='Started'?'Maintenance':'off-line')."</span></div>";
+    echo "<div class='usage-bar'><span style='text-align:center'>".($var['fsState']=='Started'?'Maintenance':'offline')."</span></div>";
   }
 }
 

--- a/emhttp/plugins/dynamix/nchan/update_2
+++ b/emhttp/plugins/dynamix/nchan/update_2
@@ -172,7 +172,7 @@ function yellow_text($disk) {
 function device_status(&$disk, &$error, &$warning) {
   global $var;
   if (_var($disk,'type')!='Extra' && _var($var,'fsState')=='Stopped') {
-    $color = 'green'; $text = 'off-line';
+    $color = 'green'; $text = 'offline';
   } else switch (_var($disk,'color')) {
     case 'green-on'    : $color = 'green';  $text = 'active';     break;
     case 'green-blink' : $color = 'grey';   $text = 'standby';    break;

--- a/emhttp/plugins/dynamix/nchan/update_2
+++ b/emhttp/plugins/dynamix/nchan/update_2
@@ -172,7 +172,7 @@ function yellow_text($disk) {
 function device_status(&$disk, &$error, &$warning) {
   global $var;
   if (_var($disk,'type')!='Extra' && _var($var,'fsState')=='Stopped') {
-    $color = 'green'; $text = 'offline';
+    $color = 'green'; $text = 'off-line';
   } else switch (_var($disk,'color')) {
     case 'green-on'    : $color = 'green';  $text = 'active';     break;
     case 'green-blink' : $color = 'grey';   $text = 'standby';    break;


### PR DESCRIPTION
## What changed
- replace `off-line` with `offline` in the array stop helper text
- replace `off-line` with `offline` in the offline usage-bar fallback
- replace `off-line` with `offline` in the stopped-array device status label
- replace `on-line` with `online` in the array start helper text across the stopped-array flows

## Why
A handful of older UI strings were still using hyphenated `off-line` and `on-line` spellings, which made the copy look inconsistent and dated next to the rest of the product.

## Impact
Users will now see normalized `offline` and `online` wording in the affected array status and action helper text.

## Root cause
These older status strings had not been normalized when the rest of the interface copy moved to `offline` and `online`.

## Validation
- `php -l emhttp/plugins/dynamix/ArrayOperation.page`
- `php -l emhttp/plugins/dynamix/include/Helpers.php`
- `php -l emhttp/plugins/dynamix/nchan/update_2`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized status labels across the UI: changed "off-line" → "offline" and "on-line" → "online" for disk and filesystem states, confirmation messages, and start/recovery flows to ensure consistent terminology and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->