### PR TITLE
Update unsupported qemu models in XMLs

### DIFF
--- a/etc/rc.d/rc.libvirt
+++ b/etc/rc.d/rc.libvirt
@@ -174,6 +174,22 @@ version(){
   echo $1 | awk -F. '{printf("%03d%03d",$1,$2);}'
 }
 
+update_legacy_machine_types(){
+  local XML=$1
+  local MACHINE=
+  local PREFIX=
+  local MAJOR=
+
+  while IFS= read -r MACHINE; do
+    [[ $MACHINE =~ ^((pc-(i440fx|q35)))-([0-9]+)\.([0-9]+)$ ]] || continue
+    PREFIX=${BASH_REMATCH[1]}
+    MAJOR=${BASH_REMATCH[4]}
+    if (( MAJOR < 8 )); then
+      sed -ri "s/machine='$MACHINE'/machine='${PREFIX}-8.0'/g" "$XML"
+    fi
+  done < <(grep -oP "machine='pc-(?:i440fx|q35)-[0-9]+\.[0-9]+'" "$XML" | grep -oP "pc-(?:i440fx|q35)-[0-9]+\.[0-9]+" | sort -u)
+}
+
 libvirtd_start(){
   log "Starting $DAEMON..."
   if ! mountpoint /etc/libvirt &>/dev/null; then
@@ -188,6 +204,7 @@ libvirtd_start(){
   # update interface section((s) of VM configuration files
   for XML in /etc/libvirt/qemu/*.xml; do
     [[ -f "$XML" ]] || continue
+    update_legacy_machine_types "$XML"
     if grep -qm1 "<vendor_id='none'/>" "$XML"; then
       # convert libvirt 1.3.1 w/ eric's hyperv vendor id patch to how libvirt does it in libvirt 1.3.3+
       sed -ri "s/<vendor id='none'\/>/<vendor_id state='on' value='none'\/>/g" "$XML"

--- a/etc/rc.d/rc.libvirt
+++ b/etc/rc.d/rc.libvirt
@@ -186,7 +186,7 @@ update_legacy_machine_types(){
     MAJOR=${BASH_REMATCH[4]}
     if (( MAJOR < 8 )); then
       local ESC_PREFIX=${PREFIX//./\\.}
-      sed -ri "s/machine=([\"'])${ESC_PREFIX}-[0-9]+\.[0-9]+\1/machine=\1${ESC_PREFIX}-8.0\1/g" "$XML"
+      sed -ri "s/machine=([\"'])${ESC_PREFIX}-[0-7]\.[0-9]+\1/machine=\1${ESC_PREFIX}-8.0\1/g" "$XML"
     fi
   done < <(grep -oP "machine=[\"']pc-(?:i440fx|q35)-[0-9]+\.[0-9]+[\"']" "$XML" | grep -oP "pc-(?:i440fx|q35)-[0-9]+\.[0-9]+" | sort -u)
 }

--- a/etc/rc.d/rc.libvirt
+++ b/etc/rc.d/rc.libvirt
@@ -188,7 +188,7 @@ update_legacy_machine_types(){
       local ESC_PREFIX=${PREFIX//./\\.}
       sed -ri "s/machine=([\"'])${ESC_PREFIX}-[0-9]+\.[0-9]+\1/machine=\1${ESC_PREFIX}-8.0\1/g" "$XML"
     fi
-  done < <(grep -oP "machine='pc-(?:i440fx|q35)-[0-9]+\.[0-9]+'" "$XML" | grep -oP "pc-(?:i440fx|q35)-[0-9]+\.[0-9]+" | sort -u)
+  done < <(grep -oP "machine=[\"']pc-(?:i440fx|q35)-[0-9]+\.[0-9]+[\"']" "$XML" | grep -oP "pc-(?:i440fx|q35)-[0-9]+\.[0-9]+" | sort -u)
 }
 
 libvirtd_start(){

--- a/etc/rc.d/rc.libvirt
+++ b/etc/rc.d/rc.libvirt
@@ -185,7 +185,8 @@ update_legacy_machine_types(){
     PREFIX=${BASH_REMATCH[1]}
     MAJOR=${BASH_REMATCH[4]}
     if (( MAJOR < 8 )); then
-      sed -ri "s/machine='$MACHINE'/machine='${PREFIX}-8.0'/g" "$XML"
+      local ESC_PREFIX=${PREFIX//./\\.}
+      sed -ri "s/machine=([\"'])${ESC_PREFIX}-[0-9]+\.[0-9]+\1/machine=\1${ESC_PREFIX}-8.0\1/g" "$XML"
     fi
   done < <(grep -oP "machine='pc-(?:i440fx|q35)-[0-9]+\.[0-9]+'" "$XML" | grep -oP "pc-(?:i440fx|q35)-[0-9]+\.[0-9]+" | sort -u)
 }


### PR DESCRIPTION
This change is to update the minimum support q35 of i440fx model in the XML.

Support of older values are being dropped. This will update all values < 8.0 to 8.0

These are still supported but deprecated so will be removed in future updates. The current best level is 8.0

root@computenode:~# virsh capabilities | grep "deprecated='yes'>pc-"
      <machine maxCpus='288' deprecated='yes'>pc-q35-5.2</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-6.2</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-5.2</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-7.1</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-6.1</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-7.1</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-5.1</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-6.1</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-5.1</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-7.0</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-6.0</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-7.0</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-5.0</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-7.2</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-6.0</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-5.0</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-6.2</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-7.2</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-5.2</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-6.2</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-5.2</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-7.1</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-6.1</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-7.1</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-5.1</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-6.1</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-5.1</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-7.0</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-6.0</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-7.0</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-5.0</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-7.2</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-6.0</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-5.0</machine>
      <machine maxCpus='288' deprecated='yes'>pc-q35-6.2</machine>
      <machine maxCpus='255' deprecated='yes'>pc-i440fx-7.2</machine>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automatic startup step that scans installed libvirt VM configurations and normalizes legacy machine-type entries to the 8.0 format.
  * Runs during system boot and updates on-disk VM XML files so stored configurations consistently use the standardized 8.0 machine-type notation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->