### PR TITLE
fix(avahi): avoid restart on transient iface loss

### DIFF
--- a/emhttp/plugins/dynamix/NetworkExtra.page
+++ b/emhttp/plugins/dynamix/NetworkExtra.page
@@ -63,6 +63,8 @@ $(function(){
 <form markdown="1" name="network_extra" method="POST" action="/update.php" target="progressFrame" onsubmit="return prepareText(this)">
 <input type="hidden" name="#file" value="<?=$cfg?>">
 <input type="hidden" name="#command" value="/webGui/scripts/update_services">
+<input type="hidden" name="#arg[1]" value="1">
+<input type="hidden" name="#arg[2]" value="force">
 <input type="hidden" name="include_interfaces" value="">
 <input type="hidden" name="exclude_interfaces" value="">
 

--- a/emhttp/plugins/dynamix/scripts/reload_services
+++ b/emhttp/plugins/dynamix/scripts/reload_services
@@ -17,6 +17,10 @@ else
 fi
 
 for cmd in $SERVICES; do
-  /etc/rc.d/rc.$cmd update &>/dev/null
+  if [[ $cmd == avahidaemon && $1 == force ]]; then
+    /etc/rc.d/rc.$cmd update force &>/dev/null
+  else
+    /etc/rc.d/rc.$cmd update &>/dev/null
+  fi
 done
 exit 0

--- a/emhttp/plugins/dynamix/scripts/update_services
+++ b/emhttp/plugins/dynamix/scripts/update_services
@@ -22,7 +22,11 @@ if [[ -n $1 && ! $1 =~ ^[0-9]+$ ]]; then
 else
   DELAY=${1:-1}
 fi
+case "${2:-}" in
+  'force') MODE=force ;;
+  *) MODE= ;;
+esac
 
-echo "sleep $DELAY; /usr/local/emhttp/webGui/scripts/reload_services" | at -M now 2>/dev/null
+echo "sleep $DELAY; /usr/local/emhttp/webGui/scripts/reload_services $MODE" | at -M now 2>/dev/null
 log "queue new job $(queue), wait for ${DELAY}s"
 exit 0

--- a/etc/rc.d/rc.avahidaemon
+++ b/etc/rc.d/rc.avahidaemon
@@ -119,8 +119,28 @@ avahid_reload(){
   fi
 }
 
+bind_changed(){
+  local CURRENT=",$1," NEXT=",$2," IFACE
+  # A new active bind target needs a restart so avahi-daemon reads it.
+  for IFACE in ${2//,/ }; do
+    [[ $CURRENT == *",$IFACE,"* ]] || return 0
+  done
+  # Missing inactive targets are usually transient carrier/DHCP loss; keep
+  # Avahi running so it can notice the interface when it returns.
+  for IFACE in ${1//,/ }; do
+    [[ $NEXT == *",$IFACE,"* || -z $(show dev "$IFACE") ]] || return 0
+  done
+  # Shell convention: 1 means "no meaningful bind change" for this predicate.
+  return 1
+}
+
 avahid_update(){
-  if avahid_running && check && [[ "$(this allow-interfaces)" != "$BIND" ]]; then
+  local CURRENT
+  if avahid_running && check; then
+    CURRENT="$(this allow-interfaces)"
+    [[ "$CURRENT" != "$BIND" ]] || return 0
+    # Network hooks are often transient; explicit config applies pass "force".
+    [[ $1 == force ]] || bind_changed "$CURRENT" "$BIND" || return 0
     log "Updating $DAEMON..."
     avahid_restart # note we need restart here, not reload in order to update interfaces
   fi
@@ -149,7 +169,7 @@ case "$1" in
   avahid_reload
   ;;
 'update')
-  avahid_update
+  avahid_update "$2"
   ;;
 'status')
   avahid_status


### PR DESCRIPTION
## Summary

Prevent network-hook service reloads from restarting Avahi when an allowed interface is only temporarily unavailable, while preserving forced restarts for explicit Network Extra configuration changes.

## What Changed

- Added a compact bind-list check in `rc.avahidaemon` to distinguish meaningful runtime binding changes from transient interface loss.
- `update` skips restart when the only runtime difference is a previously allowed interface that is currently inactive.
- Network Extra settings applies now call `update_services 1 force` through `update.php` args.
- `update_services` whitelists and carries the optional `force` mode into the delayed `reload_services` job.
- `reload_services` passes `force` only to `rc.avahidaemon update`, leaving other service update calls unchanged.
- `rc.avahidaemon update force` preserves the old restart-on-bind-mismatch behavior for explicit user config applies.

## Why

Avahi already observes interface loss and recovery while it remains running. Restarting it during a temporary carrier/DHCP outage can start the daemon before any suitable interface is available, causing Avahi to exit and remain stopped.

The earlier heuristic alone was not sufficient because it could not distinguish transient interface loss from a user intentionally removing an interface in Network Extra while that interface was inactive. Passing `force` from the config-apply path makes that intent explicit.

## Relationship To Other PR

Alternative to #2661.

- This PR tries to prevent the early restart during transient interface loss.
- #2661 fixes recovery by starting Avahi if `update` finds it stopped.
- This PR is more complete prevention, but it touches more call-chain surface.

## Verification

- `bash -n etc/rc.d/rc.avahidaemon emhttp/plugins/dynamix/scripts/update_services emhttp/plugins/dynamix/scripts/reload_services`
- Manual shell harness for forced/unforced `bind_changed` cases:
  - skips restart for runtime transient `wlan0` loss
  - restarts for explicit config removal while `wlan0` is inactive
  - restarts for runtime active-interface removal
  - restarts for runtime active-interface addition
  - skips restart when the bind list is unchanged
- `git diff --check`

## Review Notes

- No UI behavior changed beyond passing command args with the existing `update.php` mechanism.
- The restart decision remains in `rc.avahidaemon`, which owns Avahi restart behavior.
- The queued mode is whitelisted to `force` before being embedded in the delayed service reload command.
- Residual risk: this is shell-script behavior without an existing repo test harness, so verification is syntax plus targeted decision-logic checks.
