### PR TITLE
Fix: Prevent docker installs / updates from blocking the GUI

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/AddContainer.page
+++ b/emhttp/plugins/dynamix.docker.manager/AddContainer.page
@@ -22,5 +22,10 @@ if (substr($_SERVER['REQUEST_URI'],0,7) != '/Docker') {
   $docker = "$docroot/languages/$locale/docker.dot";
   if (file_exists($docker)) $language = array_merge($language,unserialize(file_get_contents($docker)));
 }
+// Avoid blocking other browser tabs by releasing the PHP session lock
+// before running long-running container creation logic.
+if (session_status() === PHP_SESSION_ACTIVE) {
+  session_write_close();
+}
 eval('?>'.parse_file("$docroot/plugins/dynamix.docker.manager/include/CreateDocker.php"));
 ?>

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -69,9 +69,7 @@ function cpu_pinning() {
 ##########################
 
 // Simple UI blocker used by create/update operations so the user can't keep clicking around mid-install.
-function dockerUIBlockerScript($enable, $text = null) {
-  if ($text === null) $text = _('Working… please wait');
-  $textJS = addslashes($text);
+function dockerUIBlockerScript($enable) {
   if ($enable) {
     echo <<<HTML
 <script>
@@ -83,46 +81,32 @@ function dockerUIBlockerScript($enable, $text = null) {
     // Define helpers once.
     if (!window.parent) window.parent = window;
     if (!window.parent.dockerUIBlock) {
-      window.parent.dockerUIBlock = function (on, label) {
+      window.parent.dockerUIBlock = function (on) {
         try {
           var doc = (window.parent && window.parent.document) ? window.parent.document : document;
           if (!doc || !doc.body) return;
 
-          var styleId = 'dockerInstallBlockerStyle';
           var blockerId = 'dockerInstallBlocker';
+          var blockerClass = 'docker-install-blocker';
 
           if (!on) {
             var o = doc.getElementById(blockerId);
             if (o) o.remove();
-            var s = doc.getElementById(styleId);
-            if (s) s.remove();
             return;
-          }
-
-          if (!doc.getElementById(styleId)) {
-            var s2 = doc.createElement('style');
-            s2.id = styleId;
-            s2.textContent =
-              '#' + blockerId + '{position:fixed;inset:0;z-index:2147483647;background:rgba(0,0,0,.05);cursor:wait}' +
-              '#' + blockerId + ' .dibox{position:absolute;top:16px;right:16px;background:#fff;border:1px solid #ccc;border-radius:6px;' +
-              'padding:10px 12px;box-shadow:0 2px 12px rgba(0,0,0,.15);font:13px/1.3 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#111}';
-            doc.head && doc.head.appendChild(s2);
           }
 
           var o2 = doc.getElementById(blockerId);
           if (!o2) {
             o2 = doc.createElement('div');
             o2.id = blockerId;
-            o2.innerHTML = '<div class="dibox"></div>';
+            o2.className = blockerClass;
             doc.body.appendChild(o2);
           }
-          var box = o2.querySelector('.dibox');
-          if (box) box.textContent = (label || '');
         } catch (e) {}
       };
     }
 
-    window.parent.dockerUIBlock(true, '{$textJS}');
+    window.parent.dockerUIBlock(true);
   } catch (e) {}
 })();
 </script>
@@ -149,6 +133,7 @@ if (isset($_POST['contName'])) {
   // Get the command line
   [$cmd, $Name, $Repository] = xmlToCommand($postXML, $create_paths);
   readfile("$docroot/plugins/dynamix.docker.manager/log.htm");
+  echo '<link type="text/css" rel="stylesheet" href="'.autov("/plugins/dynamix.docker.manager/sheets/AddContainer.css",true).'">';
   if (!$dry_run) dockerUIBlockerScript(true);
   @flush();
   // Saving the generated configuration file.
@@ -254,6 +239,7 @@ if (isset($_GET['updateContainer'])){
   $echo = empty($_GET['mute']);
   if ($echo) {
     readfile("$docroot/plugins/dynamix.docker.manager/log.htm");
+    echo '<link type="text/css" rel="stylesheet" href="'.autov("/plugins/dynamix.docker.manager/sheets/AddContainer.css",true).'">';
     dockerUIBlockerScript(true);
     @flush();
   }

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -68,6 +68,79 @@ function cpu_pinning() {
 ##   CREATE CONTAINER   ##
 ##########################
 
+// Simple UI blocker used by create/update operations so the user can't keep clicking around mid-install.
+function dockerUIBlockerScript($enable, $text = null) {
+  if ($text === null) $text = _('Working… please wait');
+  $textJS = addslashes($text);
+  if ($enable) {
+    echo <<<HTML
+<script>
+(function () {
+  try {
+    var d = (window.parent && window.parent.document) ? window.parent.document : document;
+    if (!d || !d.body) return;
+
+    // Define helpers once.
+    if (!window.parent) window.parent = window;
+    if (!window.parent.dockerUIBlock) {
+      window.parent.dockerUIBlock = function (on, label) {
+        try {
+          var doc = (window.parent && window.parent.document) ? window.parent.document : document;
+          if (!doc || !doc.body) return;
+
+          var styleId = 'dockerInstallBlockerStyle';
+          var blockerId = 'dockerInstallBlocker';
+
+          if (!on) {
+            var o = doc.getElementById(blockerId);
+            if (o) o.remove();
+            var s = doc.getElementById(styleId);
+            if (s) s.remove();
+            return;
+          }
+
+          if (!doc.getElementById(styleId)) {
+            var s2 = doc.createElement('style');
+            s2.id = styleId;
+            s2.textContent =
+              '#' + blockerId + '{position:fixed;inset:0;z-index:2147483647;background:rgba(0,0,0,.05);cursor:wait}' +
+              '#' + blockerId + ' .dibox{position:absolute;top:16px;right:16px;background:#fff;border:1px solid #ccc;border-radius:6px;' +
+              'padding:10px 12px;box-shadow:0 2px 12px rgba(0,0,0,.15);font:13px/1.3 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#111}';
+            doc.head && doc.head.appendChild(s2);
+          }
+
+          var o2 = doc.getElementById(blockerId);
+          if (!o2) {
+            o2 = doc.createElement('div');
+            o2.id = blockerId;
+            o2.innerHTML = '<div class="dibox"></div>';
+            doc.body.appendChild(o2);
+          }
+          var box = o2.querySelector('.dibox');
+          if (box) box.textContent = (label || '');
+        } catch (e) {}
+      };
+    }
+
+    window.parent.dockerUIBlock(true, '{$textJS}');
+  } catch (e) {}
+})();
+</script>
+HTML;
+  } else {
+    echo <<<HTML
+<script>
+(function () {
+  try {
+    var w = window.parent || window;
+    if (w && w.dockerUIBlock) w.dockerUIBlock(false);
+  } catch (e) {}
+})();
+</script>
+HTML;
+  }
+}
+
 if (isset($_POST['contName'])) {
   $postXML = postToXML($_POST, true);
   $dry_run = isset($_POST['dryRun']) && $_POST['dryRun']=='true';
@@ -76,6 +149,7 @@ if (isset($_POST['contName'])) {
   // Get the command line
   [$cmd, $Name, $Repository] = xmlToCommand($postXML, $create_paths);
   readfile("$docroot/plugins/dynamix.docker.manager/log.htm");
+  if (!$dry_run) dockerUIBlockerScript(true);
   @flush();
   // Saving the generated configuration file.
   $userTmplDir = $dockerManPaths['templates-user'];
@@ -114,6 +188,7 @@ if (isset($_POST['contName'])) {
   if (!$DockerClient->doesImageExist($Repository)) {
     // Pull image
     if (!pullImage($Name, $Repository)) {
+      dockerUIBlockerScript(false);
       echo '<div style="text-align:center"><button type="button" onclick="done()">'._('Done').'</button></div><br>';
       goto END;
     }
@@ -166,6 +241,7 @@ if (isset($_POST['contName'])) {
   execCommand($cmd);
   if ($startContainer) addRoute($Name); // add route for remote WireGuard access
 
+  dockerUIBlockerScript(false);
   echo '<div style="text-align:center"><button type="button" onclick="openTerminal(\'docker\',\''.addslashes($Name).'\',\'.log\')">'._('View Container Log').'</button> <button type="button" onclick="done()">'._('Done').'</button></div><br>';
   goto END;
 }
@@ -178,6 +254,7 @@ if (isset($_GET['updateContainer'])){
   $echo = empty($_GET['mute']);
   if ($echo) {
     readfile("$docroot/plugins/dynamix.docker.manager/log.htm");
+    dockerUIBlockerScript(true);
     @flush();
   }
   foreach ($_GET['ct'] as $value) {
@@ -244,6 +321,9 @@ if (isset($_GET['updateContainer'])){
     $newImageID = $DockerClient->getImageID($Repository);
     // remove old orphan image since it's no longer used by this container
     if ($oldImageID && $oldImageID != $newImageID) removeImage($oldImageID, $echo);
+  }
+  if ($echo) {
+    dockerUIBlockerScript(false);
   }
   echo '<div style="text-align:center"><button type="button" onclick="window.parent.jQuery(\'#iframe-popup\').dialog(\'close\')">'._('Done').'</button></div><br>';
   goto END;

--- a/emhttp/plugins/dynamix.docker.manager/sheets/AddContainer.css
+++ b/emhttp/plugins/dynamix.docker.manager/sheets/AddContainer.css
@@ -1,0 +1,7 @@
+/* Only used for the UI blocker during long-running create/update operations */
+.docker-install-blocker {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483647;
+  cursor: wait;
+}


### PR DESCRIPTION
Allows other browser tabs to be able to access the WebGUI while an install / update of a container is in progress.   AddContainer.page handles that.   The code within CreateContainer.php preserves existing behaviour by blocking all clicks / navigations on the tab installing the container until after its finished, as navigating away from the page while the install is in progress does not abort the installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fullscreen blocking overlay ("Working… please wait") during container create/update flows to prevent accidental interaction while operations run.

* **Bug Fixes**
  * Released session locks earlier during create/update so concurrent browser tabs/requests remain responsive.
  * Overlay is now enabled/disabled appropriately for success, failure, and streaming update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->