### PR TITLE
Fix file upload truncation on Safari

### DIFF
--- a/emhttp/plugins/dynamix/Browse.page
+++ b/emhttp/plugins/dynamix/Browse.page
@@ -1247,6 +1247,7 @@ function stopUpload(file,error,errorType) {
     var message = "_(File is removed)_";
     if (errorType === 'timeout') message += "<br><br>_(Upload timed out. Please check your network connection and try again.)_";
     else if (errorType === 'network') message += "<br><br>_(Network error occurred. Please check your connection and try again.)_";
+    else if (errorType === 'read') message += "<br><br>_(Failed to read file. The file may have been removed or is inaccessible.)_";
     else if (errorType && errorType.indexOf('http') === 0) message += "<br><br>_(HTTP error: )_" + errorType.substring(5);
     setTimeout(function(){swal({title:"_(Upload Error)_",text:message,html:true,confirmButtonText:"_(Ok)_"});},200);
   }
@@ -1282,6 +1283,10 @@ function uploadFile(files,index,start,time,prefetchedBuffer) {
   xhr.timeout = Math.max(600000, slice / 1024 * 60); // ~1 minute per MB, minimum 10 minutes
 
   xhr.onload = function() {
+    if (cancel === 1) {
+      stopUpload(file.name, false);
+      return;
+    }
     if (xhr.status < 200 || xhr.status >= 300) {
       stopUpload(file.name, true, 'http:' + xhr.status);
       return;
@@ -1306,12 +1311,24 @@ function uploadFile(files,index,start,time,prefetchedBuffer) {
       var speed = autoscale(bytesTransferred / elapsedSeconds);
       var percent = Math.floor(bytesTransferred / total * 100);
       $('#dfm_uploadStatus').html("_(Uploading)_: <span class='dfm_percent'>"+percent+"%</span><span class='dfm_speed'>Speed: "+speed+"</span><span class='orange-text'> ["+(index+1)+'/'+files.length+']&nbsp;&nbsp;'+escapeHtml(file.name)+"</span>");
-      if (cancel === 1) return;
+      if (cancel === 1) {
+        stopUpload(file.name, false);
+        return;
+      }
       nextBufferPromise.then(function(nextBuffer) {
-        if (cancel === 1) return;
+        if (cancel === 1) {
+          stopUpload(file.name, false);
+          return;
+        }
         uploadFile(files,index,next,time,nextBuffer);
-      }).catch(function() { stopUpload(file.name, true, 'read'); });
+      }).catch(function() {
+        if (cancel !== 1) stopUpload(file.name, true, 'read');
+      });
     } else if (index < files.length-1) {
+      if (cancel === 1) {
+        stopUpload(file.name, false);
+        return;
+      }
       // Clean up temp file for completed upload before starting next file
       $.post('/webGui/include/Control.php',{mode:'stop',file:encodeURIComponent(file.name)});
       uploadFile(files,index+1,0,time);
@@ -1341,7 +1358,7 @@ function uploadFile(files,index,start,time,prefetchedBuffer) {
     stopUpload(file.name, true, 'timeout');
   };
 
-  // On Safari iOS, XHR with a file-backed Blob as request body sends successfully but never reaches
+  // On Safari/WebKit, XHR with a file-backed Blob as request body sends successfully but never reaches
   // readyState 4 (DONE), so onload never fires and the upload loop stalls after the first chunk.
   // Converting to ArrayBuffer first uses a different WebKit code path that behaves correctly.
   // To minimize the disk-read overhead, the next chunk is prefetched in parallel while this one sends.

--- a/emhttp/plugins/dynamix/Browse.page
+++ b/emhttp/plugins/dynamix/Browse.page
@@ -1262,12 +1262,16 @@ function downloadFile(source) {
   document.body.removeChild(a);
 }
 
-function uploadFile(files,index,start,time) {
+function uploadFile(files,index,start,time,prefetchedBuffer) {
   var file = files[index];
   var slice = 20971520; // 20MB chunks - no Base64 overhead, raw binary
   var next = start + slice;
   var blob = file.slice(start, next);
-  
+
+  // Start prefetching next chunk from disk immediately, in parallel with sending current chunk
+  var nextBlob = (next < file.size) ? file.slice(next, next + slice) : null;
+  var nextBufferPromise = nextBlob ? nextBlob.arrayBuffer() : null;
+
   var xhr = new XMLHttpRequest();
   currentXhr = xhr; // Store for abort capability
   var filePath = dir.replace(/\/+$/, '') + '/' + file.name;
@@ -1276,7 +1280,7 @@ function uploadFile(files,index,start,time) {
   xhr.setRequestHeader('Content-Type', 'application/octet-stream');
   xhr.setRequestHeader('X-CSRF-Token', '<?=$var['csrf_token']?>');
   xhr.timeout = Math.max(600000, slice / 1024 * 60); // ~1 minute per MB, minimum 10 minutes
-  
+
   xhr.onload = function() {
     if (xhr.status < 200 || xhr.status >= 300) {
       stopUpload(file.name, true, 'http:' + xhr.status);
@@ -1286,7 +1290,7 @@ function uploadFile(files,index,start,time) {
     if (reply == 'stop') {stopUpload(file.name); return;}
     if (reply.indexOf('error') === 0) {
       console.error('Upload error:', reply);
-      stopUpload(file.name,true); 
+      stopUpload(file.name,true);
       return;
     }
     if (next < file.size) {
@@ -1302,14 +1306,18 @@ function uploadFile(files,index,start,time) {
       var speed = autoscale(bytesTransferred / elapsedSeconds);
       var percent = Math.floor(bytesTransferred / total * 100);
       $('#dfm_uploadStatus').html("_(Uploading)_: <span class='dfm_percent'>"+percent+"%</span><span class='dfm_speed'>Speed: "+speed+"</span><span class='orange-text'> ["+(index+1)+'/'+files.length+']&nbsp;&nbsp;'+escapeHtml(file.name)+"</span>");
-      uploadFile(files,index,next,time);
+      if (cancel === 1) return;
+      nextBufferPromise.then(function(nextBuffer) {
+        if (cancel === 1) return;
+        uploadFile(files,index,next,time,nextBuffer);
+      }).catch(function() { stopUpload(file.name, true, 'read'); });
     } else if (index < files.length-1) {
       // Clean up temp file for completed upload before starting next file
       $.post('/webGui/include/Control.php',{mode:'stop',file:encodeURIComponent(file.name)});
       uploadFile(files,index+1,0,time);
     } else {stopUpload(file.name); return;}
   };
-  
+
   xhr.onabort = function() {
     // User cancelled upload - trigger deletion via cancel=1 parameter
     $.post('/webGui/include/Control.php', {
@@ -1322,18 +1330,27 @@ function uploadFile(files,index,start,time) {
       stopUpload(file.name, false);
     });
   };
-  
+
   xhr.onerror = function() {
     // Don't show error if it was a user cancel
     if (cancel === 1) return;
     stopUpload(file.name, true, 'network');
   };
-  
+
   xhr.ontimeout = function() {
     stopUpload(file.name, true, 'timeout');
   };
-  
-  xhr.send(blob);
+
+  // On Safari iOS, XHR with a file-backed Blob as request body sends successfully but never reaches
+  // readyState 4 (DONE), so onload never fires and the upload loop stalls after the first chunk.
+  // Converting to ArrayBuffer first uses a different WebKit code path that behaves correctly.
+  // To minimize the disk-read overhead, the next chunk is prefetched in parallel while this one sends.
+  (prefetchedBuffer ? Promise.resolve(prefetchedBuffer) : blob.arrayBuffer()).then(function(buffer) {
+    if (cancel === 1) return;
+    xhr.send(buffer);
+  }).catch(function() {
+    stopUpload(file.name, true, 'read');
+  });
 }
 
 var cancel = 0;


### PR DESCRIPTION
Fixes: https://product.unraid.net/p/7-3-0-file-manager-large-uploads-truncate-in-web-ui

**Problem**

On Safari, uploading files via the file manager resulted in only the first 20 MB being written. All subsequent chunks were silently dropped.

**Root cause**

When `xhr.send()` is called with a file-backed `Blob`, Safari sends the data correctly and receives the server's 200 response, but the XHR never transitions to `readyState 4` (DONE). As a result, `onload` never fires, the upload loop never advances to the next chunk, and the connection hangs indefinitely. This is a WebKit bug specific to file-backed Blobs as XHR request bodies.

**Fix**

Convert each file slice to an `ArrayBuffer` via `blob.arrayBuffer()` before passing it to `xhr.send()`. This uses a different WebKit code path that correctly reaches `readyState 4`.

To avoid a sequential disk-read bottleneck (read chunk N, then send chunk N, then read chunk N+1, ...), the next chunk's `arrayBuffer()` call is started immediately when the current chunk begins sending, so the disk read for chunk N+1 overlaps with the network transfer of chunk N.

**Testing**

- Chrome: 1 GB test file, ~70 MB/s, no regression
- Safari: upload completes correctly for files larger than 20 MB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload speed through optimized chunk processing
  * Fixed upload stalls on Safari iOS browsers
  * User-cancelled uploads no longer display error dialogs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/webgui/pull/2645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->