### PR TITLE
fix(plugin-manager): parallel, non-blocking Plugins page update check

### DIFF
--- a/emhttp/plugins/dynamix.plugin.manager/Plugins.page
+++ b/emhttp/plugins/dynamix.plugin.manager/Plugins.page
@@ -108,9 +108,52 @@ function initlist() {
       $('#plugin_table').tablesorter({sortList:[[4,0],[1,0]],sortAppend:[[1,0]],headers:{0:{sorter:false},5:{sorter:false}},textAttribute:'data'});
       $('.desc_readmore').readmore({maxHeight:80,moreLink:"<a href='#'><i class='fa fa-chevron-down'></i></a>",lessLink:"<a href='#'><i class='fa fa-chevron-up'></i></a>"});
       $('div.spinner.fixed').hide('slow');
-      loadlist();
+      checkPlugins();
     }
   });
+}
+// Update check, parallel + non-blocking. Instead of one serial sweep that
+// blocks on the slowest/unreachable plugin, fire one bounded-concurrency
+// request per installed plugin. Each row resolves independently; a slow or
+// failed check only affects its own row (never the page), and times out into a
+// definite "cannot check" state instead of spinning forever.
+var pluginUpdates = 0;
+function checkPlugin(plg) {
+  var name = plg.replace(/\.plg$/,'');
+  return $.ajax({url:'/plugins/dynamix.plugin.manager/include/ShowPlugins.php',data:{one:name},timeout:20000})
+    .done(function(data){
+      data = (data||'').split('\0');
+      updateInfo(data[0]);
+      pluginUpdates += (parseInt(data[1],10) || 0);
+    })
+    .fail(function(){
+      var id = name.replace(/\./g,'-');
+      $('#sid-'+id).attr('data','4').html("<span class='red-text'><i class='fa fa-exclamation-triangle fa-fw'></i>&nbsp;<?=_('cannot check')?></span>");
+    });
+}
+function checkPlugins() {
+  var queue = [];
+  $('input.remove').each(function(){var d=$(this).attr('data'); if (d) queue.push(d);});
+  pluginUpdates = 0;
+  $('#updateall').hide();
+  var total = queue.length, done = 0, idx = 0, active = 0, MAX = 6;
+  if (!total) { $('#checkall').find('input').prop('disabled',false); return; }
+  function pump() {
+    while (active < MAX && idx < total) {
+      active++;
+      checkPlugin(queue[idx++]).always(function(){
+        active--; done++;
+        $('#plugin_table').trigger('update');
+        if (done == total) {
+          if (pluginUpdates > 1) $('#updateall').show(); else $('#updateall').hide();
+          $('#checkall').find('input').prop('disabled',false);
+        } else {
+          pump();
+        }
+      });
+    }
+  }
+  pump();
 }
 function loadlist(id,check) {
   if (id) timers.plugins = setTimeout(function(){$('div.spinner.fixed').show('slow');},500);

--- a/emhttp/plugins/dynamix.plugin.manager/Plugins.page
+++ b/emhttp/plugins/dynamix.plugin.manager/Plugins.page
@@ -132,8 +132,10 @@ function checkPlugin(plg) {
     });
 }
 function checkPlugins() {
-  var queue = [];
-  $('input.remove').each(function(){var d=$(this).attr('data'); if (d) queue.push(d);});
+  var queue = [], seen = {};
+  // class 'remove' is on both the checkbox and the button for each plugin, so
+  // dedupe by data attribute to avoid checking every plugin twice
+  $('input.remove').each(function(){var d=$(this).attr('data'); if (d && !seen[d]) {seen[d]=1; queue.push(d);}});
   pluginUpdates = 0;
   $('#updateall').hide();
   var total = queue.length, done = 0, idx = 0, active = 0, MAX = 6;

--- a/emhttp/plugins/dynamix.plugin.manager/Plugins.page
+++ b/emhttp/plugins/dynamix.plugin.manager/Plugins.page
@@ -145,7 +145,12 @@ function checkPlugins() {
       active++;
       checkPlugin(queue[idx++]).always(function(){
         active--; done++;
-        $('#plugin_table').trigger('update');
+        // Refresh the sort cache in place (do NOT 'update', which re-applies
+        // sortList and re-sorts by Status). Each check changes a row's Status
+        // rank, so 'update' would make rows jump around as results land. Rows
+        // stay in their initial order; a later header click still sorts on the
+        // current data because the cache is kept fresh.
+        $('#plugin_table').trigger('updateCache');
         if (done == total) {
           if (pluginUpdates > 1) $('#updateall').show(); else $('#updateall').hide();
           $('#checkall').find('input').prop('disabled',false);

--- a/emhttp/plugins/dynamix.plugin.manager/Plugins.page
+++ b/emhttp/plugins/dynamix.plugin.manager/Plugins.page
@@ -131,13 +131,24 @@ function checkPlugin(plg) {
       $('#sid-'+id).attr('data','4').html("<span class='red-text'><i class='fa fa-exclamation-triangle fa-fw'></i>&nbsp;<?=_('cannot check')?></span>");
     });
 }
-function checkPlugins() {
+function checkPlugins(reset) {
   var queue = [], seen = {};
   // class 'remove' is on both the checkbox and the button for each plugin, so
   // dedupe by data attribute to avoid checking every plugin twice
-  $('input.remove').each(function(){var d=$(this).attr('data'); if (d && !seen[d]) {seen[d]=1; queue.push(d);}});
+  $('input.remove').each(function(){
+    var d=$(this).attr('data');
+    if (d && !seen[d]) {
+      seen[d]=1;
+      queue.push(d);
+      if (reset) {
+        var id = d.replace(/\.plg$/,'').replace(/\./g,'-');
+        $('#sid-'+id).attr('data','0').html("<span style='color:#267CA8'><i class='fa fa-refresh fa-spin fa-fw'></i>&nbsp;<?=_('checking')?>...</span>");
+      }
+    }
+  });
   pluginUpdates = 0;
   $('#updateall').hide();
+  $('#checkall').find('input').prop('disabled',true);
   var total = queue.length, done = 0, idx = 0, active = 0, MAX = 6;
   if (!total) { $('#checkall').find('input').prop('disabled',false); return; }
   function pump() {
@@ -195,7 +206,7 @@ function loadlist(id,check) {
 }
 $(function() {
   initlist();
-  $('.tabs-container').append("<span id='checkall' class='status vhshift'><input type='button' value=\"_(Check For Updates)_\" onclick='openPlugin(\"checkall\",\"_(Plugin Update Check)_\",\":return\")' disabled></span>");
+  $('.tabs-container').append("<span id='checkall' class='status vhshift'><input type='button' value=\"_(Check For Updates)_\" onclick='checkPlugins(true)' disabled></span>");
   $('.tabs-container').append("<span id='updateall' class='status vhshift' style='display:none;margin-left:12px'><input type='button' value=\"_(Update All Plugins)_\" onclick='updateList()'></span>");
   $('.tabs-container').append("<span id='removeall' class='status vhshift' style='display:none;margin-left:12px'><input type='button' value=\"_(Remove Selected Plugins)_\" onclick='removeList()'></span>");
 });

--- a/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
+++ b/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
@@ -25,6 +25,7 @@ $audit   = unscript(_var($_GET,'audit'));
 $check   = unscript(_var($_GET,'check'));
 $cmd     = unscript(_var($_GET,'cmd'));
 $init    = unscript(_var($_GET,'init'));
+$one     = unscript(_var($_GET,'one')); // single-plugin update check (fired per row, in parallel)
 $empty   = true;
 $install = false;
 $updates = 0;
@@ -55,6 +56,13 @@ if ($audit) {
     case 'update' : $plugins = "/var/log/plugins/$plg.plg"; break;
   }
 }
+
+// Restrict to a single installed plugin so its (network) update check can run
+// in parallel with the others, instead of the legacy serial sweep that blocks
+// the page on the slowest/unreachable plugin. Goes through the normal update
+// check path below (no $audit, $check stays falsy) and returns just this
+// plugin's vid-/sid- line.
+if ($one) $plugins = "/var/log/plugins/".basename($one,'.plg').".plg";
 
 delete_file($alerts);
 foreach (glob($plugins,GLOB_NOSORT) as $plugin_link) {

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
@@ -262,7 +262,9 @@ function download($url, $name, &$error, $write=true) {
       if (($perror = pclose($file)) != 0) {
         $error = "$plg download failure: ".error_desc($perror);
         return false;
-      } elseif (filesize($name) == 0) {
+      }
+      clearstatcache(true, $name);
+      if (filesize($name) == 0) {
         $error = "$plg download failure: zero-length file";
         if ($write) write("plugin: download failure: zero-length file\r","\n");
         return false;

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
@@ -263,6 +263,7 @@ function download($url, $name, &$error, $write=true) {
         $error = "$plg download failure: ".error_desc($perror);
         return false;
       } elseif (filesize($name) == 0) {
+        $error = "$plg download failure: zero-length file";
         if ($write) write("plugin: download failure: zero-length file\r","\n");
         return false;
       } else {
@@ -330,7 +331,11 @@ function plugin($method, $plugin_file, &$error) {
 
   // validate plugin download without installation
   if ($method  == 'validate') {
-    $name = '/tmp/validate-plugin.tmp';
+    $name = tempnam('/tmp', 'validate-plugin-');
+    if ($name === false) {
+      $error = "unable to create validation temporary file";
+      return false;
+    }
     foreach ($xml->FILE as $file) if ($file->URL) {
       if (!$file->SHA256 and !$file->MD5) continue;
       if ( (download($file->URL, $name, $error, false) === false) && (download(filter_url($file->URL), $name, $error, false) === false) ) {


### PR DESCRIPTION
## Problem
The Installed Plugins page (`Tools > Plugins`) can sit with every row spinning `checking...` indefinitely, which makes the page look hung.

## Root cause
The page loads in two passes:
- Pass 1: `ShowPlugins.php?init=true` renders the table from local `.plg` data. Fast.
- Pass 2: the old all-plugin check path walked every plugin serially and spawned the `plugin` script to `wget` each plugin's `pluginURL`.

One slow or unreachable plugin URL blocked the whole pass, so every row stayed at `checking...` until the slowest plugin resolved.

## Fix
- `ShowPlugins.php`: add single-plugin mode with `?one=<name>` so one request checks one plugin and returns just that row's update/status fragment.
- `Plugins.page`: replace the automatic post-init sweep with bounded concurrency fan-out, one `?one=` request per installed plugin, each with a 20s AJAX timeout.
- `Plugins.page`: route manual **Check For Updates** through the same row-check flow. It resets rows to `checking...`, disables the button while active, and re-enables when all row checks complete.
- Fail-safe: timeout/error resolves only that row to `cannot check`; the page is never gated on one plugin host.
- `scripts/plugin`: harden validation downloads by using a per-process temp file, reporting zero-length downloads as explicit errors, and clearing PHP's stat cache before `filesize()`.

A slow/unreachable plugin now affects only its own row, bounded by one timeout. Automatic and manual checks use the same visible row behavior.

## Scope / follow-up
- Phase 2 in OS-457, a single-parse `plugin_attributes()` path to reduce remaining per-plugin `exec` spawns for `changes` / `alert`, remains a follow-up.
- External plugin asset hosts can still fail or throttle downloads. Those should now surface as download errors or per-row `cannot check`, not as false hash/blank temp-file races.

## Testing
- `php -l` clean on `Plugins.page` and `scripts/plugin`.
- Deployed to `devgen.local` with backups at `/tmp/Plugins.page.before-manual-row-check.1783609619` and `/tmp/plugin.before-manual-row-check.1783609619`.
- Verified devgen syntax for both files.
- Verified manual button now renders `onclick='checkPlugins(true)'` instead of `openPlugin("checkall", ...)`.
- Verified serial Apprise validation on devgen returns `valid`, rc=0, and leaves no `/tmp/validate-plugin-*` files behind.

Ref: [OS-457](https://linear.app/lime-technology/issue/OS-457/plugins-page-can-hang-on-the-loading-spinner-slowblocking-on-load) · prior art: #2352 (closed), #2421 (merged)