### PR TITLE
feat(docker): allow SVG icons for Docker containers

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -140,7 +140,11 @@ foreach ($containers as $ct) {
   $color = $status=='started' ? 'green-text' : ($status=='paused' ? 'orange-text' : 'red-text');
   $update = $updateStatus==1 && !empty($compose) ? 'blue-text' : '';
   $icon = $info['icon'] ?: '/plugins/dynamix.docker.manager/images/question.png';
-  $image = substr($icon,-4)=='.png' ? "<img src='$icon?".filemtime("$docroot{$info['icon']}")."' class='img' onerror=this.src='/plugins/dynamix.docker.manager/images/question.png';>" : (substr($icon,0,5)=='icon-' ? "<i class='$icon img'></i>" : "<i class='fa fa-$icon img'></i>");
+  $image = in_array(strtolower(pathinfo($icon, PATHINFO_EXTENSION)), ['png', 'svg'])
+    ? "<img src='$icon?".filemtime("$docroot{$info['icon']}")."' class='img' onerror=this.src='/plugins/dynamix.docker.manager/images/question.png';>"
+    : (substr($icon,0,5)=='icon-'
+      ? "<i class='$icon img'></i>"
+      : "<i class='fa fa-$icon img'></i>");
   $wait = var_split($autostart[array_search($name,$names)]??'',1);
   $networks = [];
   $network_ips = [];
@@ -163,7 +167,7 @@ foreach ($containers as $ct) {
     } elseif (!isset($ct['Ports']['vlan']) || strpos($ct['NetworkMode'],'container:')!==false) {
       foreach ($ct['Ports'] as $port) {
         if (_var($port,'PublicPort') && _var($port,'Driver') == 'bridge') {
-          if (_var($port, "HostIp") != "") $hostip = _var($port, "HostIp"); else $hostip = $host; 
+          if (_var($port, "HostIp") != "") $hostip = _var($port, "HostIp"); else $hostip = $host;
           $ports_external[] = sprintf('%s:%s', $hostip, strtoupper(_var($port,'PublicPort')));
         }
         if ((!isset($ct['Networks']['host'])) || (!isset($ct['Networks']['vlan']))) {


### PR DESCRIPTION
### Purpose
Right now only `.png` files are treated as valid Docker container icons in the WebGUI. Everything else falls back to FontAwesome icons.


### Added
Adds support for `.svg` icons in the same rendering path as PNG icons.


### Notes
- PNG support stays exactly the same
- SVG is handled the same way as PNG in the icon rendering path
- No other logic changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Docker container UI icon rendering system with improved selection logic, maintaining all existing visual output and fallback behaviors.

* **Bug Fixes**
  * Fixed host IP address selection in external port binding configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->