### PR TITLE
fix(storage): for differences to main pool sizes

### DIFF
--- a/emhttp/plugins/dynamix/DashStats.page
+++ b/emhttp/plugins/dynamix/DashStats.page
@@ -82,7 +82,7 @@ foreach ($disks as $disk) {
     $name = _var($disk,'name');
     if (in_array($name,$pools)) {
       $cache_size[$name] = _var($disk,'fsSize',0);
-      $cache_used[$name] = _var($disk,'fsSize',0)-_var($disk,'fsFree',0);
+      $cache_used[$name] = _var($disk,'fsUsed',_var($disk,'fsSize',0)-_var($disk,'fsFree',0));
       $cache_type[$name] = _var($disk,'rotational') ? (_var($disk,'luksState') ? 'disk-encrypted' : 'disk') : 'nvme';
       $cache_rate[$name] = number_format(100*$cache_used[$name]/($cache_size[$name] ?: 1),1,$dot,'');
       if (empty($disks[$name]['devices'])) unset($pools[array_search($name,$pools)]);
@@ -1188,11 +1188,11 @@ switch ($themeHelper->getThemeName()) { // $themeHelper set in DefaultPageLayout
                                         <i class='icon-disk f32'></i>
                                         <div class='section'>
                                             <h3 class='tile-header-main'><?=($pool=='flash' ? _('Internal boot') : _(native($pool),3)).($started ? '' : ' ('._('stopped').')')?> <span class='tile-header-main' id="pool_status_<?=$i?>"> <?=_('Status')." :"?></span></h3>
-                                            <span>
+                                            <span id='pool_usage<?=$i?>'>
                                                 <?if ($started):?>
                                                     <?
-                                                    if ($pool == "flash") echo sprintf(_("%s used of %s (%s %%)"),my_scale($boot_used[$pool]*1024,$unit)." $unit",my_scale($boot_size[$pool]*1024,$unit,-1,-1)." $unit",$boot_rate[$pool]);
-                                                    else echo sprintf(_("%s used of %s (%s %%)"),my_scale($cache_used[$pool]*1024,$unit)." $unit",my_scale($cache_size[$pool]*1024,$unit,-1,-1)." $unit",$cache_rate[$pool])
+                                                    if ($pool == "flash") echo sprintf(_("Used: %s of %s (%s %%)"),my_scale($boot_used[$pool]*1024,$unit)." $unit",my_scale($boot_size[$pool]*1024,$unit,-1,-1)." $unit",$boot_rate[$pool]);
+                                                    else echo sprintf(_("Used: %s of %s (%s %%)"),my_scale($cache_used[$pool]*1024,$unit)." $unit",my_scale($cache_size[$pool]*1024,$unit,-1,-1)." $unit",$cache_rate[$pool])
                                                       ?>
                                                 <?endif;?>
                                           </span><br>
@@ -2654,6 +2654,7 @@ dashboard.on('message',function(msg,meta) {
         $('#pool_info'+i).parent().css({'display':info?'':'none'});
         $('#pool_info'+i).html(info);
         $('#pool_status_'+i).html(get.pool[i][5] || "");
+        if (get.pool[i][6] !== undefined) $('#pool_usage'+i).html(get.pool[i][6]);
         smartMenu('#pool_list'+i);
       }
     }

--- a/emhttp/plugins/dynamix/DashStats.page
+++ b/emhttp/plugins/dynamix/DashStats.page
@@ -81,7 +81,10 @@ foreach ($disks as $disk) {
   case 'Cache':
     $name = _var($disk,'name');
     if (in_array($name,$pools)) {
-      $cache_size[$name] = _var($disk,'fsSize',0);
+      $cache_fstype = str_replace('luks:','',_var($disk,'fsType',''));
+      $cache_size[$name] = ($cache_fstype=='btrfs' && is_numeric(_var($disk,'fsFree',null)) && is_numeric(_var($disk,'fsUsed',null)))
+                        ? _var($disk,'fsFree',0)+_var($disk,'fsUsed',0)
+                        : _var($disk,'fsSize',0);
       $cache_used[$name] = _var($disk,'fsUsed',_var($disk,'fsSize',0)-_var($disk,'fsFree',0));
       $cache_type[$name] = _var($disk,'rotational') ? (_var($disk,'luksState') ? 'disk-encrypted' : 'disk') : 'nvme';
       $cache_rate[$name] = number_format(100*$cache_used[$name]/($cache_size[$name] ?: 1),1,$dot,'');

--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -245,6 +245,9 @@ function get_pool_boot_metrics(?array $bootDisk): array
   $size = _var($bootDisk,'fsSize',null);
   $used = _var($bootDisk,'fsUsed',null);
   $free = _var($bootDisk,'fsFree',null);
+  $fsType = str_replace('luks:','',_var($bootDisk,'fsType',''));
+
+  if ($fsType=='btrfs' && is_numeric($used) && is_numeric($free)) $size = $used+$free;
 
   if ($size !== null || $used !== null || $free !== null) {
     return [
@@ -265,6 +268,8 @@ function get_boot_pool_metrics(array $bootDisks, string $bootPoolName, ?array $f
       $size = _var($disk,'fsSize',null);
       $used = _var($disk,'fsUsed',null);
       $free = _var($disk,'fsFree',null);
+      $fsType = str_replace('luks:','',_var($disk,'fsType',''));
+      if ($fsType=='btrfs' && is_numeric($used) && is_numeric($free)) $size = $used+$free;
       if ($size !== null || $used !== null || $free !== null) {
         return [
           'fsSize' => $size ?? 0,
@@ -298,6 +303,9 @@ function get_pool_data_metrics(?array $poolDisk, string $poolName='', array $dis
   $size = _var($metricsDisk,'fsSize',0);
   $used = _var($metricsDisk,'fsUsed',0);
   $free = _var($metricsDisk,'fsFree',0);
+  $fsType = str_replace('luks:','',_var($metricsDisk,'fsType',''));
+
+  if ($fsType=='btrfs' && is_numeric($used) && is_numeric($free)) $size = $used+$free;
 
   return [
     'fsSize' => $size,
@@ -657,24 +665,33 @@ function vfs_type(&$disk,$online = false) {
   return $luks.str_replace('luks:','',$fsType);
 }
 
+function effective_fs_size(&$disk) {
+  $size = _var($disk,'fsSize',0);
+  $used = _var($disk,'fsUsed',null);
+  $free = _var($disk,'fsFree',null);
+  $fsType = str_replace('luks:','',_var($disk,'fsType',''));
+  return ($fsType=='btrfs' && is_numeric($used) && is_numeric($free)) ? $used+$free : $size;
+}
+
 function fs_info(&$disk,$online = false) {
   global $display;
   $echo = [];
   if (empty(_var($disk,'fsStatus','')))
     return "<td colspan='4'></td>";
   if (_var($disk,'fsStatus')=='Mounted') {
+    $fsSize = effective_fs_size($disk);
     $echo[] = "<td>".vfs_type($disk,$online)."</td>";
-    $echo[] = "<td>".my_scale(_var($disk,'fsSize',0)*1024,$unit,-1)." $unit</td>";
+    $echo[] = "<td>".my_scale($fsSize*1024,$unit,-1)." $unit</td>";
     if ($display['text']%10==0) {
       $echo[] = "<td>".my_scale(_var($disk,'fsUsed',0)*1024,$unit)." $unit</td>";
     } else {
-      $used = _var($disk,'fsSize',0)>0 ? 100-round(100*_var($disk,'fsFree',0)/$disk['fsSize']) : 0;
+      $used = $fsSize>0 ? max(0,min(100,100*(1-_var($disk,'fsFree',0)/$fsSize))) : 0;
       $echo[] = "<td><div class='usage-disk'><span style='width:$used%' class='".usage_color($disk,$used,false)."'></span><span>".my_scale(_var($disk,'fsUsed',0)*1024,$unit)." $unit</span></div></td>";
     }
     if (_var($display,'text',0)<10 ? _var($display,'text',0)%10==0 : _var($display,'text',0)%10!=0) {
       $echo[] = "<td>".my_scale(_var($disk,'fsFree',0)*1024,$unit)." $unit</td>";
     } else {
-      $free = _var($disk,'fsSize',0)>0 ? round(100*_var($disk,'fsFree',0)/$disk['fsSize']) : 0;
+      $free = $fsSize>0 ? max(0,min(100,100*_var($disk,'fsFree',0)/$fsSize)) : 0;
       $echo[] = "<td><div class='usage-disk'><span style='width:$free%' class='".usage_color($disk,$free,true)."'></span><span>".my_scale(_var($disk,'fsFree',0)*1024,$unit)." $unit</span></div></td>";
     }
   } else {
@@ -803,7 +820,7 @@ function array_online(&$disk, $fstype='', $poolName='', $poolstatusData=[], $opt
   $sum['numWrites'] += _var($disk,'numWrites',0);
   $sum['numErrors'] += _var($disk,'numErrors',0); 
   if (isset($disk['fsFree'])) {
-    $sum['fsSize'] += _var($disk,'fsSize',0);
+    $sum['fsSize'] += effective_fs_size($disk);
     $sum['fsUsed'] += _var($disk,'fsUsed',0);
     $sum['fsFree'] += _var($disk,'fsFree',0);
   }
@@ -812,9 +829,6 @@ function array_online(&$disk, $fstype='', $poolName='', $poolstatusData=[], $opt
   case 'DISK_NP':
     if (in_array(_var($disk,'name'),$pools) || $fstype=='zfs') {
       $echo[] = "<td>".device_info($disk,true,$poolName,$poolstatusData,$options)."</td>";
-        $echo[] = "<td>".device_info($disk,true,$poolName,$poolstatusData,$options)."</td>";
-        $echo[] = "<td>".device_info($disk,true,$poolName,$poolstatusData,$options)."</td>";
-        $echo[] = "<td>".device_info($disk,true,$poolName,$poolstatusData,$options)."</td>";
       $echo[] = "<td><a class='static'><i class='icon-disk icon'></i><span></span></a><em>".($fstype=='zfs' ? _('Not present') : _('Not installed'))."</em></td>";
       $echo[] = "<td colspan='4'></td>";
       $echo[] = $showFsInfo ? fs_info($disk,true) : "<td colspan='4'></td>";
@@ -880,13 +894,13 @@ function show_totals($text,$array,$name) {
     if ($display['text']%10==0) {
       $echo[] = "<td>".my_scale($sum['fsUsed']*1024,$unit)." $unit</td>";
     } else {
-      $used = $sum['fsSize'] ? 100-round(100*$sum['fsFree']/$sum['fsSize']) : 0;
+      $used = $sum['fsSize'] ? max(0,min(100,100*(1-$sum['fsFree']/$sum['fsSize']))) : 0;
       $echo[] = "<td><div class='usage-disk'><span style='width:$used%' class='".usage_color($display,$used,false)."'></span><span>".my_scale($sum['fsUsed']*1024,$unit)." $unit</span></div></td>";
     }
     if ($display['text']<10 ? $display['text']%10==0 : $display['text']%10!=0) {
       $echo[] = "<td>".my_scale($sum['fsFree']*1024,$unit)." $unit</td>";
     } else {
-      $free = $sum['fsSize'] ? round(100*$sum['fsFree']/$sum['fsSize']) : 0;
+      $free = $sum['fsSize'] ? max(0,min(100,100*$sum['fsFree']/$sum['fsSize'])) : 0;
       $echo[] = "<td><div class='usage-disk'><span style='width:$free%' class='".usage_color($display,$free,true)."'></span><span>".my_scale($sum['fsFree']*1024,$unit)." $unit</span></div></td>";
     }
   } else {

--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -243,6 +243,7 @@ function get_pool_boot_metrics(?array $bootDisk): array
 {
   if (empty($bootDisk)) return [];
   $size = _var($bootDisk,'fsSize',null);
+  $rawSize = $size;
   $used = _var($bootDisk,'fsUsed',null);
   $free = _var($bootDisk,'fsFree',null);
   $fsDisk = [
@@ -253,7 +254,7 @@ function get_pool_boot_metrics(?array $bootDisk): array
   ];
   $size = effective_fs_size($fsDisk);
 
-  if ($size !== null || $used !== null || $free !== null) {
+  if ($rawSize !== null || $used !== null || $free !== null) {
     return [
       'fsSize' => $size ?? 0,
       'fsUsed' => $used ?? 0,
@@ -270,6 +271,7 @@ function get_boot_pool_metrics(array $bootDisks, string $bootPoolName, ?array $f
     foreach ($bootDisks as $disk) {
       if (prefix(_var($disk,'name','')) !== $bootPoolName) continue;
       $size = _var($disk,'fsSize',null);
+      $rawSize = $size;
       $used = _var($disk,'fsUsed',null);
       $free = _var($disk,'fsFree',null);
       $fsDisk = [
@@ -279,7 +281,7 @@ function get_boot_pool_metrics(array $bootDisks, string $bootPoolName, ?array $f
         'fsType' => _var($disk,'fsType',''),
       ];
       $size = effective_fs_size($fsDisk);
-      if ($size !== null || $used !== null || $free !== null) {
+      if ($rawSize !== null || $used !== null || $free !== null) {
         return [
           'fsSize' => $size ?? 0,
           'fsUsed' => $used ?? 0,

--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -245,9 +245,13 @@ function get_pool_boot_metrics(?array $bootDisk): array
   $size = _var($bootDisk,'fsSize',null);
   $used = _var($bootDisk,'fsUsed',null);
   $free = _var($bootDisk,'fsFree',null);
-  $fsType = str_replace('luks:','',_var($bootDisk,'fsType',''));
-
-  if ($fsType=='btrfs' && is_numeric($used) && is_numeric($free)) $size = $used+$free;
+  $fsDisk = [
+    'fsSize' => $size ?? 0,
+    'fsUsed' => $used ?? 0,
+    'fsFree' => $free ?? 0,
+    'fsType' => _var($bootDisk,'fsType',''),
+  ];
+  $size = effective_fs_size($fsDisk);
 
   if ($size !== null || $used !== null || $free !== null) {
     return [
@@ -268,8 +272,13 @@ function get_boot_pool_metrics(array $bootDisks, string $bootPoolName, ?array $f
       $size = _var($disk,'fsSize',null);
       $used = _var($disk,'fsUsed',null);
       $free = _var($disk,'fsFree',null);
-      $fsType = str_replace('luks:','',_var($disk,'fsType',''));
-      if ($fsType=='btrfs' && is_numeric($used) && is_numeric($free)) $size = $used+$free;
+      $fsDisk = [
+        'fsSize' => $size ?? 0,
+        'fsUsed' => $used ?? 0,
+        'fsFree' => $free ?? 0,
+        'fsType' => _var($disk,'fsType',''),
+      ];
+      $size = effective_fs_size($fsDisk);
       if ($size !== null || $used !== null || $free !== null) {
         return [
           'fsSize' => $size ?? 0,
@@ -300,12 +309,9 @@ function get_pool_data_metrics(?array $poolDisk, string $poolName='', array $dis
     if (!empty($firstPoolDisk)) $metricsDisk = $firstPoolDisk;
   }
   if (empty($metricsDisk)) return [];
-  $size = _var($metricsDisk,'fsSize',0);
+  $size = effective_fs_size($metricsDisk);
   $used = _var($metricsDisk,'fsUsed',0);
   $free = _var($metricsDisk,'fsFree',0);
-  $fsType = str_replace('luks:','',_var($metricsDisk,'fsType',''));
-
-  if ($fsType=='btrfs' && is_numeric($used) && is_numeric($free)) $size = $used+$free;
 
   return [
     'fsSize' => $size,

--- a/emhttp/plugins/dynamix/nchan/update_2
+++ b/emhttp/plugins/dynamix/nchan/update_2
@@ -242,9 +242,37 @@ function device_smart(&$disk, &$fail, &$smart) {
 }
 
 function device_usage(&$disk, &$full, &$high) {
-  global $display;
+  global $display,$disks;
   $text = $display['text'];
-  $used = (_var($disk,'type')!='Parity' && _var($disk,'type')!='Extra' && _var($disk,'fsStatus')=='Mounted') ? (_var($disk,'fsSize',0)>0 ? round((1-_var($disk,'fsFree',0)/$disk['fsSize'])*100) : 0).'%' : false;
+  $type = _var($disk,'type');
+  $status = _var($disk,'fsStatus');
+  $size = _var($disk,'fsSize',0);
+  $free = _var($disk,'fsFree',null);
+  $used_kib = null;
+
+  if ($type=='Cache') {
+    $name = _var($disk,'name');
+    $pool = prefix($name);
+    if ($name!=$pool) return $text%10==0 ? "-" : "<span class='load'>-</span><div class='usage-disk sys none'><span></span></div>";
+    $root = _var($disks,$pool,[]);
+    if (!empty($root)) {
+      $status = _var($root,'fsStatus',$status);
+      $size = _var($root,'fsSize',$size);
+      $free = _var($root,'fsFree',$free);
+      $used_kib = _var($root,'fsUsed',null);
+    }
+  }
+
+  if ($type!='Parity' && $type!='Extra' && $status=='Mounted') {
+    if ($type=='Cache' && is_numeric($used_kib) && $size>0) {
+      $pct = round(100*$used_kib/$size);
+    } else {
+      $pct = $size>0 && is_numeric($free) ? round((1-$free/$size)*100) : 0;
+    }
+    $used = $pct.'%';
+  } else {
+    $used = false;
+  }
   if ($used) {
     if ($text==2 || $text==21) {
       $load = substr($used,0,-1);
@@ -339,6 +367,18 @@ function print_error($error) {
   return sprintf(_('Finding **%s** error'.($error==1?'':'s')),$error?:'0');
 }
 
+function pool_usage($pool) {
+  global $disks,$display;
+  $disk = _var($disks,$pool,[]);
+  if (_var($disk,'fsStatus')!='Mounted') return '';
+  $size = _var($disk,'fsSize',0);
+  $free = _var($disk,'fsFree',0);
+  $used = _var($disk,'fsUsed',$size-$free);
+  $dot  = _var($display,'number','.,')[0];
+  $rate = number_format(100*$used/($size ?: 1),1,$dot,'');
+  return sprintf(_('Used: %s of %s (%s %%)'),my_scale($used*1024,$unit)." $unit",my_scale($size*1024,$unit,-1,-1)." $unit",$rate);
+}
+
 $pool_check_counter = 0;
 $poolstatus = [];
 
@@ -390,10 +430,10 @@ while (true) {
         $statusText = "<span title='"._('Check pool status')."'><i class='fa fa-warning fa-fw orange-text'></i> ".$statusText."</span>";
       }
       $poolType = _var($disks[$pool],'type') == 'Boot' ? 'Boot' : 'Cache';
-      $echo['pool'][$p++] = [array_group($poolType,$pool), $error+$warning, $red+$orange, $fail+$smart, $full+$high,$statusText];
+      $echo['pool'][$p++] = [array_group($poolType,$pool), $error+$warning, $red+$orange, $fail+$smart, $full+$high,$statusText,pool_usage($pool)];
     } else {
       $poolType = _var($disks[$pool],'type') == 'Boot' ? 'Boot' : 'Cache';
-      $echo['pool'][$p++] = [array_group($poolType,$pool), $error+$warning, $red+$orange, $fail+$smart, $full+$high,""];
+      $echo['pool'][$p++] = [array_group($poolType,$pool), $error+$warning, $red+$orange, $fail+$smart, $full+$high,"",pool_usage($pool)];
     }
   }
   //unassigned devices

--- a/emhttp/plugins/dynamix/nchan/update_2
+++ b/emhttp/plugins/dynamix/nchan/update_2
@@ -249,6 +249,7 @@ function device_usage(&$disk, &$full, &$high) {
   $size = _var($disk,'fsSize',0);
   $free = _var($disk,'fsFree',null);
   $used_kib = null;
+  $fs_type = '';
 
   if ($type=='Cache') {
     $name = _var($disk,'name');
@@ -260,6 +261,8 @@ function device_usage(&$disk, &$full, &$high) {
       $size = _var($root,'fsSize',$size);
       $free = _var($root,'fsFree',$free);
       $used_kib = _var($root,'fsUsed',null);
+      $fs_type = str_replace('luks:','',_var($root,'fsType',''));
+      if ($fs_type=='btrfs' && is_numeric($free) && is_numeric($used_kib)) $size = $free+$used_kib;
     }
   }
 
@@ -374,6 +377,8 @@ function pool_usage($pool) {
   $size = _var($disk,'fsSize',0);
   $free = _var($disk,'fsFree',0);
   $used = _var($disk,'fsUsed',$size-$free);
+  $fs_type = str_replace('luks:','',_var($disk,'fsType',''));
+  if ($fs_type=='btrfs' && is_numeric($free) && is_numeric($used)) $size = $free+$used;
   $dot  = _var($display,'number','.,')[0];
   $rate = number_format(100*$used/($size ?: 1),1,$dot,'');
   return sprintf(_('Used: %s of %s (%s %%)'),my_scale($used*1024,$unit)." $unit",my_scale($size*1024,$unit,-1,-1)." $unit",$rate);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cache and mounted-device calculations so free/used values and aggregate totals display accurately, including proper handling of Btrfs (and LUKS-wrapped Btrfs).
  * Fixed real-time dashboard updates so pool usage values refresh reliably in the UI.

* **New Features**
  * Added per-pool usage indicators and localized "Used … of … (%)" strings in live updates for clearer pool readouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->