### PR TITLE
fix(plugin-manager): surface plugin update validation failures instead of reporting up-to-date (OS-380)

### DIFF
--- a/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
+++ b/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
@@ -196,9 +196,11 @@ foreach (glob($plugins,GLOB_NOSORT) as $plugin_link) {
         $info   = json_decode(file_get_contents($invalid),true) ?: [];
         $newver = (string)($info['version'] ?? '');
         if ($newver !== '' && strcmp($newver,$version) > 0) {
-          $reason  = trim((string)($info['reason'] ?? ''));
+          $summary = trim((string)($info['summary'] ?? $info['reason'] ?? ''));
+          $message = trim((string)($info['message'] ?? $summary));
           $version .= "<br><span class='red-text'>$newver</span>";
-          $status  = "<span class='warning'".($reason ? " title='".htmlspecialchars($reason,ENT_QUOTES)."'" : "")."><i class='fa fa-exclamation-triangle' aria-hidden='true'></i> "._('Update validation failed')."</span>";
+          $status  = "<span class='warning'".($message ? " title='".htmlspecialchars($message,ENT_QUOTES)."'" : "")."><i class='fa fa-exclamation-triangle' aria-hidden='true'></i> "._('update validation failed')."</span>";
+          if ($summary !== '') $status .= "<br><span class='orange-text' style='font-size:smaller'>".htmlspecialchars($summary,ENT_QUOTES)."</span>";
         } else {
           @unlink($invalid);
         }
@@ -206,7 +208,7 @@ foreach (glob($plugins,GLOB_NOSORT) as $plugin_link) {
     }
     if (strpos($status,'update')!==false) $rank = '0';
     elseif (strpos($status,'install')!==false) $rank = '1';
-    elseif (strpos($status,'Update validation failed')!==false) $rank = '0';
+    elseif (strpos($status,'update validation failed')!==false) $rank = '0';
     elseif ($status=='need check') $rank = '2';
     elseif ($status=='up-to-date') $rank = '3';
     else $rank = '4';

--- a/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
+++ b/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
@@ -186,8 +186,27 @@ foreach (glob($plugins,GLOB_NOSORT) as $plugin_link) {
         }
       }
     }
+    // an available update that failed validation: surface it instead of the
+    // silent "up-to-date" the revert would otherwise produce (marker written by
+    // the pre_plugin_checks hook). Common cause: the root filesystem is full so
+    // the update files can't be downloaded for the integrity check.
+    if (!$os && $checked) {
+      $invalid = "/tmp/plugins/".basename($plugin_file).".invalid";
+      if (is_file($invalid)) {
+        $info   = json_decode(file_get_contents($invalid),true) ?: [];
+        $newver = (string)($info['version'] ?? '');
+        if ($newver !== '' && strcmp($newver,$version) > 0) {
+          $reason  = trim((string)($info['reason'] ?? ''));
+          $version .= "<br><span class='red-text'>$newver</span>";
+          $status  = "<span class='warning'".($reason ? " title='".htmlspecialchars($reason,ENT_QUOTES)."'" : "")."><i class='fa fa-exclamation-triangle' aria-hidden='true'></i> "._('Update validation failed')."</span>";
+        } else {
+          @unlink($invalid);
+        }
+      }
+    }
     if (strpos($status,'update')!==false) $rank = '0';
     elseif (strpos($status,'install')!==false) $rank = '1';
+    elseif (strpos($status,'Update validation failed')!==false) $rank = '0';
     elseif ($status=='need check') $rank = '2';
     elseif ($status=='up-to-date') $rank = '3';
     else $rank = '4';

