### PR TITLE
fix: create boot logs directory before syslog writes

### DIFF
--- a/emhttp/plugins/dynamix/scripts/rsyslog_config
+++ b/emhttp/plugins/dynamix/scripts/rsyslog_config
@@ -50,6 +50,7 @@ fi
 
 # mirror syslog to boot drive
 if [[ -n $syslog_flash ]]; then
+  mkdir -p /boot/logs
   if ! grep -q '^\$template flash,' $ETC; then
     sed -ri '/^#\$UDPServerRun [0-9]+.*$/a$template flash,"/boot/logs/syslog"' $ETC
   fi

--- a/etc/rc.d/rc.6
+++ b/etc/rc.d/rc.6
@@ -219,7 +219,7 @@ if [[ ! -f /boot/logs/syslog && -z $MIRROR && -z $COPY ]]; then
   SIZE=$(($(/bin/stat -c%s /var/log/syslog)*2))
   if [[ $AVAIL -ge $SIZE ]]; then
     log "Saving syslog to boot drive"
-    /bin/cp -f /var/log/syslog /boot/logs/syslog
+    /bin/mkdir -p /boot/logs && /bin/cp -f /var/log/syslog /boot/logs/syslog
   fi
 fi
 


### PR DESCRIPTION
## Summary
- create /boot/logs before rc.6 copies syslog to the boot device during shutdown
- create /boot/logs before enabling rsyslog mirror-to-flash output

## Why
Shutdown could emit `cp: cannot create regular file '/boot/logs/syslog': No such file or directory` when the boot logs directory did not already exist.

## Validation
- `bash -n etc/rc.d/rc.6`
- `bash -n emhttp/plugins/dynamix/scripts/rsyslog_config`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced system log handling by automatically creating required directories for boot logs during startup and shutdown procedures, preventing potential write failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/webgui/pull/2655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->