### PR TITLE
feat(task-tray): show target name in background-task progress headings [OS-460]

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
+++ b/emhttp/plugins/dynamix.docker.manager/javascript/docker.js
@@ -107,7 +107,7 @@ function updateContainer(container) {
   swal({
     title:_('Are you sure?'),text:_('Update container')+': '+container, type:'warning',html:true,showCancelButton:true,closeOnConfirm:false,confirmButtonText:_('Yes, update it!'),cancelButtonText:_('Cancel')
   },function(){
-    openDocker('update_container '+encodeURIComponent(container),_('Updating the container'),'','loadlist');
+    openDocker('update_container '+encodeURIComponent(container),_('Update container')+': '+container,'','loadlist');
   });
 }
 function rmContainer(container, image, id) {
@@ -182,7 +182,7 @@ function updateAll() {
   $('input[type=button]').prop('disabled',true);
   var ct = [];
   for (var i=0,d; d=docker[i]; i++) if (d.update==1) ct.push(encodeURIComponent(d.name));
-  openDocker('update_container '+ct.join('*'),_('Updating all Containers'),'','loadlist');
+  openDocker('update_container '+ct.join('*'),_('Updating all Containers')+' ('+ct.length+')','','loadlist');
 }
 function rebuildAll() {
   $('input[type=button]').prop('disabled',true);

--- a/emhttp/plugins/dynamix/Apps.page
+++ b/emhttp/plugins/dynamix/Apps.page
@@ -16,7 +16,10 @@ Code="e942"
 ?>
 <script>
 function installPlugin(file) {
-  openPlugin("plugin install "+file,"_(Install Plugin)_","","refresh");
+  // show which plugin in the progress heading; sanitize to a safe display slug
+  // (the heading is rendered as HTML), derived from the .plg basename
+  var name = (file.split('/').pop()||'').replace(/\.[a-z0-9]+$/i,'').replace(/[^\w.\- ]+/g,' ').trim();
+  openPlugin("plugin install "+file,"_(Install Plugin)_"+(name?': '+name:''),"","refresh");
 }
 </script>
 

--- a/emhttp/plugins/dynamix/Language.page
+++ b/emhttp/plugins/dynamix/Language.page
@@ -75,7 +75,10 @@ function getZIPfile(event,form) {
 }
 function installXML(name) {
   var file = name.trim();
-  if (file) openPlugin('language install '+file, "_(Install Language)_");
+  // show which language pack in the progress heading; sanitize to a safe display
+  // slug (the heading is rendered as HTML), derived from the file basename
+  var disp = (file.split('/').pop()||'').replace(/\.[a-z0-9]+$/i,'').replace(/[^\w.\- ]+/g,' ').trim();
+  if (file) openPlugin('language install '+file, "_(Install Language)_"+(disp?': '+disp:''));
 }
 $(function() {
   $('input.view').switchButton({labels_placement:'left', off_label:"_(User)_", on_label:"_(Developer)_"});

--- a/emhttp/plugins/dynamix/Tailscale.page
+++ b/emhttp/plugins/dynamix/Tailscale.page
@@ -16,7 +16,10 @@ Title="Tailscale"
 ?>
 <script>
 function installPlugin(file) {
-  openPlugin("plugin install "+file,"_(Install Plugin)_","","refresh");
+  // show which plugin in the progress heading; sanitize to a safe display slug
+  // (the heading is rendered as HTML), derived from the .plg basename
+  var name = (file.split('/').pop()||'').replace(/\.[a-z0-9]+$/i,'').replace(/[^\w.\- ]+/g,' ').trim();
+  openPlugin("plugin install "+file,"_(Install Plugin)_"+(name?': '+name:''),"","refresh");
 }
 </script>
 


### PR DESCRIPTION
## Summary

Background-operation progress headings use generic labels that don't say *what* is being acted on — ambiguous when several operations run at once (and especially in the multi-task tray landing in #2665). The specific target is already in scope at each call site; this folds it into the title that `openDocker`/`openPlugin` render.

| Call site | Before | After |
| --- | --- | --- |
| `docker.js` `updateContainer()` | Updating the container | **Update container: `<name>`** |
| `docker.js` `updateAll()` | Updating all Containers | **Updating all Containers (`N`)** |
| `Apps.page` / `Tailscale.page` `installPlugin()` | Install Plugin | **Install Plugin: `<plugin>`** |
| `Language.page` `installXML()` | Install Language | **Install Language: `<pack>`** |

This improves the existing swal "In Progress" modal heading today, and the multi-task tray tiles once #2665 merges (titles flow through unchanged).

## Safety

The legacy `openPlugin`/`openDocker` swal heading is rendered with `html:true` and is **not** escaped, so injected names must be HTML-safe:

- **Container names** are constrained by Docker's naming charset (`[a-zA-Z0-9][a-zA-Z0-9_.-]+`) — safe.
- **Plugin / language names** are reduced to a sanitized basename slug (`[^\w.\- ]` stripped, trailing extension removed) before display.
- **Counts** are numeric.

## Scope / conflicts

- Touches only call sites: `docker.js`, `Apps.page`, `Tailscale.page`, `Language.page`.
- Deliberately stays out of `HeadInlineJS.php`, so **no conflict with #2665** (verified: #2665 does not modify these files).
- No backend, task-record schema, or tray markup changes.

## Validation

- `node --check` passes on `docker.js`.
- Title strings keep the translatable verb (`_()`) and append the in-scope name; the ellipsis/`min-width:0` handling already covers longer headings.

## Follow-ups (not here)

- Plugin batch update/remove counts (`Plugins.page`), Install Key naming.
- Optional richer two-line tile (bold action + dimmed target) after #2665, via a `detail` field on the task record.

Closes OS-460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Docker container updates now display the specific container name in progress dialogs.
  * Batch container updates show the total number of containers being updated.
  * Plugin and language pack installations now display the package name in progress dialogs instead of generic text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->