### PR TITLE
Add checks on reserved names

### DIFF
--- a/emhttp/plugins/dynamix/CacheDevices.page
+++ b/emhttp/plugins/dynamix/CacheDevices.page
@@ -80,7 +80,7 @@ if (count($devs) > 1) {
 <script>
 function isReservedPoolName(poolname, reserved) {
   var name = (poolname || '').trim().toLowerCase();
-  var reservedPrefixes = ['mirror', 'raidz', 'raidz1', 'raidz2', 'raidz3', 'spare'];
+  var reservedPrefixes = ['mirror', 'raidz', 'draid', 'spare'];
 
   if (!name) return false;
 

--- a/emhttp/plugins/dynamix/CacheDevices.page
+++ b/emhttp/plugins/dynamix/CacheDevices.page
@@ -80,6 +80,7 @@ if (count($devs) > 1) {
 <script>
 function isReservedPoolName(poolname, reserved) {
   var name = (poolname || '').trim().toLowerCase();
+  var reservedPrefixes = ['mirror', 'raidz', 'raidz1', 'raidz2', 'raidz3', 'spare'];
 
   if (!name) return false;
 
@@ -89,7 +90,10 @@ function isReservedPoolName(poolname, reserved) {
     if (reservedName.endsWith('*')) {
       return name.startsWith(reservedName.slice(0, -1));
     }
-    return name === reservedName || name.startsWith(reservedName);
+    if (reservedPrefixes.includes(reservedName)) {
+      return name === reservedName || name.startsWith(reservedName);
+    }
+    return name === reservedName;
   });
 }
 

--- a/emhttp/plugins/dynamix/CacheDevices.page
+++ b/emhttp/plugins/dynamix/CacheDevices.page
@@ -78,13 +78,29 @@ if (count($devs) > 1) {
 }
 ?>
 <script>
+function isReservedPoolName(poolname, reserved) {
+  var name = (poolname || '').trim().toLowerCase();
+
+  if (!name) return false;
+
+  return reserved.some(function(entry) {
+    var reservedName = (entry || '').toLowerCase();
+    if (!reservedName) return false;
+    if (reservedName.endsWith('*')) {
+      return name.startsWith(reservedName.slice(0, -1));
+    }
+    return name === reservedName || name.startsWith(reservedName);
+  });
+}
+
 function validate(poolname) {
   var valid = /^[a-z]([a-z0-9~._-]*[a-z_-])*$/;
   var reserved = [<?=makeList(explode(',',_var($var,'reservedNames')))?>];
   var shares = [<?=makeList(array_map('sharename',glob('boot/config/shares/*.cfg',GLOB_NOSORT)))?>];
   var pools = [<?=makeList($pools)?>];
+  poolname = (poolname || '').trim();
   if (!poolname.trim()) return false;
-  if (reserved.includes(poolname)) {
+  if (isReservedPoolName(poolname, reserved)) {
     swal({title:"_(Invalid pool name)_",text:"_(Do not use reserved names)_",html:true,type:'error',confirmButtonText:"_(Ok)_"});
     return false;
   } else if (shares.includes(poolname)) {

--- a/emhttp/plugins/dynamix/DeviceInfo.page
+++ b/emhttp/plugins/dynamix/DeviceInfo.page
@@ -240,7 +240,7 @@ function setFloor() {
   }
   $('#shareFloor').val(isNaN(number) ? '' : number);
 }
-<?if (fsType('btrfs')):?>
+<?if (fsType('btrfs') && isPool($name) && !isSubpool($name)):?>
 function presetBTRFS(form,hour) {
   var mode = form.mode.value;
   form.min.disabled = mode==0;
@@ -1416,7 +1416,7 @@ _(btrfs check status)_:
 </form>
 <?endif;?>
 <?endif;?>
-<?if (fsType('zfs') && !isSubpool($name)):?>
+<?if (fsType('zfs') && isPool($name) && !isSubpool($name)):?>
 <?if (_var($disk,'fsStatus')=="Mounted"):?>
 <div id="poolsummary" class="title nocontrol">
   <span class="left">

--- a/emhttp/plugins/dynamix/DeviceInfo.page
+++ b/emhttp/plugins/dynamix/DeviceInfo.page
@@ -240,7 +240,7 @@ function setFloor() {
   }
   $('#shareFloor').val(isNaN(number) ? '' : number);
 }
-<?if (fsType('btrfs') && isPool($name) && !isSubpool($name)):?>
+<?if (fsType('btrfs')):?>
 function presetBTRFS(form,hour) {
   var mode = form.mode.value;
   form.min.disabled = mode==0;
@@ -1055,6 +1055,7 @@ _(Critical disk utilization threshold)_ (%):
 
 <?if (fsType('btrfs')):?>
 <?if (_var($disk,'fsStatus')=="Mounted"):?>
+<?if (isPool($name)):?>
 <div id="poolsummary" class="title nocontrol">
   <span class="left">
     <i class="title fa fa-hdd-o"></i> _(Pool Status)_
@@ -1079,6 +1080,7 @@ if (!empty($poolstatus['pools'][$poolName])) {
 ?>
 _(pool status)_:
 : <span class="<?=$statusClass?>"><?=$status?><?=$statusLink?></span>
+<?endif;?>
 
 </form>
 
@@ -1416,8 +1418,9 @@ _(btrfs check status)_:
 </form>
 <?endif;?>
 <?endif;?>
-<?if (fsType('zfs') && isPool($name) && !isSubpool($name)):?>
+<?if (fsType('zfs') && !isSubpool($name)):?>
 <?if (_var($disk,'fsStatus')=="Mounted"):?>
+<?if (isPool($name)):?>
 <div id="poolsummary" class="title nocontrol">
   <span class="left">
     <i class="title fa fa-info-circle"></i>_(Pool Status Summary)_
@@ -1442,6 +1445,7 @@ if (!empty($poolstatus['pools'][$poolName])) {
 ?>
 _(pool status)_:
 : <span class="<?=$statusClass?>"><?=$status?><?=$statusLink?></span>
+<?endif;?>
 
 </form>
 <?endif;?>

--- a/emhttp/plugins/dynamix/DeviceInfo.page
+++ b/emhttp/plugins/dynamix/DeviceInfo.page
@@ -197,7 +197,7 @@ String.prototype.celsius = function(){return Math.round((parseInt(this)-32)*5/9)
 
 function isReservedPoolName(poolname, reserved) {
   var name = (poolname || '').trim().toLowerCase();
-  var reservedPrefixes = ['mirror', 'raidz', 'raidz1', 'raidz2', 'raidz3', 'spare'];
+  var reservedPrefixes = ['mirror', 'raidz', 'draid', 'spare'];
 
   if (!name) return false;
 

--- a/emhttp/plugins/dynamix/DeviceInfo.page
+++ b/emhttp/plugins/dynamix/DeviceInfo.page
@@ -197,6 +197,7 @@ String.prototype.celsius = function(){return Math.round((parseInt(this)-32)*5/9)
 
 function isReservedPoolName(poolname, reserved) {
   var name = (poolname || '').trim().toLowerCase();
+  var reservedPrefixes = ['mirror', 'raidz', 'raidz1', 'raidz2', 'raidz3', 'spare'];
 
   if (!name) return false;
 
@@ -206,7 +207,10 @@ function isReservedPoolName(poolname, reserved) {
     if (reservedName.endsWith('*')) {
       return name.startsWith(reservedName.slice(0, -1));
     }
-    return name === reservedName || name.startsWith(reservedName);
+    if (reservedPrefixes.includes(reservedName)) {
+      return name === reservedName || name.startsWith(reservedName);
+    }
+    return name === reservedName;
   });
 }
 

--- a/emhttp/plugins/dynamix/DeviceInfo.page
+++ b/emhttp/plugins/dynamix/DeviceInfo.page
@@ -195,6 +195,21 @@ function is_upgraded_ZFS_pool($pool_name)
 
 String.prototype.celsius = function(){return Math.round((parseInt(this)-32)*5/9).toString();}
 
+function isReservedPoolName(poolname, reserved) {
+  var name = (poolname || '').trim().toLowerCase();
+
+  if (!name) return false;
+
+  return reserved.some(function(entry) {
+    var reservedName = (entry || '').toLowerCase();
+    if (!reservedName) return false;
+    if (reservedName.endsWith('*')) {
+      return name.startsWith(reservedName.slice(0, -1));
+    }
+    return name === reservedName || name.startsWith(reservedName);
+  });
+}
+
 function setFloor() {
   if ($('#shareFloor').length==0) return;
   const fsSize = {<?=fsSize()?>};
@@ -711,8 +726,9 @@ function validate(poolname) {
   var reserved = [<?=makeList(explode(',', _var($var, 'reservedNames')))?>];
   var shares = [<?=makeList(array_map('sharename', glob('boot/config/shares/*.cfg', GLOB_NOSORT)))?>];
   var pools = [<?=makeList($pools)?>];
+  poolname = (poolname || '').trim();
   if (!poolname.trim()) return false;
-  if (reserved.includes(poolname)) {
+  if (isReservedPoolName(poolname, reserved)) {
     swal({title:"_(Invalid pool name)_",text:"_(Do not use reserved names)_",type:'error',html:true,confirmButtonText:"_(Ok)_"});
     return false;
   } else if (shares.includes(poolname)) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pool-name validation: trims input, uses case-insensitive comparisons, and supports wildcard/prefix-style reserved entries (e.g., `foo*` blocks `foo`, `foobar`, etc.), including common reserved prefixes like mirror/raidz/spare.

* **New Features**
  * Added a centralized client-side reserved-name check.
  * Tightened UI rendering: BTRFS pool status and ZFS pool status summary now display only for top-level pools.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/webgui/pull/2632)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->