### PR TITLE
Fix dropdown z-index on docker page when clicking on container icon

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
+++ b/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
@@ -52,7 +52,7 @@ function addDockerContainerContext(container, image, template, started, paused, 
   context.destroy('#'+id);
   context.attach('#'+id, opts);
   $('#dropdown-'+id).css('z-index', 10001)
-    .append('<li style="position:absolute;top:100%;left:0;width:1px;height:60px;pointer-events:none;list-style:none"></li>');
+    .append('<li class="docker-dropdown-spacer" aria-hidden="true" style="position:absolute;top:100%;left:0;width:1px;height:60px;pointer-events:none;list-style:none"></li>');
 }
 function addDockerImageContext(image, imageTag) {
   var opts = [];

--- a/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
+++ b/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
@@ -51,6 +51,8 @@ function addDockerContainerContext(container, image, template, started, paused, 
   }
   context.destroy('#'+id);
   context.attach('#'+id, opts);
+  $('#dropdown-'+id).css('z-index', 10001)
+    .append('<li style="position:absolute;top:100%;left:0;width:1px;height:60px;pointer-events:none;list-style:none"></li>');
 }
 function addDockerImageContext(image, imageTag) {
   var opts = [];


### PR DESCRIPTION
Fixes clicking on a docker container when page has many containers the dropdown menu will be behind the footer and even outside the visible area because the scrollbar doesnt extend as far. The fix will make sure that the dropdown will always be in front of the footer if expanded and will increase the height slightly so the dropdown doesnt overlay the footer. Tested on multiple machines across 7.2.6 and 7.3.0

Before: <img src="https://uploads.linear.app/591120cc-8b2a-4b49-8f6b-60f35b677eb6/109e86b6-fe58-47d7-bba9-43ddc032d3ba/9a44f4b1-2df6-4783-a74b-fdfa86cf4933?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzU5MTEyMGNjLThiMmEtNGI0OS04ZjZiLTYwZjM1YjY3N2ViNi8xMDllODZiNi1mZTU4LTQ3ZDctYmJhOS00M2RkYzAzMmQzYmEvOWE0NGY0YjEtMmRmNi00NzgzLWE3NGItZmRmYTg2Y2Y0OTMzIiwiaWF0IjoxNzc5Mjk3ODAxLCJleHAiOjE4MTA4NjgzNjF9.zwDbU1MKj-Mfux6XC7bhmdnQYx6A32oiiDymCdjlkqI " alt="grafik" width="470" data-linear-height="309" /> After: <img src="https://uploads.linear.app/591120cc-8b2a-4b49-8f6b-60f35b677eb6/7a7e5fcf-c620-4107-85a7-9e245af475ad/68b10bf7-3591-4c8b-8f6e-9c36a1de3a77?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzU5MTEyMGNjLThiMmEtNGI0OS04ZjZiLTYwZjM1YjY3N2ViNi83YTdlNWZjZi1jNjIwLTQxMDctODVhNy05ZTI0NWFmNDc1YWQvNjhiMTBiZjctMzU5MS00YzhiLThmNmUtOWMzNmExZGUzYTc3IiwiaWF0IjoxNzc5Mjk3ODAxLCJleHAiOjE4MTA4NjgzNjF9.zJDv75clVwI346idQR2rYh8wP_rz2ayVF0BOwslAPhM " alt="grafik" width="556" data-linear-height="350" />

Related to [OS-178](https://linear.app/lime-technology/issue/OS-178/backport-docker-dropdown-spacer-fix-for-731)