### PR TITLE
fix(System Info): add chassis serial

### DIFF
--- a/emhttp/plugins/dynamix/scripts/system_information
+++ b/emhttp/plugins/dynamix/scripts/system_information
@@ -165,7 +165,7 @@ span.link{text-decoration:underline;cursor:pointer}
 <tr><td><?=_('Model')?>:</td><td><?=htmlspecialchars($model)?></td></tr>
 <tr><td><?=('M/B')?>:</td><td><?="{$board['Manufacturer']} {$board['Product Name']} {$board['Version']} {$board['Serial Number']}"?></td></tr>
 <?if ($chassis['Serial Number'] && preg_match('/\d/',$chassis['Serial Number'])):?>
-<tr><td><?=_('Chassis')?>:</td><td><?=$chassis['Serial Number']?></td></tr>
+<tr><td><?=_('Chassis')?>:</td><td><?=htmlspecialchars($chassis['Serial Number'], ENT_QUOTES, 'UTF-8')?></td></tr>
 <?endif;?>
 <tr><td><?=_('BIOS')?>:</td><td><?="{$bios['Vendor']} {$bios['Version']} {$bios['Release Date']}"?></td></tr>
 <tr><td><?=_('CPU')?>:</td><td><?="$cpumodel {$cpu['Current Speed']}"?></td></tr>

--- a/emhttp/plugins/dynamix/scripts/system_information
+++ b/emhttp/plugins/dynamix/scripts/system_information
@@ -28,6 +28,7 @@ function port_get_contents($port) {
 $var      = (array)@parse_ini_file('state/var.ini');
 $model    = _var($var,'SYS_MODEL',_('N/A'));
 $board    = dmidecode('Base Board Information',2,0);
+$chassis  = dmidecode('Chassis Information',3,0);
 $bios     = dmidecode('BIOS Information',0,0);
 $cpu      = dmidecode('Processor Information',4,0);
 $cpumodel = str_ireplace(["Processor","(C)","(R)","(TM)"],["","&#169;","&#174;","&#8482;"],exec("grep -Pom1 '^model name\s+:\s*\K.+' /proc/cpuinfo") ?: $cpu['Version']);
@@ -38,6 +39,7 @@ $board['Manufacturer']  = (empty($board['Manufacturer']))  ? _('Unknown') : $boa
 $board['Product Name']  = (empty($board['Product Name']))  ? "" : $board['Product Name'];
 $board['Version']       = (empty($board['Version']))       ? "" : _('Version')." ".$board['Version'];
 $board['Serial Number'] = (empty($board['Serial Number'])) ? "" : _('s/n')." ".$board['Serial Number'];
+$chassis['Serial Number'] = (empty($chassis['Serial Number'])) ? "" : _('s/n')." ".$chassis['Serial Number'];
 $bios['Vendor']         = (empty($bios['Vendor']))         ? "" : $bios['Vendor'];
 $bios['Version']        = (empty($bios['Version']))        ? "" : _('Version')." ".$bios['Version'];
 $bios['Release Date']   = (empty($bios['Release Date']))   ? "" : _('Dated')." ".$bios['Release Date'];
@@ -162,6 +164,9 @@ span.link{text-decoration:underline;cursor:pointer}
 <table class='info'>
 <tr><td><?=_('Model')?>:</td><td><?=htmlspecialchars($model)?></td></tr>
 <tr><td><?=('M/B')?>:</td><td><?="{$board['Manufacturer']} {$board['Product Name']} {$board['Version']} {$board['Serial Number']}"?></td></tr>
+<?if ($chassis['Serial Number'] && preg_match('/\d/',$chassis['Serial Number'])):?>
+<tr><td><?=_('Chassis')?>:</td><td><?=$chassis['Serial Number']?></td></tr>
+<?endif;?>
 <tr><td><?=_('BIOS')?>:</td><td><?="{$bios['Vendor']} {$bios['Version']} {$bios['Release Date']}"?></td></tr>
 <tr><td><?=_('CPU')?>:</td><td><?="$cpumodel {$cpu['Current Speed']}"?></td></tr>
 <tr><td><?=_('HVM')?>:</td><td><?=$hvm?></td></tr>


### PR DESCRIPTION
Add support to show chassis serial numbers. Serial number must have a least one number, this is to stop unset values showing like Default String.

<img width="3460" height="1940" alt="image" src="https://github.com/user-attachments/assets/568517e5-5972-4d83-855f-98a91b96e7c7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System information panel now shows chassis serial number when available. The serial is displayed with an "s/n" label and appears only if a valid serial (containing digits) is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->