### PR TITLE
fix: Sort and widen VM network source dropdown

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -1229,8 +1229,9 @@ class Array2XML {
 		$arrValidNetworks['bridges'] = array_diff($arrBridges, $remove);
 
 		// This breaks VMSettings.page if libvirt is not running
-			if ($libvirt_running == "yes") {
+		if ($libvirt_running == "yes") {
 			$arrVirtual = $lv->libvirt_get_net_list($lv->get_connection());
+			sort($arrVirtual, SORT_NATURAL | SORT_FLAG_CASE);
 
 			if (($key = array_search('default', $arrVirtual)) !== false) {
 				unset($arrVirtual[$key]);

--- a/emhttp/plugins/dynamix.vm.manager/styles/edit.css
+++ b/emhttp/plugins/dynamix.vm.manager/styles/edit.css
@@ -272,6 +272,10 @@ select.narrow {
     min-width: 90px !important;
 }
 
+select.network_source {
+    width: 100%;
+}
+
 select.second {
     margin-left: 12px;
     max-width: 90px;

--- a/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -1576,7 +1576,7 @@ foreach ($arrConfig['nic'] as $i => $arrNic) {
 	<tr class="advanced">
 		<td>_(Network Source)_:</td>
 		<td>
-			<span class="width"><select name="nic[<?=$i?>][network]" class="narrow" onchange="updateMAC(<?=$i?>,this.value)">
+			<span class="width"><select name="nic[<?=$i?>][network]" class="network_source narrow" onchange="updateMAC(<?=$i?>,this.value)">
 			<?
 			foreach (array_keys($arrValidNetworks) as $key) {
 				echo mk_option("", $key, "- "._($key)." -", "disabled");
@@ -1649,7 +1649,7 @@ foreach ($arrConfig['nic'] as $i => $arrNic) {
 	<tr class="advanced">
 		<td>_(Network Source)_:</td>
 		<td>
-			<span class="width"><select name="nic[{{INDEX}}][network]" class="narrow" onchange="updateMAC(INDEX,this.value)">
+			<span class="width"><select name="nic[{{INDEX}}][network]" class="network_source narrow" onchange="updateMAC(INDEX,this.value)">
 			<?
 			foreach (array_keys($arrValidNetworks) as $key) {
 				echo mk_option("", $key, "- "._($key)." -", "disabled");


### PR DESCRIPTION
## Summary
- Sort libvirt VM network source entries naturally, while keeping `default` first
- Widen the VM Network Source select using the existing VM form width wrapper
- Apply the same class to existing NIC rows and newly added NIC template rows

## Testing
- `git diff --check`
- `git diff --cached --check`
- `php -l emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php`
- `php -l emhttp/plugins/dynamix.vm.manager/templates/Custom.form.php`
- Verified live on titan under `/usr/local/emhttp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Network source dropdown elements now span the full available width in the virtual machine editor, improving visibility and user interaction during network configuration

* **Bug Fixes**
  * Network lists are now consistently sorted with natural ordering to ensure predictable results and improved usability when selecting networks for virtual machines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->