### PR TITLE
[7.2] Show Docker container MAC addresses

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
@@ -37,7 +37,7 @@ $cpus    = cpu_list();
                 <th><a id="resetsort" class="nohand" onclick="resetSorting()" title="_(Reset sorting)_"><i class="fa fa-th-list"></i></a>_(Application)_</th>
                 <th>_(Version)_</th>
                 <th>_(Network)_</th>
-                <th>_(Container IP)_</th>
+                <th>_(Container IP)_ <span class="advanced">/ _(MAC)_</span></th>
                 <th>_(Container Port)_</th>
                 <th>_(LAN IP:Port)_</th>
                 <th>_(Volume Mappings)_ <small>(_(App to Host)_)</small></th>
@@ -46,7 +46,7 @@ $cpus    = cpu_list();
                 <th class="five">_(Uptime)_</th>
             </tr>
         </thead>
-        <tbody id="docker_list" class="js-fill-available-height"><tr><td colspan='9'></td></tr></tbody>
+        <tbody id="docker_list" class="js-fill-available-height"><tr><td colspan='10'></td></tr></tbody>
     </table>
 </div>
 

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -1016,15 +1016,23 @@ class DockerClient {
 				$ports = &$info['Config']['ExposedPorts'];
 			}
 			foreach($ct['NetworkSettings']['Networks'] as $netName => $netVals) {
+				$networkDetails = $info['NetworkSettings']['Networks'][$netName] ?? $netVals;
 				$i = $c['NetworkMode']=='host' ? $host : $netVals['IPAddress'];
-				$c['Networks'][$netName] = [ 'IPAddress' => $i ];
+				$c['Networks'][$netName] = [
+					'IPAddress' => $i,
+					'MacAddress' => $networkDetails['MacAddress'] ?? ''
+				];
 				if ( isset($driver[$netName]) && ($driver[$netName]=='ipvlan' || $driver[$netName]=='macvlan') ) {
 					if (!isset($c['Ports']['vlan'])) $c['Ports']['vlan'] = [];
 					$c['Ports']['vlan']["$i"] = $i;
 				}
 			}
+			$networkDetails = $info['NetworkSettings']['Networks'][$c['NetworkMode']] ?? $ct['NetworkSettings']['Networks'][$c['NetworkMode']] ?? [];
 			$ip = $c['NetworkMode']=='host' ? $host : $ct['NetworkSettings']['Networks'][$c['NetworkMode']]['IPAddress'] ?? null;
-			$c['Networks'][$c['NetworkMode']] = [ 'IPAddress' => $ip ];
+			$c['Networks'][$c['NetworkMode']] = [
+				'IPAddress' => $ip,
+				'MacAddress' => $networkDetails['MacAddress'] ?? ''
+			];
 			$ports = (isset($ports) && is_array($ports)) ? $ports : [];
 			foreach ($ports as $port => $value) {
 				if (!isset($info['HostConfig']['PortBindings'][$port])) {

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -28,7 +28,7 @@ $user_prefs      = $dockerManPaths['user-prefs'];
 $autostart_file  = $dockerManPaths['autostart-file'];
 
 if (!$containers && !$images) {
-  echo "<tr><td colspan='7' style='text-align:center;padding-top:12px'>"._('No Docker containers installed')."</td></tr>";
+  echo "<tr><td colspan='10' style='text-align:center;padding-top:12px'>"._('No Docker containers installed')."</td></tr>";
   return;
 }
 
@@ -154,7 +154,9 @@ foreach ($containers as $ct) {
   }
   foreach($ct['Networks'] as $netName => $netVals) {
     $networks[] = $netName;
-    $network_ips[] = $running ? $netVals['IPAddress'] : null;
+    $network_ip = $running ? htmlspecialchars((string)$netVals['IPAddress']) : '';
+    $network_mac = $running ? htmlspecialchars((string)($netVals['MacAddress'] ?? '')) : '';
+    $network_ips[] = $network_mac ? "$network_ip<span class='advanced'><br>$network_mac</span>" : $network_ip;
     if (isset($ct['Networks']['host'])) {
       $ports_external[] = sprintf('%s', $netVals['IPAddress']);
       $ports_internal[0] = sprintf('%s', 'all');


### PR DESCRIPTION
## Summary
- Backports the Docker container MAC address display fix from master to 7.2.
- Passes endpoint MAC addresses through the Docker client/container data path and renders them with the existing container IP details.
- Keeps MAC display hidden when no running container endpoint value exists.

## Why
The 7.2 Docker container list did not expose assigned MAC addresses, making it hard to confirm fixed or runtime endpoint MACs from the UI.

## Validation
- `php -l emhttp/plugins/dynamix.docker.manager/include/DockerClient.php`
- `php -l emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php`
- `git diff --check origin/7.2..HEAD`