--- a/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
+++ b/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
@@ -190,6 +190,7 @@ foreach (glob($plugins,GLOB_NOSORT) as $plugin_link) {
     // silent "up-to-date" the revert would otherwise produce (marker written by
     // the pre_plugin_checks hook). Common cause: the root filesystem is full so
     // the update files can't be downloaded for the integrity check.
+    $validation_failed = false;
     if (!$os && $checked) {
       $invalid = "/tmp/plugins/".basename($plugin_file).".invalid";
       if (is_file($invalid)) {
@@ -201,14 +202,15 @@ foreach (glob($plugins,GLOB_NOSORT) as $plugin_link) {
           $version .= "<br><span class='red-text'>$newver</span>";
           $status  = "<span class='warning'".($message ? " title='".htmlspecialchars($message,ENT_QUOTES)."'" : "")."><i class='fa fa-exclamation-triangle' aria-hidden='true'></i> "._('update validation failed')."</span>";
           if ($summary !== '') $status .= "<br><span class='orange-text' style='font-size:smaller'>".htmlspecialchars($summary,ENT_QUOTES)."</span>";
+          $validation_failed = true;
         } else {
           @unlink($invalid);
         }
       }
     }
-    if (strpos($status,'update')!==false) $rank = '0';
+    if ($validation_failed) $rank = '0';
+    elseif (strpos($status,'update')!==false) $rank = '0';
     elseif (strpos($status,'install')!==false) $rank = '1';
-    elseif (strpos($status,'update validation failed')!==false) $rank = '0';
     elseif ($status=='need check') $rank = '2';
     elseif ($status=='up-to-date') $rank = '3';
     else $rank = '4';

--- a/emhttp/plugins/dynamix.plugin.manager/post-hooks/post_plugin_checks
+++ b/emhttp/plugins/dynamix.plugin.manager/post-hooks/post_plugin_checks
@@ -42,6 +42,8 @@ case 'plugin':
   case 'update':
     // abort if method was unsuccessful
     if ($error) break;
+    // a successful install/update clears any prior validation-failure marker
+    @unlink("/tmp/plugins/$name.invalid");
     // update support link in plugin file
     $info = readJson('/tmp/community.applications/tempFiles/templates.json');
     // find matching support link

--- a/emhttp/plugins/dynamix.plugin.manager/pre-hooks/pre_plugin_checks
+++ b/emhttp/plugins/dynamix.plugin.manager/pre-hooks/pre_plugin_checks
@@ -39,13 +39,31 @@ case 'plugin':
     // validate plugin update (not applicable to OS updates)
     if (in_array($name, $unraid)) break;
     $new_plugin = "/tmp/plugins/$name";
+    $invalid    = "/tmp/plugins/$name.invalid";
     if (plugin('version', $new_plugin) > plugin('version', $plugin)) {
       echo "Validating $name update\n";
-      if (($status = plugin('validate', $new_plugin)) != 'valid') {
-        echo "$status\n";
+      $new_version = plugin('version', $new_plugin);
+      // scripts/plugin exits non-zero and prints "plugin: <reason>" on failure
+      // (bad hash, or the update files failing to download for the hash check)
+      $output = [];
+      exec("$docroot/plugins/dynamix.plugin.manager/scripts/plugin validate ".escapeshellarg($new_plugin)." 2>&1", $output, $retval);
+      if ($retval != 0) {
+        $reason = trim(preg_replace('/^plugin:\s*/m', '', implode("\n", $output)));
+        echo ($reason ?: 'validation failed')."\n";
+        // An update is available but failed validation. Record why so the webGUI
+        // can surface it, instead of silently reverting to "up-to-date". The most
+        // common cause is the update files not downloading because the root
+        // filesystem is full.
+        file_put_contents($invalid, json_encode(['version'=>$new_version, 'reason'=>$reason]));
         // restore original plugin and undo update
         copy($plugin, $new_plugin);
+      } else {
+        // validation passed - clear any stale failure marker
+        @unlink($invalid);
       }
+    } else {
+      // no newer version available - clear any stale failure marker
+      @unlink($invalid);
     }
     break;
   }

--- a/emhttp/plugins/dynamix.plugin.manager/pre-hooks/pre_plugin_checks
+++ b/emhttp/plugins/dynamix.plugin.manager/pre-hooks/pre_plugin_checks
@@ -49,12 +49,36 @@ case 'plugin':
       exec("$docroot/plugins/dynamix.plugin.manager/scripts/plugin validate ".escapeshellarg($new_plugin)." 2>&1", $output, $retval);
       if ($retval != 0) {
         $reason = trim(preg_replace('/^plugin:\s*/m', '', implode("\n", $output)));
-        echo ($reason ?: 'validation failed')."\n";
-        // An update is available but failed validation. Record why so the webGUI
-        // can surface it, instead of silently reverting to "up-to-date". The most
-        // common cause is the update files not downloading because the root
-        // filesystem is full.
-        file_put_contents($invalid, json_encode(['version'=>$new_version, 'reason'=>$reason]));
+        // Classify the failure so the webGUI can explain it (and what to do)
+        // instead of silently reverting to "up-to-date". Validation downloads
+        // the update's files to /tmp (rootfs) and checks their hash, so the
+        // usual culprits are a full root filesystem, a transient network error,
+        // or a genuine bad hash.
+        $free_kb = (int)trim((string)@shell_exec("df -Pk /tmp 2>/dev/null | awk 'NR==2{print \$4}'"));
+        $free_mb = $free_kb > 0 ? intdiv($free_kb, 1024) : 0;
+        if (stripos($reason, 'hash') !== false) {
+          $category = 'integrity';
+          $summary  = 'integrity check failed (bad hash)';
+          $message  = 'The update failed its integrity check (bad hash). The download may be incomplete or corrupt. Check for updates again shortly.';
+        } elseif ($free_kb > 0 && $free_kb < 102400) {
+          $category = 'diskspace';
+          $summary  = 'low on disk space';
+          $message  = sprintf('Not enough free space to download and verify the update (%s MB free). Free up space and check for updates again.', $free_mb);
+        } else {
+          $category = 'download';
+          $summary  = 'update files could not be downloaded';
+          $message  = 'Could not download the update files to verify them. This may be a temporary network problem. Check for updates again shortly.';
+        }
+        echo "$message\n";
+        // An update is available but failed validation. Record the available
+        // version and the classified reason so the webGUI can surface it.
+        file_put_contents($invalid, json_encode([
+          'version'  => $new_version,
+          'category' => $category,
+          'summary'  => $summary,
+          'message'  => $message,
+          'reason'   => $reason,
+        ]));
         // restore original plugin and undo update
         copy($plugin, $new_plugin);
       } else {


### PR DESCRIPTION
## Summary

When a plugin update is available, the `pre_plugin_checks` hook validates it by re-downloading the update's files and verifying their SHA256/MD5. On **any** validation failure it silently reverted the cached `.plg` to the installed version, and `plugin check` still exited successfully — so the **Plugins page showed "up-to-date" and the available update vanished with no error**.

The failure is most visible when the **root filesystem is full**: the (often large) `.txz` can't be downloaded for the hash check, validation fails, and the update silently disappears. This was diagnosed on a live server where a stale 1.2 GB `/tmp/unRAIDServer.zip` filled the rootfs — every plugin update check reported "up-to-date" with no indication that validation was failing for lack of space.

## Root cause

In `check` flow:
1. `plugin check` downloads the new `.plg`, then runs `pre_plugin_checks`.
2. The hook validates the update — `scripts/plugin validate` re-downloads the txz and checks its hash.
3. On failure it returns `false` (download/IO/network error and bad-hash are indistinguishable), and the hook **reverts** the cached `.plg` to the installed one.
4. `plugin check` prints the reverted (old) version and exits `done(0)`. The version comparison in `ShowPlugins.php` sees them equal → renders **up-to-date**.

The failure reason was swallowed twice (PluginHelpers discards it; the hook reverts silently).

## Change

- **`pre-hooks/pre_plugin_checks`** — capture the validation reason (via `scripts/plugin validate`, which prints `plugin: <reason>` and exits non-zero) and, on failure, write a `/tmp/plugins/<name>.invalid` marker recording the available version + reason. Clears the marker when validation passes or no newer version exists. The existing revert behavior is unchanged (we still don't offer an unvalidated update).
- **`post-hooks/post_plugin_checks`** — clear the marker after a successful install/update.
- **`include/ShowPlugins.php`** — when the marker is present and a newer version exists, render an **"Update validation failed"** status (with the reason as a tooltip) and the available version, ranked with updates — instead of the silent "up-to-date".

Additive and contained: success / no-update paths are unchanged except for marker cleanup. OS (`unRAIDServer`) updates are excluded, matching the existing hook guard.

## Testing

- `php -l` clean on all three files.
- Unit-tested the reason extraction (handles `download failure: File I/O error`, `bad hash value`, `zero-length file`) and the marker-driven status/version/rank rendering.

## Notes

A natural follow-up (not in this PR) is to also raise a notification and/or proactively warn on low rootfs free space, since "disk full" is the most common trigger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin update validation failures now surface as warning tooltips, including the rejected version details.

* **Improvements**
  * When an update fails validation, the previously working plugin version is automatically restored.
  * Validation failure warnings are deprioritized in the plugin list (ranking set to reflect the warning).
  * Any prior validation-failure indicators are cleared after successful installs/updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Linear

- OS-380
