### PR TITLE
fix(avahi): start stopped daemon on update

### DIFF
--- a/etc/rc.d/rc.avahidaemon
+++ b/etc/rc.d/rc.avahidaemon
@@ -120,9 +120,13 @@ avahid_reload(){
 }
 
 avahid_update(){
-  if avahid_running && check && [[ "$(this allow-interfaces)" != "$BIND" ]]; then
-    log "Updating $DAEMON..."
-    avahid_restart # note we need restart here, not reload in order to update interfaces
+  if check && [[ "$(this allow-interfaces)" != "$BIND" ]]; then
+    if avahid_running; then
+      log "Updating $DAEMON..."
+      avahid_restart # note we need restart here, not reload in order to update interfaces
+    else
+      avahid_start # handle case where avahi-daemon exited because no suitable interfaces
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary

Make `rc.avahidaemon update` recover Avahi when the daemon is stopped and the computed bind list differs from the current Avahi configuration.

## What Changed

- `avahid_update` still starts with the existing `check` and `allow-interfaces` comparison.
- If bindings changed and Avahi is running, it uses the existing restart path.
- If bindings changed and Avahi is stopped, it calls `avahid_start`.

## Why

If Avahi restarts while no suitable network interface is available, it can exit and remain stopped. In the observed failure, the early restart happened while the active interface list had shrunk; when networking later recovered, the computed bind list differed from the saved Avahi `allow-interfaces` value, but the old `update` path could not recover because it was guarded by `avahid_running`.

This alternate fix keeps the patch minimal and focuses on recovery: when a later service update sees the bind list needs to change, it can start Avahi instead of doing nothing.

## Relationship To Other PR

Alternative to #2660.

- This PR fixes recovery after Avahi is stopped and bindings need to be refreshed.
- #2660 tries to prevent the early restart during transient interface loss.
- This PR is smaller and lower-risk, but it does not prevent the initial failed restart.

## Verification

- `bash -n etc/rc.d/rc.avahidaemon`
- `git diff --check`

## Review Notes

- No UI surfaces changed.
- This keeps existing bind-mismatch restart behavior intact when Avahi is already running.
- The submitted sketch had a shell typo; the PR uses `if avahid_running; then`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Avahi daemon configuration handling to properly manage state transitions when network interfaces change. The service now correctly restarts on configuration updates and automatically starts if previously stopped due to unavailable interfaces, improving reliability in dynamic network environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->