### PR TITLE
fix: [ENG-424] Backport Docker dropdown spacer fix to 7.2

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
+++ b/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
@@ -52,7 +52,7 @@ function addDockerContainerContext(container, image, template, started, paused, 
   context.destroy('#'+id);
   context.attach('#'+id, opts);
   $('#dropdown-'+id).css('z-index', 10001)
-    .append('<li style="position:absolute;top:100%;left:0;width:1px;height:60px;pointer-events:none;list-style:none"></li>');
+    .append('<li class="docker-dropdown-spacer" aria-hidden="true" style="position:absolute;top:100%;left:0;width:1px;height:60px;pointer-events:none;list-style:none"></li>');
 }
 function addDockerImageContext(image, imageTag) {
   var opts = [];

--- a/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
+++ b/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
@@ -51,6 +51,8 @@ function addDockerContainerContext(container, image, template, started, paused, 
   }
   context.destroy('#'+id);
   context.attach('#'+id, opts);
+  $('#dropdown-'+id).css('z-index', 10001)
+    .append('<li style="position:absolute;top:100%;left:0;width:1px;height:60px;pointer-events:none;list-style:none"></li>');
 }
 function addDockerImageContext(image, imageTag) {
   var opts = [];


### PR DESCRIPTION
## Summary
- Backports Joly0's Docker dropdown z-index/spacer fix to the `7.2` branch.
- Preserves Joly0 as the author on both cherry-picked commits from `Joly0:patch-1`.
- Adds the final spacer markup with `docker-dropdown-spacer` and `aria-hidden="true"`.

## Linear tracking
- 7.3 tracking ticket: ENG-424 https://linear.app/lime-technology/issue/ENG-424/backport-docker-dropdown-spacer-fix-for-731
- Note: this PR targets `7.2`; the Linear ticket is for 7.3-side tracking/cross-linking only because 7.2 is not managed in Linear yet.

## Credit
Original work by @Joly0 from https://github.com/Joly0/webgui/tree/patch-1.

Backported commits:
- d464bdae26a57293746d2c2fa1e09e1798d41732 - Fix dropdown z-index
- 6abd3fc4e1773334c6be7b8701241187d65760ca - Update dropdown spacer element in docker.js

## Validation
- `node --check emhttp/plugins/dynamix.docker.manager/javascript/docker.js`