### PR TITLE
Dashboard: support custom fan names on Airflow tile

### DIFF
--- a/emhttp/plugins/dynamix/DashStats.page
+++ b/emhttp/plugins/dynamix/DashStats.page
@@ -804,10 +804,14 @@ switch ($themeHelper->getThemeName()) { // $themeHelper set in DefaultPageLayout
                     <?
                     $label = $value = [];
                     $i = 0;
+                    // optional custom fan names, indexed in the same order as `sensors -uA`
+                    $fan_names_file = '/boot/config/plugins/dynamix/fan_names.json';
+                    $fan_names = file_exists($fan_names_file) ? (json_decode(file_get_contents($fan_names_file), true) ?: []) : [];
                     for ($fan=0; $fan<$fans; $fan++) {
                         if ($fan > 0 && $fan % 3 == 0) $i++;
                         $class = $fan % 3 == 2 ? "" : " class='fan'";
-                        $label[$i][] = "<span{$class}>"._('FAN')." ".($fan+1)."</span>";
+                        $fan_label = ($fan_names[$fan] ?? '') !== '' ? htmlspecialchars($fan_names[$fan]) : _('FAN')." ".($fan+1);
+                        $label[$i][] = "<span{$class}>$fan_label</span>";
                     }
                     $i = 0;
                     for ($fan=0; $fan<$fans; $fan++) {

--- a/emhttp/plugins/dynamix/DashStats.page
+++ b/emhttp/plugins/dynamix/DashStats.page
@@ -804,13 +804,22 @@ switch ($themeHelper->getThemeName()) { // $themeHelper set in DefaultPageLayout
                     <?
                     $label = $value = [];
                     $i = 0;
-                    // optional custom fan names, indexed in the same order as `sensors -uA`
+                    // optional custom fan names, keyed by "<chip> - <fanN>" (matches `sensors -uA` order)
                     $fan_names_file = '/boot/config/plugins/dynamix/fan_names.json';
                     $fan_names = file_exists($fan_names_file) ? (json_decode(file_get_contents($fan_names_file), true) ?: []) : [];
+                    $fan_keys = [];
+                    $fan_chip = '';
+                    foreach (explode("\n", shell_exec("sensors -uA 2>/dev/null") ?: '') as $fan_line) {
+                        if (strpos($fan_line, ':') === false && trim($fan_line) !== '') {
+                            $fan_chip = trim($fan_line);
+                        } elseif (preg_match('/^\s*(fan\d+)_input:/', $fan_line, $fan_m)) {
+                            $fan_keys[] = "$fan_chip - {$fan_m[1]}";
+                        }
+                    }
                     for ($fan=0; $fan<$fans; $fan++) {
                         if ($fan > 0 && $fan % 3 == 0) $i++;
                         $class = $fan % 3 == 2 ? "" : " class='fan'";
-                        $fan_label = ($fan_names[$fan] ?? '') !== '' ? htmlspecialchars($fan_names[$fan]) : _('FAN')." ".($fan+1);
+                        $fan_label = (($fan_names[$fan_keys[$fan] ?? ''] ?? '') !== '') ? htmlspecialchars($fan_names[$fan_keys[$fan]]) : _('FAN')." ".($fan+1);
                         $label[$i][] = "<span{$class}>$fan_label</span>";
                     }
                     $i = 0;


### PR DESCRIPTION
## Summary
- The Dashboard's Airflow tile labels fans sequentially as "FAN 1", "FAN 2"... based on `sensors -uA` enumeration order. This order frequently doesn't match the physical header labels printed on the motherboard (e.g. dashboard "FAN 1" may actually be the "PWM2" header).
- This adds support for an optional `/boot/config/plugins/dynamix/fan_names.json` file (a JSON array, indexed in the same order `sensors -uA` reports fans) whose values override the generic "FAN N" label when present and non-empty. If the file doesn't exist, behavior is unchanged.

## Companion plugin
A small plugin (https://github.com/mrjacobarussell/dashboard-fan-labels) provides a settings page (Settings -> Dashboard Fan Labels) that lists each detected fan sensor (chip, sensor name, live RPM) in the same order as the Dashboard, with a text field to assign a custom name. It writes to the `fan_names.json` path this PR reads.

## Test plan
- [x] Verified on Unraid with a Corsair Commander Pro + motherboard sensors: without `fan_names.json`, dashboard shows "FAN 1".."FAN 6" as before.
- [x] With `fan_names.json` populated (e.g. `["CPU","Case Top","","Pump"]`), tile shows custom names for indices 0,1,3 and falls back to "FAN 3" for the empty entry.
- [x] RPM values (`get.fan[k]` via nchan) are unaffected - only the static label changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard fan display now supports optional custom fan names loaded from a local configuration file. When valid custom labels exist they replace the default "FAN <n>" identifiers; missing or invalid entries fall back to standard labels. Custom labels are safely rendered to ensure proper display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->