### PR TITLE
fix(System Devices) only show igpu SRIOV if plugin installed.

### DIFF
--- a/emhttp/plugins/dynamix/include/SriovHelpers.php
+++ b/emhttp/plugins/dynamix/include/SriovHelpers.php
@@ -58,10 +58,10 @@ function getSriovInfoJson(bool $includeVfDetails = true): string {
     foreach ($paths as $totalvfFile) {
         $devdir = dirname($totalvfFile);
         $pci = basename($devdir);
+        $numVfsFile = "$devdir/sriov_numvfs";
 
         $total_vfs = (int) @file_get_contents($totalvfFile);
-        $num_vfs   = (int) @file_get_contents("$devdir/sriov_numvfs");
-
+        $num_vfs   = (int) @file_get_contents($numVfsFile);
         // Driver/module detection
         $driver = $module = $vf_param = null;
         $driver_link = "$devdir/driver";
@@ -141,6 +141,7 @@ function getSriovInfoJson(bool $includeVfDetails = true): string {
     return json_encode($results, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 }
 
+// Rebind VF to original or vfio-pci driver.
 function rebindVfDriver($vf, $sriov, $target = 'original')
 {
     $res = ['pci'=>$vf,'success'=>false,'error'=>null,'details'=>[]];

--- a/emhttp/plugins/dynamix/include/SysDevs.php
+++ b/emhttp/plugins/dynamix/include/SysDevs.php
@@ -394,10 +394,10 @@ case 't1':
         }
         $isI915SriovPci = (substr($pciaddress, -7) === '00:02.0');
         $showI915SriovOptions = $i915SriovPluginInstalled && $isI915SriovPci;
+        $isAllowedSriovDevice = array_key_exists($pciaddress,$sriov)
+          && in_array(substr($sriov[$pciaddress]['class_id'],0,4),$allowedPCIClass);
 
-        if ($showI915SriovOptions
-          && array_key_exists($pciaddress,$sriov)
-          && in_array(substr($sriov[$pciaddress]['class_id'],0,4),$allowedPCIClass)) {
+        if ($isAllowedSriovDevice && (!$isI915SriovPci || $showI915SriovOptions)) {
           echo "<tr><td></td><td></td><td></td><td></td><td>";
           echo _("SR-IOV Available VFs").":{$sriov[$pciaddress]['total_vfs']}";
           $num_vfs= $sriov[$pciaddress]['num_vfs'];

--- a/emhttp/plugins/dynamix/include/SysDevs.php
+++ b/emhttp/plugins/dynamix/include/SysDevs.php
@@ -387,7 +387,17 @@ case 't1':
             break;
         }
 
-        if (array_key_exists($pciaddress,$sriov) && in_array(substr($sriov[$pciaddress]['class_id'],0,4),$allowedPCIClass)) {
+        static $i915SriovPluginInstalled = null;
+        if ($i915SriovPluginInstalled === null) {
+          $i915SriovPluginInstalled = is_file('/boot/config/plugins/i915-sriov.plg')
+            || is_file('/var/log/plugins/i915-sriov.plg');
+        }
+        $isI915SriovPci = (substr($pciaddress, -7) === '00:02.0');
+        $showI915SriovOptions = $i915SriovPluginInstalled && $isI915SriovPci;
+
+        if ($showI915SriovOptions
+          && array_key_exists($pciaddress,$sriov)
+          && in_array(substr($sriov[$pciaddress]['class_id'],0,4),$allowedPCIClass)) {
           echo "<tr><td></td><td></td><td></td><td></td><td>";
           echo _("SR-IOV Available VFs").":{$sriov[$pciaddress]['total_vfs']}";
           $num_vfs= $sriov[$pciaddress]['num_vfs'];


### PR DESCRIPTION
Only show available SR-IOV VFs for the igpu at 00:02.0 if the SR-IOV plugin is installed.

The VFs show currently but the VFs are not selectable without the plugin. This change hides the SR-IOV options if not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SR-IOV virtual function enumeration logic.
  * Restricted SR-IOV configuration options for Intel i915 devices to only display when the required plugin is installed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/webgui/pull/2643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

OS-195