### PR TITLE
fix(VM) context menu position for VMs.

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/javascript/vmmanager.js
+++ b/emhttp/plugins/dynamix.vm.manager/javascript/vmmanager.js
@@ -6,6 +6,56 @@ function displayWebUI(url) {
   window.open(url, '_blank').focus();
 }
 
+function clampVMContextDropdownToViewport(id) {
+  var $dropdown = $('#dropdown-'+id);
+  if (!$dropdown.length) return;
+
+  var scrollTop = $(window).scrollTop();
+  var viewportTop = scrollTop + 8;
+  var viewportBottom = scrollTop + window.innerHeight - 8;
+  var menuHeight = $dropdown.outerHeight();
+  var top = parseFloat($dropdown.css('top'));
+
+  if (isNaN(top)) {
+    top = $dropdown.offset().top || viewportTop;
+  }
+
+  if (top < viewportTop) {
+    top = viewportTop;
+  }
+  if (top + menuHeight > viewportBottom) {
+    top = Math.max(viewportTop, viewportBottom - menuHeight);
+  }
+
+  $dropdown.css('top', top);
+}
+
+function applyVMContextDropdownFix(id, selector) {
+  var $dropdown = $('#dropdown-'+id);
+  if (!$dropdown.length) return;
+
+  $dropdown.css({
+    'z-index': 10001,
+    'max-height': '',
+    'overflow-y': '',
+    'overflow-x': ''
+  });
+  if (!$dropdown.children('.docker-dropdown-spacer').length) {
+    $dropdown.append('<li class="docker-dropdown-spacer" aria-hidden="true" style="position:absolute;top:100%;left:0;width:1px;height:60px;pointer-events:none;list-style:none"></li>');
+  }
+
+  if (selector) {
+    $(document)
+      .off('click.vmcontextfix contextmenu.vmcontextfix', selector)
+      .on('click.vmcontextfix contextmenu.vmcontextfix', selector, function() {
+        setTimeout(function() {
+          applyVMContextDropdownFix(id);
+          clampVMContextDropdownToViewport(id);
+        }, 0);
+      });
+  }
+}
+
 function downloadFile(source) {
   var a = document.createElement('a');
   a.setAttribute('href',source);
@@ -125,7 +175,7 @@ function addVMContext(name, uuid, template, state, vmrcurl, vmrcprotocol, log, f
     }
   }
   if (rundivider) opts.push({divider:true});
-  context.settings({right:false,above:false});
+  context.settings({right:false,above:'auto'});
   if (state == "running") {
     opts.push({text:_("Stop"), icon:"fa-stop", action:function(e) {
       e.preventDefault();
@@ -251,7 +301,15 @@ function addVMContext(name, uuid, template, state, vmrcurl, vmrcprotocol, log, f
       });
     }});
   }
-  if (usage) { context.destroy('#vmusage-'+uuid); context.attach('#vmusage-'+uuid, opts); } else { context.destroy('#vm-'+uuid); context.attach('#vm-'+uuid, opts); }
+  if (usage) {
+    context.destroy('#vmusage-'+uuid);
+    context.attach('#vmusage-'+uuid, opts);
+    applyVMContextDropdownFix('vmusage-'+uuid, '#vmusage-'+uuid);
+  } else {
+    context.destroy('#vm-'+uuid);
+    context.attach('#vm-'+uuid, opts);
+    applyVMContextDropdownFix('vm-'+uuid, '#vm-'+uuid);
+  }
 }
 function addVMSnapContext(name, uuid, template, state, snapshotname, method){  
   var opts = [];
@@ -259,7 +317,7 @@ function addVMSnapContext(name, uuid, template, state, snapshotname, method){
   var x = path.indexOf("?");
   if (x!=-1) path = path.substring(0,x);
 
-  context.settings({right:false,above:false});
+  context.settings({right:false,above:'auto'});
 
 
     opts.push({text:_("Revert snapshot"), icon:"fa-fast-backward", action:function(e) {
@@ -287,6 +345,7 @@ function addVMSnapContext(name, uuid, template, state, snapshotname, method){
   }});
   context.destroy('#vmsnap-'+uuid);
   context.attach('#vmsnap-'+uuid, opts);
+  applyVMContextDropdownFix('vmsnap-'+uuid, '#vmsnap-'+uuid);
 }
 function startAll() {
   $('input[type=button]').prop('disabled',true);


### PR DESCRIPTION
When selecting a VM to get the context menu if the the icon was at the bottom of the page then the menu would not fully show on the screen with some of the content showing off the page.

This change moves the location of the context menu to be above if close to bottom.

<img width="476" height="653" alt="image" src="https://github.com/user-attachments/assets/3ddd1197-2933-4f64-9b66-ec8fec791e79" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context menu positioning for virtual machine and snapshot options to remain properly visible within the viewport during user interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/webgui/pull/2642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

OS-220