### PR TITLE
fix(docker): use configured gateways for VLAN networks

### DIFF
--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -210,6 +210,51 @@ network(){
   docker network ls --filter driver="$1" --format='{{.Name}}' 2>/dev/null | grep -P "^[a-z]+$2(\$|\.)" | tr '\n' ' '
 }
 
+configured_gateway(){
+  local NETWORK=$1
+  local KEY=$2
+  local CFG=${NETWORK_CFG:-/boot/config/network.cfg}
+  [[ -s $CFG ]] || return
+
+  (
+    declare -A VLANID USE_DHCP IPADDR NETMASK GATEWAY METRIC USE_DHCP6 IPADDR6 NETMASK6 GATEWAY6 METRIC6 PRIVACY6 DESCRIPTION PROTOCOL
+    local BASE=${NETWORK%%.*}
+    local VLAN=
+    local IFACE ETH VALUE
+    local CANDIDATE
+    local -a CANDIDATES
+    local i j
+
+    [[ $NETWORK == *.* ]] && VLAN=${NETWORK#*.}
+    . <(fromdos <"$CFG")
+
+    for ((i=0; i<${SYSNICS:-1}; i++)); do
+      IFACE=${IFNAME[$i]:-eth$i}
+      ETH=${IFACE/#br/eth}
+      ETH=${ETH/#bond/eth}
+      CANDIDATES=("$IFACE" "$ETH" "${BRNAME[$i]}" "${BONDNAME[$i]}")
+      if [[ $i -eq 0 ]]; then
+        [[ ${BRIDGING:-} == yes ]] && CANDIDATES+=("br0")
+        [[ ${BONDING:-} == yes ]] && CANDIDATES+=("bond0")
+      fi
+      for CANDIDATE in "${CANDIDATES[@]}"; do
+        [[ -n $CANDIDATE && $CANDIDATE == "$BASE" ]] || continue
+        if [[ -z $VLAN ]]; then
+          [[ $KEY == GATEWAY6 ]] && VALUE=${GATEWAY6[$i]} || VALUE=${GATEWAY[$i]}
+          [[ -n $VALUE ]] && printf '%s\n' "$VALUE"
+          exit
+        fi
+        for ((j=1; j<${VLANS[$i]:-0}; j++)); do
+          [[ ${VLANID[$i,$j]} == "$VLAN" ]] || continue
+          [[ $KEY == GATEWAY6 ]] && VALUE=${GATEWAY6[$i,$j]} || VALUE=${GATEWAY[$i,$j]}
+          [[ -n $VALUE ]] && printf '%s\n' "$VALUE"
+          exit
+        done
+      done
+    done
+  )
+}
+
 # Is container running?
 container_running(){
   local CONTAINER
@@ -470,6 +515,7 @@ docker_network_start(){
       if [[ -n $IPV4 ]]; then
         SUBNET=$(ip -4 route show dev $NETWORK | sort | awk -v ORS=" " '$1 !~ /^default/ {print $1}' | sed 's/ $//')
         GATEWAY=$(ip -4 route show to default dev $NETWORK | awk '{print $3;exit}')
+        [[ -n $GATEWAY ]] || GATEWAY=$(configured_gateway "$NETWORK" GATEWAY)
         SERVER=${IPV4%/*}
         DHCP=${NETWORK/./_}
         DHCP=DOCKER_DHCP_${DHCP^^}
@@ -481,6 +527,7 @@ docker_network_start(){
       if [[ -n $IPV6 ]]; then
         SUBNET6=$(ip -6 route show dev $NETWORK | sort | awk -v ORS=" " '$1 !~ /^(default|fe80)/ {print $1}' | sed 's/ $//')
         GATEWAY6=$(ip -6 route show to default dev $NETWORK | awk '{print $3;exit}')
+        [[ -n $GATEWAY6 ]] || GATEWAY6=$(configured_gateway "$NETWORK" GATEWAY6)
       fi
     else
       # add user defined networks


### PR DESCRIPTION
## Summary
- Add a `configured_gateway` fallback for automatic Docker custom network creation.
- Use configured `GATEWAY` / `GATEWAY6` values from `/boot/config/network.cfg` when no interface-specific default route exists.
- Source the same network config shape used by `rc.inet1.conf`, with associative arrays declared before import, instead of parsing generated `network.ini` text.
- Preserve existing live-route behavior when a default route is present.

## Root Cause
`rc.docker` recreates automatic custom Docker networks from the live interface state. For VLANs and secondary interfaces, `ip route show to default dev <network>` can be empty even though Unraid has a configured gateway for that network.

When Docker creates a macvlan/ipvlan network without `--gateway`, Docker may select the first address in the subnet as the gateway. On common VLANs this can collide with the real router address, for example `192.168.10.1`, breaking containers that depend on DHCP or static IP reachability.

## Impact
This keeps VLAN and secondary-NIC Docker custom networks from losing their configured gateway during automatic network recreation, addressing reports where containers on VLANs stopped receiving DHCP or became unreachable after upgrading.

## Validation
- Ran `bash -n etc/rc.d/rc.docker`.
- Ran `git diff --check`.
- Exercised `configured_gateway` locally against synthetic `network.cfg` inputs for:
  - `eth0`, `br0`, `br0.10`, `eth0.30`, `br1.20`, `eth1.20`, `br2.40`, and `bond2.40` IPv4 gateway lookup
  - `br0.10` IPv6 gateway lookup
  - missing VLAN returns no fallback gateway
  - legacy scalar `GATEWAY` / `GATEWAY6` lookup for `br0` and `bond0`
  - CRLF `network.cfg` import through `fromdos`
  - sourcing a config containing other associative fields such as `IPADDR[0,1]` and `USE_DHCP[1,1]`
- Repeated helper tests on `root@unraid.local` using its real Bash/fromdos environment.
- On `root@unraid.local`, waited for Docker startup after the array was unlocked, then reproduced the missing-default-route case with temporary VLAN interfaces and verified Docker network creation used the configured gateway:
  - default route gateway was empty
  - configured gateway resolved to `192.0.2.254` and Docker inspect reported `gateway=192.0.2.254`
  - repeated across both Docker drivers with `ipvlan` and `macvlan`; each reported `gateway=192.0.3.254`
- Configured a real UniFi VLAN 30 on `root@unraid.local` as `br0.30` using DHCP with route metric `999`:
  - `br0.30` received `192.168.30.166/24` from gateway `192.168.30.1`
  - installed this PR version of `rc.docker` on the dev server and ran `/etc/rc.d/rc.docker restart`
  - Docker created `br0.30` as `macvlan` with parent `br0.30`, subnet `192.168.30.0/24`, gateway `192.168.30.1`, and aux address `server=192.168.30.166`
  - existing containers restarted and health checks settled with no unhealthy containers
- Validated the WebGUI/Dockerman template path for the exact bug scenario with `DOCKER_USER_NETWORKS="remove"`:
  - created a temporary saved template `my-codex-vlan30-webgui.xml` with `<Network>br0.30</Network>`, `<MyIP>192.168.30.250</MyIP>`, and fixed `<MyMAC>`
  - rebuilt it through `/usr/local/emhttp/plugins/dynamix.docker.manager/scripts/rebuild_container`, which uses the same template-to-command code as the Docker WebGUI
  - confirmed the container started on `br0.30` with IP `192.168.30.250` and MAC `02:42:c0:a8:1e:fa`, and could ping `192.168.30.1`
  - ran `/etc/rc.d/rc.docker restart`; `br0.30` network ID changed from `ace392...` to `b5f728...`, proving it was removed and recreated rather than preserved
  - confirmed the WebGUI-template container reconnected to recreated `br0.30` with the same IP/MAC and could still ping `192.168.30.1`
  - removed the temporary container/template/autostart entry afterward
- Repeated the real UniFi VLAN 30 WebGUI-template validation with Docker custom networks set to `ipvlan` (`DOCKER_NETWORK_TYPE="1"`):
  - `br0.30` was recreated as `ipvlan` with gateway `192.168.30.1`
  - fixed-MAC templates are not valid on ipvlan; Docker correctly rejected that with `ipvlan interfaces do not support custom mac address assignment`
  - using the valid ipvlan case (`<MyIP>192.168.30.250</MyIP>` and empty `<MyMAC/>`), the WebGUI-template container started on `br0.30` and could ping `192.168.30.1`
  - ran `/etc/rc.d/rc.docker restart`; `br0.30` was removed/recreated as `ipvlan`, `rc.docker` logged `connecting codex-vlan30-webgui-ipvlan-ip to network br0.30`, and the container reconnected with `192.168.30.250/24` and could still ping `192.168.30.1`
  - while switching this dev server from macvlan to ipvlan, stale macvlan host-access shim links had to be removed so they could be recreated as ipvlan; otherwise Docker reported `failed to create the ipvlan port: device or resource busy`. This appears independent of the gateway fallback change.
  - restored the server to its original macvlan Docker setting afterward and confirmed no unhealthy or starting containers remained
- Temporarily restored the pre-PR `rc.docker` on `root@unraid.local` to validate the negative path:
  - with a temporary VLAN interface, configured gateway `198.51.100.254`, and no live default route, the pre-PR logic produced no `--gateway` argument
  - Docker created the macvlan network with `Gateway=invalid IP`, reproducing the missing-gateway failure path
  - restored the PR `rc.docker` and reran the same setup; `configured_gateway` resolved `198.51.100.254`, Docker was created with `--gateway=198.51.100.254`, and inspect reported `gateway=198.51.100.254`
- Confirmed no temporary `codex-gw*` Docker networks or interfaces remained after validation.

