### PR TITLE
fix(avahi): recover stopped daemon even when bind list matches config

### DIFF
--- a/etc/rc.d/rc.avahidaemon
+++ b/etc/rc.d/rc.avahidaemon
@@ -120,11 +120,16 @@ avahid_reload(){
 }
 
 avahid_update(){
-  if check && [[ "$(this allow-interfaces)" != "$BIND" ]]; then
-    if avahid_running; then
+  if avahid_running; then
+    # only restart a running daemon when the computed bind list changed
+    if check && [[ "$(this allow-interfaces)" != "$BIND" ]]; then
       log "Updating $DAEMON..."
       avahid_restart # note we need restart here, not reload in order to update interfaces
-    else
+    fi
+  else
+    # recover daemon when interfaces are back, even if config already matches computed bind list
+    if check && [[ -n $BIND ]]; then
+      log "Recovering $DAEMON..."
       avahid_start # handle case where avahi-daemon exited because no suitable interfaces
     fi
   fi


### PR DESCRIPTION
Follow-up to #2661 (already merged), addressing CodeRabbit's review.

`avahid_update` previously gated both the restart and start paths behind the `allow-interfaces != BIND` mismatch. That meant a stopped daemon would stay down if interfaces recovered to the same bind list — common after transient interface loss.

This splits on daemon state instead:
- **Running:** restart only when `check` passes and `allow-interfaces` differs from `$BIND` (unchanged).
- **Stopped:** recover via `avahid_start` whenever `check` passes and `$BIND` is non-empty, regardless of whether the bind list matches the saved config.

Verified with `bash -n etc/rc.d/rc.avahidaemon` and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized Avahi daemon restart logic to avoid unnecessary restarts by detecting actual configuration changes.
  * Improved daemon recovery behavior with smarter conditional startup based on interface configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->