### PR TITLE
Fix title for bootloader config.

### DIFF
--- a/emhttp/plugins/dynamix/BootParameters.page
+++ b/emhttp/plugins/dynamix/BootParameters.page
@@ -2000,8 +2000,8 @@ function loadCurrentConfig() {
             const configLabel = document.getElementById('current-config-label');
             if (configLabel) {
                 configLabel.textContent = (bootloaderType === 'grub')
-                    ? 'Current GRUB Configuration:'
-                    : 'Current Syslinux Configuration:';
+                    ? _('Current GRUB Configuration:')
+                    : _('Current Syslinux Configuration:');
             }
 
             // Display current configuration (full syslinux.cfg file)

--- a/emhttp/plugins/dynamix/BootParameters.page
+++ b/emhttp/plugins/dynamix/BootParameters.page
@@ -337,7 +337,7 @@ $csrf_token = $var['csrf_token'] ?? '';
     <!-- Config Preview -->
     <div id="config-preview">
         <div class="config-header">
-            <strong>_(Current Syslinux Configuration)_:</strong>
+            <strong id="current-config-label">_(Current Bootloader Configuration)_:</strong>
             <div class="view-toggle-wrapper">
                 <input type="checkbox" id="syslinux-view-toggle" class="switch narrow">
             </div>
@@ -1995,6 +1995,14 @@ function loadCurrentConfig() {
 
             // Set bootloader type for rendering and validation
             bootloaderType = (config.bootloader_type || 'syslinux').toLowerCase();
+
+            // Update config header label to match active bootloader
+            const configLabel = document.getElementById('current-config-label');
+            if (configLabel) {
+                configLabel.textContent = (bootloaderType === 'grub')
+                    ? 'Current GRUB Configuration:'
+                    : 'Current Syslinux Configuration:';
+            }
 
             // Display current configuration (full syslinux.cfg file)
             if (config.full_config) {


### PR DESCRIPTION
Title for section was saying syslinx when it was grub.

<img width="1323" height="109" alt="image" src="https://github.com/user-attachments/assets/3bd18d58-9736-4fa9-965b-9e5ae6750a2b" />

This pr now fixes the bootloader name

<img width="1300" height="100" alt="image" src="https://github.com/user-attachments/assets/9909b493-18a1-4d5e-9615-263048305d7f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Boot configuration preview header now shows a generic "Current Bootloader Configuration" label and automatically updates to indicate either GRUB or Syslinux configuration based on the detected bootloader, ensuring the displayed preview matches your system.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/webgui/pull/2635)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->