### PR TITLE
fix: treat IPv4LL DHCP assignments as incomplete during boot

### DIFF
--- a/etc/rc.d/rc.inet1
+++ b/etc/rc.d/rc.inet1
@@ -184,6 +184,24 @@ carrier(){
   return 1
 }
 
+# check for a non-IPv4LL address
+dhcp4_addr(){
+  ip -4 -o addr show dev $1 | awk '$4 !~ /^169[.]254[.]/ {found=1} END{exit !found}'
+}
+
+# wait for DHCP; return 2 when dhcpcd is running but only IPv4LL was assigned
+dhcp_wait(){
+  local n start=$SECONDS
+  run timeout 60 dhcpcd -w $DHCP_OPTIONS $1 || return 1
+  [[ $IP == ipv6 ]] && return 0
+  dhcp4_addr $1 && return 0
+  for ((n=SECONDS-start;n<60;n=SECONDS-start)); do
+    sleep 1
+    dhcp4_addr $1 && return 0
+  done
+  return 2
+}
+
 # create bond interface
 bond_up(){
   [[ -d /proc/net/bonding ]] || modprobe bonding mode=${BONDING_MODE[$i]} miimon=${BONDING_MIIMON[$i]}
@@ -385,13 +403,20 @@ ipaddr_up(){
     if carrier $IFACE; then
       # interface is UP
       log "interface $IFACE is UP, polling up to 60 sec for DHCP $IP server"
-      if ! run timeout 60 dhcpcd -w $DHCP_OPTIONS $IFACE; then
-        log "can't obtain IP address, continue polling in background on interface $IFACE"
+      dhcp_wait $IFACE
+      case $? in
+      0) ;;
+      2)
+        log "can't obtain non-link-local IP address, existing dhcpcd continues polling in background on interface $IFACE"
+        ;;
+      *)
+        log "can't obtain IP address, starting dhcpcd to continue polling in background on interface $IFACE"
         run dhcpcd -b $DHCP_OPTIONS $IFACE
-      fi
+        ;;
+      esac
     else
       # interface is DOWN
-      log "interface $IFACE is DOWN, polling DHCP $IP server in background"
+      log "interface $IFACE is DOWN, starting dhcpcd to poll DHCP $IP server in background"
       run dhcpcd -b $DHCP_OPTIONS $IFACE
     fi
   elif [[ $DHCP == no ]]; then

--- a/etc/rc.d/rc.inet1
+++ b/etc/rc.d/rc.inet1
@@ -195,9 +195,13 @@ dhcp_wait(){
   run timeout 60 dhcpcd -w $DHCP_OPTIONS $1 || return 1
   [[ $IP == ipv6 ]] && return 0
   dhcp4_addr $1 && return 0
+  log "DHCP returned with IPv4LL only on interface $1; waiting for non-link-local IPv4 address"
   for ((n=SECONDS-start;n<60;n=SECONDS-start)); do
     sleep 1
-    dhcp4_addr $1 && return 0
+    if dhcp4_addr $1; then
+      log "non-link-local IPv4 address ready on interface $1 after $((SECONDS-start))s"
+      return 0
+    fi
   done
   return 2
 }


### PR DESCRIPTION
## Summary
- Treat IPv4LL/link-local DHCP assignments as incomplete during boot.
- When IPv4 DHCP is enabled and the interface has carrier, rc.inet1 now waits up to 60 seconds for a non-link-local IPv4 address instead of continuing as soon as dhcpcd assigns a 169.254.x.x address.
- Clarify DHCP fallback logs to distinguish an existing dhcpcd process from starting a new background process.

## Validation
- Ran: bash -n etc/rc.d/rc.inet1
- Tested on test4 with the updated rc.inet1 override. During boot, dhcpcd assigned 169.254.150.83 at 14:25:51, then rc.inet1 continued waiting until dhcpcd leased 10.11.1.191 at 14:25:59.
- Confirmed current test4 state: br0 has 10.11.1.191/24, default route via 10.11.1.1, and nameserver 10.11.1.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DHCP handling to avoid unnecessary restarts when DHCP is already running and to better detect link-local-only IPv4 addresses.
  * Clarified log messages during interface bring-up/shutdown for more accurate diagnostics.

* **New Features**
  * Added IPv4-specific DHCP wait and address detection to reduce false negatives during interface initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/webgui/pull/2649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->