### PR TITLE
fix(help): correct FTP server default text

### DIFF
--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -1404,7 +1404,7 @@ stabling is enabled.
 :end
 
 :ftp_server_help:
-Enable or disable the FTP server daemon. By default the FTP server is enabled.
+Enable or disable the FTP server daemon. By default the FTP server is disabled.
 This setting is not saved, i.e. upon system reboot it will revert to its default setting.
 :end
 


### PR DESCRIPTION
## Summary
- Update FTP server help text to say the FTP server is disabled by default.
- Keep the change scoped to the English help text entry for `:ftp_server_help:`.

## Validation
- `rg -n "By default the FTP server is disabled" emhttp/languages/en_US/helptext.txt`
- Checked `root@unraid.local` read-only: `/etc/inetd.conf` has the FTP `vsftpd` line commented and port 21 has no listener.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated FTP server help text to clarify that the FTP server daemon is disabled by default and can be toggled on or off via settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/webgui/pull/2633)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->