### PR TITLE
feat(task-tray): backgroundable running ops + corrected modal buttons [OS-461]

### DIFF
--- a/.codex/coderabbit-fixes-wip.md
+++ b/.codex/coderabbit-fixes-wip.md
@@ -1,0 +1,60 @@
+# CodeRabbit Fixes WIP
+
+## Context
+
+- Repo: unraid/webgui
+- Branch: feat/backend-task-queue
+- PR: 2665
+- PR URL: https://github.com/unraid/webgui/pull/2665
+- Generated at: 2026-06-18
+
+## Inputs Pulled
+
+- [x] Unresolved robot review threads pulled (7)
+- [x] Top-level robot review notes and PR conversation comments pulled
+- [x] Top-level actionable review-body/PR comments extracted into queue (5 nitpicks)
+- [x] User asked whether to include human review comments
+- [x] Human review comments included in queue: no (user chose robot-only)
+- [x] Existing non-CodeRabbit thread replies checked before adding duplicate feedback (none from bots/humans; only a github-actions test-plugin notice)
+
+## Fix Queue
+
+| Item ID | Type | File | Line | Summary | Status | Link | Evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| CR-001 | thread | BodyInlineJS.php | 214 | XSS in swal title via task.title (html:true) | DONE | https://github.com/unraid/webgui/pull/2665#discussion_r3436502042 | escapeTaskHtml(task.title) in swal title; php -l OK |
+| CR-002 | thread | BodyInlineJS.php | 279-291 | t.id unescaped in onclick handlers | DONE | https://github.com/unraid/webgui/pull/2665#discussion_r3436502054 | safeId=escapeTaskHtml(t.id) used in all 5 handlers; php -l OK |
+| CR-003 | thread | HeadInlineJS.php | 183-192 | createTask silent failure on POST error | DONE | https://github.com/unraid/webgui/pull/2665#discussion_r3436502071 | .fail() hides spinner + error swal; php -l OK |
+| CR-004 | thread | TaskQueue.php | 123 | Command injection via unescaped $args in bash -c | DONE | https://github.com/unraid/webgui/pull/2665#discussion_r3436502088 | escapeshellarg() over whole bash -c payload (preserves multi-arg word-split); reply posted explaining deviation from literal suggestion; php -l OK |
+| CR-005 | thread | nchan/tasks | 27-30 | Empty/non-numeric PID breaks /proc liveness check | DONE | https://github.com/unraid/webgui/pull/2665#discussion_r3436502115 | ctype_digit() guard before file_exists; php -l OK |
+| CR-006 | thread | default-base.css | 1919-1924 | Add min-width:0 for reliable ellipsis | DONE | https://github.com/unraid/webgui/pull/2665#discussion_r3436502123 | min-width:0 added to .op-tray .op-title |
+| CR-007 | thread | nchan/tasks | 62-67 | Daemon sleeps forever on queued-only restart | DONE | https://github.com/unraid/webgui/pull/2665#discussion_r3437357364 | queued-without-running recovery pass before advance/active check; php -l OK |
+| RVW-001 | review-body | TaskQueue.php | 147-177 | Race: concurrent create/launch can break one-running-per-type | DONE | https://github.com/unraid/webgui/pull/2665#pullrequestreview-4525730471 | per-type flock around dedupe->create->launch; php -l OK |
+| RVW-002 | review-body | TaskCommand.php | 35-51 | abort/dismiss return no JSON body | BLOCKED | https://github.com/unraid/webgui/pull/2665#pullrequestreview-4525730471 | Declined: response body is unused; canonical success signal is the `tasks` nchan broadcast. Adding unused API surface conflicts with no-speculative-contract policy. Reply: https://github.com/unraid/webgui/pull/2665#issuecomment-4745856704 |
+| RVW-003 | review-body | TaskCommand.php | 38-44 | Validate PID numeric before kill | DONE | https://github.com/unraid/webgui/pull/2665#pullrequestreview-4525730471 | ctype_digit()+(int)>1 guard before kill; php -l OK |
+| RVW-004 | review-body | nchan/tasks | 32-37 | _ERROR_ marker substring false positives | DONE | https://github.com/unraid/webgui/pull/2665#pullrequestreview-4525730471 | match _ERROR_ as discrete \x1e record (canonical sentinel, same as routeMessage); reads tail in PHP, removing exec last-line fragility; php -l OK |
+| RVW-005 | review-body | BodyInlineJS.php | 126-177 | Unescaped HTML in nchan message rendering | BLOCKED | https://github.com/unraid/webgui/pull/2665#pullrequestreview-4525730471 | Declined: renderMessage is a deliberate HTML/span protocol (addToID injects `<span id=...>`); blanket escaping breaks the live-log structure. Data originates from trusted server-side processes on a server-controlled channel, not untrusted client input. Reply posted. |
+
+## Execution Log
+
+1. CR-001 swal title — escaped task.title with escapeTaskHtml. DONE.
+2. CR-002 onclick ids — introduced safeId=escapeTaskHtml(t.id), used everywhere. DONE.
+3. CR-003 createTask — added .fail() with spinner hide + error swal. DONE.
+4. CR-004 command injection — wrapped the whole `sleep .3 && $name $args$suffix` payload in escapeshellarg() (superior to literal escapeshellarg($args), which would collapse multiple space-separated args). DONE + thread reply.
+5. CR-005 task_pid_alive — ctype_digit() numeric guard. DONE.
+6. CR-007 queued-only recovery — added recovery pass + $changed=true so launch publishes. DONE.
+7. RVW-004 _ERROR_ — discrete \x1e record match read in PHP. DONE.
+8. CR-006 CSS — min-width:0. DONE.
+9. RVW-001 race — per-type flock around critical section, released on every return path. DONE.
+10. RVW-003 PID kill — ctype_digit()+(int)>1. DONE.
+11. RVW-002 — BLOCKED (unused response surface). Reply posted.
+12. RVW-005 — BLOCKED (deliberate HTML protocol, trusted source). Reply posted.
+
+Validation: `php -l` clean on TaskQueue.php, TaskCommand.php, nchan/tasks, BodyInlineJS.php, HeadInlineJS.php.
+
+## Final Checks
+
+- [x] Queue reviewed: no `TODO` left
+- [x] Remaining `BLOCKED` items documented with reason (RVW-002, RVW-005)
+- [x] Every `BLOCKED`/not-valid CodeRabbit suggestion has a PR reply with the reason it was not applied
+- [x] Re-pulled CodeRabbit threads and reviews
+- [x] No unhandled top-level review-body comment remains

--- a/emhttp/plugins/dynamix.plugin.manager/Plugins.page
+++ b/emhttp/plugins/dynamix.plugin.manager/Plugins.page
@@ -4,6 +4,7 @@ Title="Installed Plugins"
 Tag="icon-plugins"
 Tabs="true"
 Code="e944"
+Markdown="false"
 ---
 <?PHP
 /* Copyright 2005-2023, Lime Technology

--- a/emhttp/plugins/dynamix.plugin.manager/Plugins.page
+++ b/emhttp/plugins/dynamix.plugin.manager/Plugins.page
@@ -141,8 +141,34 @@ function loadlist(id,check) {
     }
     $('#plugin_table').trigger('update');
     $('#checkall').find('input').prop('disabled',false);
+    syncPluginButtons();
   });
 }
+// Reflect in-flight plugin tasks on the row buttons: while the backend task queue
+// has a running/queued task for a plugin, show its update/install button as
+// "Upgrading" and disabled, so minimizing the progress modal can't leave a stale,
+// clickable button. Driven by the live task list, so it survives modal minimize,
+// list reloads and full page reloads.
+function pluginTaskRunning(arg) {
+  if (typeof taskList === 'undefined' || !arg) return false;
+  for (var i=0;i<taskList.length;i++) {
+    var t = taskList[i];
+    if (t && t.type=='plugins' && (t.status=='running'||t.status=='queued') && t.cmd && t.cmd.indexOf(arg)>=0) return true;
+  }
+  return false;
+}
+function syncPluginButtons() {
+  $('#plugin_table input.update, #plugin_table input.install').each(function(){
+    var $b = $(this), arg = $b.attr('data');
+    if (pluginTaskRunning(arg)) {
+      if ($b.data('busy')===undefined) $b.data('busy', $b.val());
+      $b.prop('disabled', true).val("_(Upgrading)_");
+    } else if ($b.data('busy')!==undefined) {
+      $b.prop('disabled', false).val($b.data('busy')).removeData('busy');
+    }
+  });
+}
+window.onTaskListChanged = syncPluginButtons;
 $(function() {
   initlist();
   $('.tabs-container').append("<span id='checkall' class='status vhshift'><input type='button' value=\"_(Check For Updates)_\" onclick='openPlugin(\"checkall\",\"_(Plugin Update Check)_\",\":return\")' disabled></span>");

--- a/emhttp/plugins/dynamix.plugin.manager/Plugins.page
+++ b/emhttp/plugins/dynamix.plugin.manager/Plugins.page
@@ -141,34 +141,25 @@ function loadlist(id,check) {
     }
     $('#plugin_table').trigger('update');
     $('#checkall').find('input').prop('disabled',false);
-    syncPluginButtons();
   });
 }
-// Reflect in-flight plugin tasks on the row buttons: while the backend task queue
-// has a running/queued task for a plugin, show its update/install button as
-// "Upgrading" and disabled, so minimizing the progress modal can't leave a stale,
-// clickable button. Driven by the live task list, so it survives modal minimize,
-// list reloads and full page reloads.
-function pluginTaskRunning(arg) {
-  if (typeof taskList === 'undefined' || !arg) return false;
-  for (var i=0;i<taskList.length;i++) {
-    var t = taskList[i];
-    if (t && t.type=='plugins' && (t.status=='running'||t.status=='queued') && t.cmd && t.cmd.indexOf(arg)>=0) return true;
-  }
-  return false;
-}
-function syncPluginButtons() {
-  $('#plugin_table input.update, #plugin_table input.install').each(function(){
-    var $b = $(this), arg = $b.attr('data');
-    if (pluginTaskRunning(arg)) {
-      if ($b.data('busy')===undefined) $b.data('busy', $b.val());
-      $b.prop('disabled', true).val("_(Upgrading)_");
-    } else if ($b.data('busy')!==undefined) {
-      $b.prop('disabled', false).val($b.data('busy')).removeData('busy');
+// Row buttons are rendered server-side (make_link) from the task queue: a plugin
+// with a running/queued task shows "Upgrading" (disabled). Refresh the rows when
+// the set of active plugin tasks changes, so that state appears/clears live —
+// loadlist(null,1) re-renders just the status cells (no network re-check, no
+// flickery full reload). The task queue is the single source of truth.
+var _plgTaskSig = '';
+function onPluginTasksChanged() {
+  var sig = '';
+  if (typeof taskList !== 'undefined') {
+    for (var i=0;i<taskList.length;i++) {
+      var t = taskList[i];
+      if (t && t.type=='plugins' && (t.status=='running'||t.status=='queued')) sig += t.id+';';
     }
-  });
+  }
+  if (sig !== _plgTaskSig) { _plgTaskSig = sig; loadlist(null,1); }
 }
-window.onTaskListChanged = syncPluginButtons;
+window.onTaskListChanged = onPluginTasksChanged;
 $(function() {
   initlist();
   $('.tabs-container').append("<span id='checkall' class='status vhshift'><input type='button' value=\"_(Check For Updates)_\" onclick='openPlugin(\"checkall\",\"_(Plugin Update Check)_\",\":return\")' disabled></span>");

--- a/emhttp/plugins/dynamix.plugin.manager/include/PluginHelpers.php
+++ b/emhttp/plugins/dynamix.plugin.manager/include/PluginHelpers.php
@@ -13,6 +13,18 @@
 <?
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/Wrappers.php";
+require_once "$docroot/plugins/dynamix/include/TaskQueue.php";
+
+// true when the backend task queue has a running/queued task targeting this .plg
+// (the task queue is the source of truth for an in-flight install/update)
+function plugin_task_busy($arg) {
+  if (!$arg) return false;
+  foreach (task_list() as $t) {
+    if ($t['type']==='plugins' && in_array($t['status'],['running','queued'],true)
+        && in_array($arg, preg_split('/\s+/', trim($t['cmd'])), true)) return true;
+  }
+  return false;
+}
 
 // Invoke the plugin command with indicated method
 function plugin($method, $arg = '', $dontCache = false) {
@@ -71,7 +83,10 @@ function make_link($method, $arg, $extra='') {
     $cmd  = "plugin $method $arg".($extra?" $extra":"");
     $func = "loadlist";
   }
-  if (is_file("/tmp/plugins/pluginPending/$arg") && !$check) {
+  if (in_array($method,['update','install']) && plugin_task_busy($arg)) {
+    $label = $method=='install' ? _('Installing') : _('Upgrading');
+    return "<span class='orange-text'><i class='fa fa-hourglass-o fa-fw'></i>&nbsp;$label</span>";
+  } elseif (is_file("/tmp/plugins/pluginPending/$arg") && !$check) {
     return "<span class='orange-text'><i class='fa fa-hourglass-o fa-fw'></i>&nbsp;"._('pending')."</span>";
   } else {
     return "$check<input type='button' id='$id' data='$arg' class='$method' value=\""._(ucfirst($method))."\" onclick='openInstall(\"$cmd\",\""._(ucwords($method)." Plugin")."\",\"$plg\",\"$func\");'$disabled>";

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -227,12 +227,12 @@ function foregroundTask(id) {
     if (foregroundTaskId===id) { foregroundTaskId=null; foregroundType=null; }
     stopAllTypeChannels();
     clearProgressDots();
-    $('.sweet-alert').hide('fast').removeClass('nchan');
     var fresh = taskById(id);
     if (fresh && (fresh.status=='done'||fresh.status=='error')) { fireTaskCallback(fresh); dismissTask(id); }
+    nchanCloseModal(false);   // swal closes via closeOnConfirm; this just cleans up
     trayRender();
   });
-  $('.sweet-alert').addClass('nchan');
+  $('.sweet-alert').addClass('nchan').css('pointer-events','');
   // a persistent top-corner control that just closes this window, leaving the
   // task in the tray: while running it reads as "minimize" (the task keeps
   // running); once finished it reads as "close" (the task stays as a finished
@@ -327,12 +327,26 @@ function trayRender() {
 
 // minimize the foreground modal: drop the live view but leave the task running
 // in the backend (the tray keeps tracking it). Backgrounding, not aborting.
+// Fade the modal out with its .nchan styling intact, then strip the class once
+// it's gone. Removing .nchan while the modal is still visible snaps it back to
+// the default swal look for a frame (the "flash"). pointer-events:none keeps the
+// fading (now-invisible but still laid-out) modal from eating clicks; the guard
+// avoids stripping .nchan off a modal that was reopened in the meantime.
+function nchanCloseModal(doClose) {
+  $('.sweet-alert').css('pointer-events','none');
+  if (doClose && typeof swal!=='undefined' && swal.close) swal.close();
+  setTimeout(function(){
+    var $sa = $('.sweet-alert');
+    $sa.css('pointer-events','');
+    if (!foregroundTaskId) $sa.removeClass('nchan');
+  }, 350);
+}
+
 function minimizeForegroundTask() {
   if (foregroundTaskId) { foregroundTaskId=null; foregroundType=null; }
   stopAllTypeChannels();
   clearProgressDots();
-  $('.sweet-alert').removeClass('nchan');
-  if (typeof swal!=='undefined' && swal.close) swal.close();
+  nchanCloseModal(true);
   trayRender();
 }
 

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -238,8 +238,11 @@ function foregroundTask(id) {
   // running); once finished it reads as "close" (the task stays as a finished
   // tile). Removal is the separate, primary Dismiss action. openDone/openError
   // swap the glyph/tooltip to the finished form.
-  var closeIcon = finished ? 'fa-times' : 'fa-minus';
-  var closeTip  = finished ? "<?=_('Close - the task stays in the tray')?>" : "<?=_('Minimize - keeps running in the background')?>";
+  // the corner control is ALWAYS minimize (it tucks the modal away and keeps the
+  // task in the tray); removal is the separate Dismiss button. Keeping one icon
+  // avoids the confusing minus->x swap where the "x" actually just minimized.
+  var closeIcon = 'fa-minus';
+  var closeTip  = finished ? "<?=_('Minimize - keeps it in the tray')?>" : "<?=_('Minimize - keeps running in the background')?>";
   $('.sweet-alert .nchan-close').remove();
   $('.sweet-alert').append("<a class='nchan-close' title=\""+closeTip+"\" onclick='minimizeForegroundTask()'><i class='fa "+closeIcon+" fa-fw'></i></a>");
   $('pre#swaltext').html('');

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -211,22 +211,32 @@ function foregroundTask(id) {
   foregroundType = task.type;
   stopAllTypeChannels();
   clearProgressDots();
-  var showConfirm = task.type=='plugins' ? task.button==0 : task.button!=0;
-  var disable     = task.type=='plugins' ? task.button!=0 : task.button==0;
+  // Drive the modal by task status, not the per-type `button` flag (which made
+  // docker ops hide the Close button while running and disabled the confirm
+  // button, surfacing SweetAlert's la-ball-fall "bouncing dots" loader):
+  //   running  -> a top-corner minimize (below) backgrounds it; no disabled
+  //               button, so the bouncing-dots loader never shows. The spinning
+  //               title icon is the in-progress indicator.
+  //   finished -> a primary Dismiss button clears the task from the tray.
+  var finished    = task.status=='done' || task.status=='error';
   var titleState  = task.status=='done'  ? "<?=_('Finished')?>"
                   : task.status=='error' ? "<?=_('Error')?>"
                   : "<?=_('In Progress')?> <i class='fa fa-refresh fa-spin'></i>";
-  swal({title:escapeTaskHtml(task.title) + ' - <span id="pluginProgressTitle">'+titleState+'</span>',text:"<pre id='swaltext'></pre><hr>",html:true,animation:'none',showConfirmButton:showConfirm,confirmButtonText:"<?=_('Close')?>"},function(close){
+  swal({title:escapeTaskHtml(task.title) + ' - <span id="pluginProgressTitle">'+titleState+'</span>',text:"<pre id='swaltext'></pre><hr>",html:true,animation:'none',showConfirmButton:finished,confirmButtonText:"<?=_('Dismiss')?>"},function(close){
+    // confirm/Dismiss (or Esc): background while running, clear once finished
     if (foregroundTaskId===id) { foregroundTaskId=null; foregroundType=null; }
     stopAllTypeChannels();
     clearProgressDots();
     $('.sweet-alert').hide('fast').removeClass('nchan');
     var fresh = taskById(id);
-    if (fresh && (fresh.status=='done'||fresh.status=='error')) fireTaskCallback(fresh);
+    if (fresh && (fresh.status=='done'||fresh.status=='error')) { fireTaskCallback(fresh); dismissTask(id); }
     trayRender();
   });
   $('.sweet-alert').addClass('nchan');
-  $('button.confirm').prop('disabled',disable);
+  // a top-corner minimize for the running phase: backgrounds the task (it keeps
+  // running in the tray) without aborting; openDone/openError swap it for Dismiss
+  $('.sweet-alert .nchan-close').remove();
+  if (!finished) $('.sweet-alert').append("<a class='nchan-close' title=\"<?=_('Minimize - keeps running in the background')?>\" onclick='minimizeForegroundTask()'><i class='fa fa-window-minimize fa-fw'></i></a>");
   $('pre#swaltext').html('');
   $.get(TASK_ENDPOINT,{action:'log',id:id},function(logdata){
     if (foregroundTaskId!==id) return; // user moved on while loading
@@ -305,6 +315,17 @@ function trayRender() {
     header = "<div class='op-tray-head'><a class='op-act' onclick='clearFinishedTasks()' title=\"<?=_('Clear finished tasks')?>\"><i class='fa fa-check-circle-o fa-fw'></i> <?=_('Clear finished')?></a></div>";
   }
   $tray.html(header + rows).show();
+}
+
+// minimize the foreground modal: drop the live view but leave the task running
+// in the backend (the tray keeps tracking it). Backgrounding, not aborting.
+function minimizeForegroundTask() {
+  if (foregroundTaskId) { foregroundTaskId=null; foregroundType=null; }
+  stopAllTypeChannels();
+  clearProgressDots();
+  $('.sweet-alert').removeClass('nchan');
+  if (typeof swal!=='undefined' && swal.close) swal.close();
+  trayRender();
 }
 
 function cancelTask(id) { $.post(TASK_ENDPOINT,{action:'abort',id:id}); }

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -332,6 +332,11 @@ function trayRender() {
     header = "<div class='op-tray-head'><a class='op-act' onclick='clearFinishedTasks()' title=\"<?=_('Clear finished tasks')?>\"><i class='fa fa-check-circle-o fa-fw'></i> <?=_('Clear finished')?></a></div>";
   }
   $tray.html(header + rows).show();
+  // On mobile the tray is a horizontal carousel; default it to the newest task
+  // (rightmost) rather than the leftmost "Clear finished" header.
+  if (window.matchMedia && window.matchMedia('(max-width: 767px)').matches) {
+    $tray.scrollLeft($tray[0].scrollWidth);
+  }
 }
 
 // minimize the foreground modal: drop the live view but leave the task running

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -219,10 +219,13 @@ function foregroundTask(id) {
   //               title icon is the in-progress indicator.
   //   finished -> a primary Dismiss button clears the task from the tray.
   var finished    = task.status=='done' || task.status=='error';
-  var titleState  = task.status=='done'  ? "<?=_('Finished')?>"
-                  : task.status=='error' ? "<?=_('Error')?>"
-                  : "<?=_('In Progress')?> <i class='fa fa-refresh fa-spin'></i>";
-  swal({title:escapeTaskHtml(task.title) + '<span id="pluginProgressTitle">'+titleState+'</span>',text:"<pre id='swaltext'></pre><hr>",html:true,animation:'none',showConfirmButton:finished,confirmButtonText:"<?=_('Dismiss')?>"},function(close){
+  // status renders as a colored "state" strip below the title (see .nchan-state)
+  var stateCls    = task.status=='done'  ? 'nchan-done'
+                  : task.status=='error' ? 'nchan-error' : 'nchan-running';
+  var stateHtml   = task.status=='done'  ? "<i class='fa fa-check fa-fw'></i> <?=_('Finished')?>"
+                  : task.status=='error' ? "<i class='fa fa-warning fa-fw'></i> <?=_('Error')?>"
+                  : "<i class='fa fa-refresh fa-spin fa-fw'></i> <?=_('In Progress')?>";
+  swal({title:escapeTaskHtml(task.title),text:"<pre id='swaltext'></pre><hr>",html:true,animation:'none',showConfirmButton:finished,confirmButtonText:"<?=_('Dismiss')?>"},function(close){
     // confirm/Dismiss (or Esc): background while running, clear once finished
     if (foregroundTaskId===id) { foregroundTaskId=null; foregroundType=null; }
     stopAllTypeChannels();
@@ -233,6 +236,9 @@ function foregroundTask(id) {
     trayRender();
   });
   $('.sweet-alert').addClass('nchan').css('pointer-events','');
+  // colored state strip between the title and the log (openDone/openError recolor it)
+  $('.sweet-alert .nchan-state').remove();
+  $('.sweet-alert > h2').after("<div id='pluginProgressTitle' class='nchan-state "+stateCls+"'>"+stateHtml+"</div>");
   // a persistent top-corner control that just closes this window, leaving the
   // task in the tray: while running it reads as "minimize" (the task keeps
   // running); once finished it reads as "close" (the task stays as a finished

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -281,7 +281,7 @@ function onTaskListUpdate() {
           fireTaskCallback(t);
         }
       } else if (t.status=='running' && foregroundTaskId==t.id) {
-        $('#pluginProgressTitle').html("<?=_('In Progress')?> <i class='fa fa-refresh fa-spin'></i>");
+        $('#pluginProgressTitle').attr('class','nchan-state nchan-running').html("<i class='fa fa-refresh fa-spin fa-fw'></i> <?=_('In Progress')?>");
         nchanStart(nchanByType[t.type]);
       }
     }
@@ -289,6 +289,9 @@ function onTaskListUpdate() {
   }
   for (var id in taskPrev) if (!taskById(id)) delete taskPrev[id];
   trayRender();
+  // let the current page react to task changes (e.g. Plugins page disables its
+  // update buttons while a plugin task is running). No-op where undefined.
+  if (typeof window.onTaskListChanged === 'function') { try { window.onTaskListChanged(); } catch(e) {} }
 }
 
 var taskChannel = new NchanSubscriber('/sub/tasks',{subscriber:'websocket', reconnectTimeout:5000});

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -300,14 +300,27 @@ taskChannel.on('message', function(msg){
   onTaskListUpdate();
 });
 
+// Tray expand/collapse state (mobile only). On desktop the tray is always a
+// full vertical stack; on mobile it collapses to a single tappable card with
+// the rest peeking behind it (the iOS/Android grouped-notification pattern).
+var trayExpanded = false;
+function isMobileTray() {
+  return !!(window.matchMedia && window.matchMedia('(max-width: 767px)').matches);
+}
+function expandTray() { trayExpanded = true; trayRender(); }
+function collapseTray() { trayExpanded = false; trayRender(); }
+
 // render the task tray
 function trayRender() {
   var $tray = $('#opTray');
   if (!$tray.length) return;
-  if (!taskList.length) { $tray.hide().empty(); return; }
-  var rows = '', finished = 0;
-  for (var i=0;i<taskList.length;i++) {
+  if (!taskList.length) { $tray.hide().empty(); trayExpanded = false; return; }
+  var rows = '', finished = 0, count = taskList.length;
+  // newest first: the most recent task sits at the top of the stack and is the
+  // single card shown when the mobile tray is collapsed.
+  for (var i=taskList.length-1;i>=0;i--) {
     var t = taskList[i], icon, actions='', safeId = escapeTaskHtml(t.id);
+    var top = (i==taskList.length-1) ? ' op-top' : '';
     if (t.status=='done' || t.status=='error') finished++;
     var show = "<a class='op-act' onclick='foregroundTask(\""+safeId+"\")' title=\"<?=_('Show')?>\"><i class='fa fa-window-maximize fa-fw'></i></a>";
     if (t.status=='running') {
@@ -323,20 +336,49 @@ function trayRender() {
       icon = "<i class='fa fa-warning fa-fw orange-text'></i>";
       actions = show + "<a class='op-act' onclick='dismissTask(\""+safeId+"\")' title=\"<?=_('Dismiss')?>\"><i class='fa fa-times fa-fw'></i></a>";
     }
-    rows += "<div class='op-task op-"+t.status+"'><span class='op-icon'>"+icon+"</span><span class='op-title'>"+escapeTaskHtml(t.title)+"</span><span class='op-actions'>"+actions+"</span></div>";
+    rows += "<div class='op-task op-"+t.status+top+"'><span class='op-icon'>"+icon+"</span><span class='op-title'>"+escapeTaskHtml(t.title)+"</span><span class='op-actions'>"+actions+"</span></div>";
   }
-  // header with a bulk "Clear finished" action, shown only when there is more
-  // than one finished task to clear (a lone one is easy to dismiss directly)
-  var header = '';
-  if (finished > 1) {
-    header = "<div class='op-tray-head'><a class='op-act' onclick='clearFinishedTasks()' title=\"<?=_('Clear finished tasks')?>\"><i class='fa fa-check-circle-o fa-fw'></i> <?=_('Clear finished')?></a></div>";
+  // Header (only when more than one task): carries the count, a bulk "Clear
+  // finished" action when there is more than one finished task, and — on the
+  // mobile expanded stack — a chevron to collapse back to the single card.
+  var head = '';
+  if (count > 1) {
+    head = "<div class='op-tray-head'>";
+    head += "<span class='op-tray-count'>"+count+" <?=_('operations')?></span>";
+    head += "<span class='op-tray-head-acts'>";
+    if (finished > 1) {
+      head += "<a class='op-act' onclick='clearFinishedTasks()' title=\"<?=_('Clear finished tasks')?>\"><i class='fa fa-check-circle-o fa-fw'></i> <?=_('Clear finished')?></a>";
+    }
+    head += "<a class='op-act op-collapse' onclick='collapseTray()' title=\"<?=_('Collapse')?>\"><i class='fa fa-chevron-down fa-fw'></i></a>";
+    head += "</span></div>";
   }
-  $tray.html(header + rows).show();
-  // On mobile the tray is a horizontal carousel; default it to the newest task
-  // (rightmost) rather than the leftmost "Clear finished" header.
-  if (window.matchMedia && window.matchMedia('(max-width: 767px)').matches) {
-    $tray.scrollLeft($tray[0].scrollWidth);
-  }
+  // Collapsed badge: a count pill on the top card so a stacked group reads as
+  // "N operations" before it's expanded.
+  var badge = (count > 1) ? "<span class='op-stack-badge' onclick='expandTray()'>"+count+"</span>" : "";
+  // State classes drive the CSS: collapsed shows just the top card with the
+  // others peeking; expanded shows the full vertical list with the header.
+  var mobile = isMobileTray();
+  var collapsed = mobile && !trayExpanded && count > 1;
+  $tray.removeClass('op-collapsed op-expanded op-multi');
+  if (count > 1) $tray.addClass('op-multi');
+  $tray.addClass(collapsed ? 'op-collapsed' : 'op-expanded');
+  $tray.html(head + rows + badge).show();
+}
+
+// When the mobile tray is collapsed into a single stacked card, a tap anywhere
+// on it (other than a row action) expands the full list. Delegated so it
+// survives trayRender() re-renders.
+$(document).on('click', '#opTray.op-collapsed', function(e) {
+  if ($(e.target).closest('.op-act').length) return;
+  expandTray();
+});
+// Re-evaluate collapsed/expanded layout when crossing the mobile breakpoint so
+// the tray doesn't get stuck in a mobile-only collapsed state on resize.
+if (window.matchMedia) {
+  var trayMql = window.matchMedia('(max-width: 767px)');
+  var onTrayBreakpoint = function(){ if (!isMobileTray()) trayExpanded = false; trayRender(); };
+  if (trayMql.addEventListener) trayMql.addEventListener('change', onTrayBreakpoint);
+  else if (trayMql.addListener) trayMql.addListener(onTrayBreakpoint);
 }
 
 // minimize the foreground modal: drop the live view but leave the task running

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -233,10 +233,15 @@ function foregroundTask(id) {
     trayRender();
   });
   $('.sweet-alert').addClass('nchan');
-  // a top-corner minimize for the running phase: backgrounds the task (it keeps
-  // running in the tray) without aborting; openDone/openError swap it for Dismiss
+  // a persistent top-corner control that just closes this window, leaving the
+  // task in the tray: while running it reads as "minimize" (the task keeps
+  // running); once finished it reads as "close" (the task stays as a finished
+  // tile). Removal is the separate, primary Dismiss action. openDone/openError
+  // swap the glyph/tooltip to the finished form.
+  var closeIcon = finished ? 'fa-times' : 'fa-window-minimize';
+  var closeTip  = finished ? "<?=_('Close - the task stays in the tray')?>" : "<?=_('Minimize - keeps running in the background')?>";
   $('.sweet-alert .nchan-close').remove();
-  if (!finished) $('.sweet-alert').append("<a class='nchan-close' title=\"<?=_('Minimize - keeps running in the background')?>\" onclick='minimizeForegroundTask()'><i class='fa fa-window-minimize fa-fw'></i></a>");
+  $('.sweet-alert').append("<a class='nchan-close' title=\""+closeTip+"\" onclick='minimizeForegroundTask()'><i class='fa "+closeIcon+" fa-fw'></i></a>");
   $('pre#swaltext').html('');
   $.get(TASK_ENDPOINT,{action:'log',id:id},function(logdata){
     if (foregroundTaskId!==id) return; // user moved on while loading

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -238,7 +238,7 @@ function foregroundTask(id) {
   // running); once finished it reads as "close" (the task stays as a finished
   // tile). Removal is the separate, primary Dismiss action. openDone/openError
   // swap the glyph/tooltip to the finished form.
-  var closeIcon = finished ? 'fa-times' : 'fa-window-minimize';
+  var closeIcon = finished ? 'fa-times' : 'fa-minus';
   var closeTip  = finished ? "<?=_('Close - the task stays in the tray')?>" : "<?=_('Minimize - keeps running in the background')?>";
   $('.sweet-alert .nchan-close').remove();
   $('.sweet-alert').append("<a class='nchan-close' title=\""+closeTip+"\" onclick='minimizeForegroundTask()'><i class='fa "+closeIcon+" fa-fw'></i></a>");

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -216,7 +216,7 @@ function foregroundTask(id) {
   var titleState  = task.status=='done'  ? "<?=_('Finished')?>"
                   : task.status=='error' ? "<?=_('Error')?>"
                   : "<?=_('In Progress')?> <i class='fa fa-refresh fa-spin'></i>";
-  swal({title:task.title + ' - <span id="pluginProgressTitle">'+titleState+'</span>',text:"<pre id='swaltext'></pre><hr>",html:true,animation:'none',showConfirmButton:showConfirm,confirmButtonText:"<?=_('Close')?>"},function(close){
+  swal({title:escapeTaskHtml(task.title) + ' - <span id="pluginProgressTitle">'+titleState+'</span>',text:"<pre id='swaltext'></pre><hr>",html:true,animation:'none',showConfirmButton:showConfirm,confirmButtonText:"<?=_('Close')?>"},function(close){
     if (foregroundTaskId===id) { foregroundTaskId=null; foregroundType=null; }
     stopAllTypeChannels();
     clearProgressDots();
@@ -280,21 +280,21 @@ function trayRender() {
   if (!taskList.length) { $tray.hide().empty(); return; }
   var rows = '', finished = 0;
   for (var i=0;i<taskList.length;i++) {
-    var t = taskList[i], icon, actions='';
+    var t = taskList[i], icon, actions='', safeId = escapeTaskHtml(t.id);
     if (t.status=='done' || t.status=='error') finished++;
-    var show = "<a class='op-act' onclick='foregroundTask(\""+t.id+"\")' title=\"<?=_('Show')?>\"><i class='fa fa-window-maximize fa-fw'></i></a>";
+    var show = "<a class='op-act' onclick='foregroundTask(\""+safeId+"\")' title=\"<?=_('Show')?>\"><i class='fa fa-window-maximize fa-fw'></i></a>";
     if (t.status=='running') {
       icon = "<i class='fa fa-circle-o-notch fa-spin fa-fw'></i>";
-      actions = show + "<a class='op-act' onclick='confirmAbortTask(\""+t.id+"\")' title=\"<?=_('Abort')?>\"><i class='fa fa-stop-circle fa-fw'></i></a>";
+      actions = show + "<a class='op-act' onclick='confirmAbortTask(\""+safeId+"\")' title=\"<?=_('Abort')?>\"><i class='fa fa-stop-circle fa-fw'></i></a>";
     } else if (t.status=='queued') {
       icon = "<i class='fa fa-clock-o fa-fw'></i>";
-      actions = "<a class='op-act' onclick='cancelTask(\""+t.id+"\")' title=\"<?=_('Cancel')?>\"><i class='fa fa-times fa-fw'></i></a>";
+      actions = "<a class='op-act' onclick='cancelTask(\""+safeId+"\")' title=\"<?=_('Cancel')?>\"><i class='fa fa-times fa-fw'></i></a>";
     } else if (t.status=='done') {
       icon = "<i class='fa fa-check fa-fw green-text'></i>";
-      actions = show + "<a class='op-act' onclick='dismissTask(\""+t.id+"\")' title=\"<?=_('Dismiss')?>\"><i class='fa fa-times fa-fw'></i></a>";
+      actions = show + "<a class='op-act' onclick='dismissTask(\""+safeId+"\")' title=\"<?=_('Dismiss')?>\"><i class='fa fa-times fa-fw'></i></a>";
     } else {
       icon = "<i class='fa fa-warning fa-fw orange-text'></i>";
-      actions = show + "<a class='op-act' onclick='dismissTask(\""+t.id+"\")' title=\"<?=_('Dismiss')?>\"><i class='fa fa-times fa-fw'></i></a>";
+      actions = show + "<a class='op-act' onclick='dismissTask(\""+safeId+"\")' title=\"<?=_('Dismiss')?>\"><i class='fa fa-times fa-fw'></i></a>";
     }
     rows += "<div class='op-task op-"+t.status+"'><span class='op-icon'>"+icon+"</span><span class='op-title'>"+escapeTaskHtml(t.title)+"</span><span class='op-actions'>"+actions+"</span></div>";
   }

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -222,7 +222,7 @@ function foregroundTask(id) {
   var titleState  = task.status=='done'  ? "<?=_('Finished')?>"
                   : task.status=='error' ? "<?=_('Error')?>"
                   : "<?=_('In Progress')?> <i class='fa fa-refresh fa-spin'></i>";
-  swal({title:escapeTaskHtml(task.title) + ' - <span id="pluginProgressTitle">'+titleState+'</span>',text:"<pre id='swaltext'></pre><hr>",html:true,animation:'none',showConfirmButton:finished,confirmButtonText:"<?=_('Dismiss')?>"},function(close){
+  swal({title:escapeTaskHtml(task.title) + '<span id="pluginProgressTitle">'+titleState+'</span>',text:"<pre id='swaltext'></pre><hr>",html:true,animation:'none',showConfirmButton:finished,confirmButtonText:"<?=_('Dismiss')?>"},function(close){
     // confirm/Dismiss (or Esc): background while running, clear once finished
     if (foregroundTaskId===id) { foregroundTaskId=null; foregroundType=null; }
     stopAllTypeChannels();

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
@@ -248,9 +248,9 @@ function openAlert(cmd,title,func) {
 function openDone(data) {
   if (data == '_DONE_') {
     $('div.spinner.fixed').hide();
-    // task finished: the corner control becomes a plain "close" (the task stays
-    // in the tray); the primary Dismiss button removes it on confirm
-    $('.sweet-alert .nchan-close').attr('title',"<?=_('Close - the task stays in the tray')?>").find('i').attr('class','fa fa-times fa-fw');
+    // task finished: corner stays minimize (keeps the finished tile in the tray);
+    // the primary Dismiss button is what removes it
+    $('.sweet-alert .nchan-close').attr('title',"<?=_('Minimize - keeps it in the tray')?>");
     $('button.confirm').text("<?=_('Dismiss')?>").prop('disabled',false).show();
     if (typeof ca_done_override !== 'undefined') {
       if (ca_done_override == true) {
@@ -267,7 +267,7 @@ function openDone(data) {
 function openError(data) {
   if (data == '_ERROR_') {
     $('div.spinner.fixed').hide();
-    $('.sweet-alert .nchan-close').attr('title',"<?=_('Close - the task stays in the tray')?>").find('i').attr('class','fa fa-times fa-fw');
+    $('.sweet-alert .nchan-close').attr('title',"<?=_('Minimize - keeps it in the tray')?>");
     $('button.confirm').text("<?=_('Dismiss')?>").prop('disabled',false).show();
     $('#pluginProgressTitle').text("<?=_('Error');?>");
     return true;

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
@@ -201,7 +201,10 @@ function createTask(type,cmd,title,plg,func,start,button) {
       if (typeof trayRender==='function') trayRender();
     }
     foregroundTask(res.id);
-  },'json');
+  },'json').fail(function() {
+    $('div.spinner.fixed').hide();
+    swal({title:"<?=_('Error')?>",text:"<?=_('Failed to start background operation')?>",type:'error',html:true,animation:'none'});
+  });
 }
 
 // abortOperation(pid) retained for backward compatibility: map the pid to its

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
@@ -258,7 +258,7 @@ function openDone(data) {
         ca_done_override = false;
       }
     }
-    $('#pluginProgressTitle').text("<?=_('Finished');?>");
+    $('#pluginProgressTitle').attr('class','nchan-state nchan-done').html("<i class='fa fa-check fa-fw'></i> <?=_('Finished')?>");
     return true;
   }
   return false;
@@ -269,7 +269,7 @@ function openError(data) {
     $('div.spinner.fixed').hide();
     $('.sweet-alert .nchan-close').attr('title',"<?=_('Minimize - keeps it in the tray')?>");
     $('button.confirm').text("<?=_('Dismiss')?>").prop('disabled',false).show();
-    $('#pluginProgressTitle').text("<?=_('Error');?>");
+    $('#pluginProgressTitle').attr('class','nchan-state nchan-error').html("<i class='fa fa-warning fa-fw'></i> <?=_('Error')?>");
     return true;
   }
   return false;

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
@@ -251,6 +251,7 @@ function openDone(data) {
     // task finished: corner stays minimize (keeps the finished tile in the tray);
     // the primary Dismiss button is what removes it
     $('.sweet-alert .nchan-close').attr('title',"<?=_('Minimize - keeps it in the tray')?>");
+    $('.sweet-alert').attr('data-has-confirm-button','true');   // un-hide the footer (CSS keys off this)
     $('button.confirm').text("<?=_('Dismiss')?>").prop('disabled',false).show();
     if (typeof ca_done_override !== 'undefined') {
       if (ca_done_override == true) {
@@ -268,6 +269,7 @@ function openError(data) {
   if (data == '_ERROR_') {
     $('div.spinner.fixed').hide();
     $('.sweet-alert .nchan-close').attr('title',"<?=_('Minimize - keeps it in the tray')?>");
+    $('.sweet-alert').attr('data-has-confirm-button','true');   // un-hide the footer (CSS keys off this)
     $('button.confirm').text("<?=_('Dismiss')?>").prop('disabled',false).show();
     $('#pluginProgressTitle').attr('class','nchan-state nchan-error').html("<i class='fa fa-warning fa-fw'></i> <?=_('Error')?>");
     return true;

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
@@ -248,9 +248,9 @@ function openAlert(cmd,title,func) {
 function openDone(data) {
   if (data == '_DONE_') {
     $('div.spinner.fixed').hide();
-    // task finished: the running-phase minimize control gives way to a primary
-    // Dismiss button (clears the task from the tray on confirm)
-    $('.sweet-alert .nchan-close').remove();
+    // task finished: the corner control becomes a plain "close" (the task stays
+    // in the tray); the primary Dismiss button removes it on confirm
+    $('.sweet-alert .nchan-close').attr('title',"<?=_('Close - the task stays in the tray')?>").find('i').attr('class','fa fa-times fa-fw');
     $('button.confirm').text("<?=_('Dismiss')?>").prop('disabled',false).show();
     if (typeof ca_done_override !== 'undefined') {
       if (ca_done_override == true) {
@@ -267,7 +267,7 @@ function openDone(data) {
 function openError(data) {
   if (data == '_ERROR_') {
     $('div.spinner.fixed').hide();
-    $('.sweet-alert .nchan-close').remove();
+    $('.sweet-alert .nchan-close').attr('title',"<?=_('Close - the task stays in the tray')?>").find('i').attr('class','fa fa-times fa-fw');
     $('button.confirm').text("<?=_('Dismiss')?>").prop('disabled',false).show();
     $('#pluginProgressTitle').text("<?=_('Error');?>");
     return true;

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
@@ -248,7 +248,10 @@ function openAlert(cmd,title,func) {
 function openDone(data) {
   if (data == '_DONE_') {
     $('div.spinner.fixed').hide();
-    $('button.confirm').text("<?=_('Done')?>").prop('disabled',false).show();
+    // task finished: the running-phase minimize control gives way to a primary
+    // Dismiss button (clears the task from the tray on confirm)
+    $('.sweet-alert .nchan-close').remove();
+    $('button.confirm').text("<?=_('Dismiss')?>").prop('disabled',false).show();
     if (typeof ca_done_override !== 'undefined') {
       if (ca_done_override == true) {
         $("button.confirm").trigger("click");
@@ -264,7 +267,8 @@ function openDone(data) {
 function openError(data) {
   if (data == '_ERROR_') {
     $('div.spinner.fixed').hide();
-    $('button.confirm').text("<?=_('Error')?>").prop('disabled',false).show();
+    $('.sweet-alert .nchan-close').remove();
+    $('button.confirm').text("<?=_('Dismiss')?>").prop('disabled',false).show();
     $('#pluginProgressTitle').text("<?=_('Error');?>");
     return true;
   }

--- a/emhttp/plugins/dynamix/include/TaskCommand.php
+++ b/emhttp/plugins/dynamix/include/TaskCommand.php
@@ -35,7 +35,7 @@ case 'create':
 case 'abort':
   $task = task_read($id);
   if ($task) {
-    if ($task['status']==='running' && $task['pid'] > 1) {
+    if ($task['status']==='running' && ctype_digit((string)$task['pid']) && (int)$task['pid'] > 1) {
       exec('kill '.escapeshellarg($task['pid']));
       foreach (glob('/tmp/plugins/pluginPending/*') ?: [] as $file) @unlink($file);
       $task['status']   = 'error';

--- a/emhttp/plugins/dynamix/include/TaskQueue.php
+++ b/emhttp/plugins/dynamix/include/TaskQueue.php
@@ -120,7 +120,11 @@ function task_launch(&$task) {
   // plugin scripts publish to nchan only when their last argument is 'nchan'
   $suffix = $task['type']==='plugins' ? ' nchan' : '';
   $env = 'NCHAN_TASK='.escapeshellarg($task['id']).' ';
-  $pid = exec($env."nohup bash -c 'sleep .3 && $name $args$suffix' 1>/dev/null 2>&1 & echo \$!");
+  // escapeshellarg the whole bash -c payload so a single quote (or other shell
+  // metacharacter) in the resolved args cannot break out of the outer shell;
+  // bash still word-splits the args internally, preserving multi-arg commands.
+  $payload = 'sleep .3 && '.$name.' '.$args.$suffix;
+  $pid = exec($env.'nohup bash -c '.escapeshellarg($payload).' 1>/dev/null 2>&1 & echo $!');
   $task['pid']     = $pid;
   $task['status']  = 'running';
   $task['started'] = time();
@@ -147,11 +151,19 @@ function task_daemon_start() {
 // create (and possibly immediately start) a task; returns the task record
 function task_create($type,$cmd,$title,$plg,$func,$start,$button) {
   if (!in_array($type, TASK_TYPES)) return null;
+  // Serialize the dedupe -> create -> launch sequence per type. Without this,
+  // two concurrent requests (e.g. a double click) could both pass the dedupe
+  // and task_running_type() checks and each call task_launch(), violating the
+  // "at most one running task per type" invariant the whole design relies on.
+  $lock = fopen(task_dir()."/.$type.lock", 'c');
+  if ($lock) flock($lock, LOCK_EX);
   // dedupe: unless unconditional (start==1), don't queue an identical pending/running op
   if ((int)$start !== 1) {
     foreach (task_list() as $t) {
-      if ($t['type']===$type && $t['cmd']===$cmd && in_array($t['status'],['queued','running']))
+      if ($t['type']===$type && $t['cmd']===$cmd && in_array($t['status'],['queued','running'])) {
+        if ($lock) { flock($lock, LOCK_UN); fclose($lock); }
         return $t;
+      }
     }
   }
   $task = [
@@ -171,6 +183,7 @@ function task_create($type,$cmd,$title,$plg,$func,$start,$button) {
   ];
   task_write($task);
   if (!task_running_type($type)) task_launch($task);
+  if ($lock) { flock($lock, LOCK_UN); fclose($lock); }
   task_daemon_start();
   task_publish();
   return task_read($task['id']) ?: $task;

--- a/emhttp/plugins/dynamix/nchan/tasks
+++ b/emhttp/plugins/dynamix/nchan/tasks
@@ -24,16 +24,26 @@
 $docroot = '/usr/local/emhttp';
 require_once "$docroot/plugins/dynamix/include/TaskQueue.php";
 
-// a task's stored pid is alive while /proc/<pid> exists
+// a task's stored pid is alive while /proc/<pid> exists; require a numeric pid so
+// an empty/garbage value can't match the /proc directory itself and wedge a task
 function task_pid_alive($pid) {
-  return $pid && file_exists("/proc/$pid");
+  return ctype_digit((string)$pid) && file_exists("/proc/$pid");
 }
 
-// the operation reported a failure if its captured output contains the _ERROR_ marker
+// the operation reported a failure if its captured output contains the _ERROR_
+// control record. The log is RS(\x1e)-delimited and _DONE_/_ERROR_ are discrete
+// records (see publish.php), so match _ERROR_ as a whole record the same way the
+// live channel does (routeMessage) — a log line that merely contains the text
+// must not trip a false failure.
 function task_log_has_error($id) {
   $log = task_log($id);
   if (!is_file($log)) return false;
-  return strpos((string)@exec('tail -c 65536 '.escapeshellarg($log)), '_ERROR_') !== false;
+  $fh = @fopen($log, 'rb');
+  if (!$fh) return false;
+  if (filesize($log) > 65536) fseek($fh, -65536, SEEK_END);
+  $tail = stream_get_contents($fh);
+  fclose($fh);
+  return in_array('_ERROR_', explode("\x1e", (string)$tail), true);
 }
 
 // tidy up stale finished tasks, then publish the current state for any client
@@ -49,6 +59,17 @@ while (true) {
       $t['status']   = task_log_has_error($t['id']) ? 'error' : 'done';
       $t['finished'] = time();
       task_write($t);
+      $freed[$t['type']] = true;
+      $changed = true;
+    }
+  }
+
+  // also launch any queued type that has nothing running. Covers a daemon
+  // (re)started by the page-load nchan sweep with queued-but-not-running
+  // records: without this it would treat those as "active" below and sleep
+  // forever without ever advancing the queue.
+  foreach (task_list() as $t) {
+    if ($t['status']==='queued' && !task_running_type($t['type'])) {
       $freed[$t['type']] = true;
       $changed = true;
     }

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1955,72 +1955,133 @@ label.checkbox input:disabled ~ .checkmark {
     text-decoration: none;
 }
 .op-tray .op-act:hover { color: var(--brand-orange); }
-/* top-corner minimize/close on the foreground task modal. The modal is a dark
-   surface, so the control is a light, bordered circular button (not a faint
-   theme-colored glyph) with a brand-orange hover so it reads clearly as an
-   action. */
+/* The foreground task modal is restyled as a right-docked sidebar/sheet to mirror
+   the Unraid notifications sidebar. Every color is a theme token so it adapts to
+   white / azure / black / gray:
+     surface = --dynamix-sweet-alert-icon-bg-color (the modal's own themed bg)
+     text    = --dynamix-sweet-alert-text-color   muted = --alt-text-color
+     card    = --shade-bg-color   lines = --border-color   accent = --brand-orange */
+.sweet-alert.nchan {
+    display: flex !important;
+    flex-direction: column;
+    left: auto;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    transform: none;
+    -webkit-transform: none;
+    width: 34rem;
+    max-width: 92vw;
+    height: 100vh;
+    height: 100dvh;
+    max-height: 100vh;
+    max-height: 100dvh;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    border-left: 1px solid var(--border-color);
+    border-radius: 0;
+    box-shadow: -0.5rem 0 1.5rem var(--bg-opacity-30);
+    text-align: left;
+    overflow: hidden;
+    box-sizing: border-box;
+    animation: nchanSlideIn .22s ease-out;
+}
+@keyframes nchanSlideIn { from { transform: translateX(100%); } to { transform: translateX(0); } }
+.sweet-alert.nchan > h2 {
+    flex: 0 0 auto;
+    margin: 0;
+    padding: 1.1rem 3.6rem 0.85rem 1.2rem;
+    font-size: 1.6rem;
+    line-height: 1.35;
+    font-weight: 600;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+}
+.sweet-alert.nchan #pluginProgressTitle {
+    display: block;
+    margin-top: 0.3rem;
+    font-size: 1.15rem;
+    font-weight: 400;
+    color: var(--alt-text-color);
+}
+.sweet-alert.nchan > p {
+    flex: 1 1 auto;
+    min-height: 0;
+    margin: 0;
+    padding: 1rem 1.2rem;
+    display: flex;
+    flex-direction: column;
+    text-align: left;
+}
+.sweet-alert.nchan #swaltext {
+    flex: 1 1 auto;
+    min-height: 0;
+    max-height: none;
+    overflow: auto;
+    margin: 0;
+    padding: 0.8rem 0.9rem;
+    text-align: left;
+    font-size: 1.2rem;
+    background: var(--shade-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 0.4rem;
+}
+.sweet-alert.nchan .sa-button-container {
+    flex: 0 0 auto;
+    margin: 0;
+    padding: 0.9rem 1.2rem;
+    border-top: 1px solid var(--border-color);
+    text-align: left;
+}
+.sweet-alert.nchan button.confirm {
+    margin: 0;
+    padding: 0.6rem 1.5rem;
+    font-size: 1.3rem;
+    color: var(--white);
+    background: var(--brand-orange);
+    border: 0;
+    border-radius: 0.4rem;
+    box-shadow: none;
+}
+.sweet-alert.nchan button.confirm:hover { background: var(--orange-800); }
+/* top-corner minimize (running) / close (finished) control — theme-token colors
+   so it stays visible on the modal surface in every theme */
 .sweet-alert .nchan-close {
     position: absolute;
-    top: .8rem;
-    right: .8rem;
+    top: 0.85rem;
+    right: 0.9rem;
     width: 2.4rem;
     height: 2.4rem;
     display: flex;
     align-items: center;
     justify-content: center;
     border-radius: 50%;
-    font-size: 1.4rem;
+    font-size: 1.3rem;
     line-height: 1;
-    color: rgba(255,255,255,.85);
-    background: rgba(255,255,255,.1);
-    border: 1px solid rgba(255,255,255,.28);
+    color: var(--dynamix-sweet-alert-text-color);
+    background: transparent;
+    border: 1px solid var(--border-color);
     cursor: pointer;
     text-decoration: none;
     transition: background-color .15s, border-color .15s, color .15s;
     z-index: 2;
 }
 .sweet-alert .nchan-close:hover {
-    color: #fff;
+    color: var(--white);
     background: var(--brand-orange);
     border-color: var(--brand-orange);
 }
-/* Mobile: the foreground task modal goes fullscreen instead of a centered,
-   rounded card (which looks cramped/"circular" on small screens). Scoped to
-   .nchan so ordinary confirm/warning dialogs keep their dialog look. The title
-   stays pinned at the top, the log fills and scrolls, and the minimize / Dismiss
-   controls stay reachable at the corners/bottom. */
+/* Mobile: full-width sheet (flush, still slides in from the right). */
 @media (max-width: 767px) {
     .sweet-alert.nchan {
-        display: flex !important;
-        flex-direction: column;
         left: 0;
-        top: 0;
+        right: 0;
         width: 100vw;
         max-width: 100vw;
-        height: 100vh;
-        height: 100dvh;
-        max-height: 100vh;
-        max-height: 100dvh;
-        margin: 0;
-        padding: 1.25rem 1rem;
-        border: 0;
-        border-radius: 0;
-        transform: none !important;
-        -webkit-transform: none !important;
-        box-sizing: border-box;
+        border-left: 0;
     }
-    .sweet-alert.nchan > h2 { flex: 0 0 auto; padding-right: 2.5rem; }
-    .sweet-alert.nchan > p  { flex: 1 1 auto; min-height: 0; display: flex; margin: 0; }
-    .sweet-alert.nchan #swaltext {
-        flex: 1 1 auto;
-        min-height: 0;
-        max-height: none;
-        overflow: auto;
-        margin: 0;
-        text-align: left;
-    }
-    .sweet-alert.nchan .sa-button-container { flex: 0 0 auto; margin-top: 1rem; }
-    .sweet-alert.nchan .nchan-close { top: 1rem; right: 1rem; width: 2.9rem; height: 2.9rem; font-size: 1.6rem; }
+    .sweet-alert.nchan .nchan-close { width: 2.9rem; height: 2.9rem; font-size: 1.6rem; }
 }
 .back_to_top {
     right: 40px;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1968,8 +1968,8 @@ label.checkbox input:disabled ~ .checkmark {
     flex-direction: column;
     width: 90vw;
     max-width: 60rem;
-    height: 34rem;         /* fixed, moderate height (overrides swal's @media 95vh) so the log scrolls in place and the Dismiss button never moves */
-    max-height: 85vh;      /* but don't exceed the viewport on short screens */
+    height: 75vh;          /* fixed (overrides swal's @media 95vh) so the log scrolls in place and the Dismiss button never moves; scales with the viewport */
+    max-height: 85vh;
     margin: 0;
     padding: 0;
     text-align: left;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1982,6 +1982,11 @@ label.checkbox input:disabled ~ .checkmark {
 .sweet-alert.nchan[data-has-confirm-button=false][data-has-cancel-button=false] {
     padding-bottom: 0;
 }
+/* While running there is no Dismiss button, so hide the whole footer bar
+   (otherwise its border-top + padding render as an empty strip). */
+.sweet-alert.nchan[data-has-confirm-button=false] .sa-button-container {
+    display: none;
+}
 .sweet-alert.nchan > h2 {
     flex: 0 0 auto;
     margin: 0;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2241,8 +2241,10 @@ label.checkbox input:disabled ~ .checkmark {
     }
     .op-tray.op-expanded .op-tray-head .op-collapse { display: inline-flex; }
 
-    .op-tray:not(:empty) ~ .back_to_top { left: auto; right: 40px; bottom: 6rem; }
-    .op-tray:not(:empty) ~ .move_to_end { left: auto; right: 12px; bottom: 6rem; }
+    /* lift the scroll buttons clear of the taller mobile tray (front card +
+       peeking stack edges + count badge sit ~5.5rem up from the bottom) */
+    .op-tray:not(:empty) ~ .back_to_top { left: auto; right: 40px; bottom: 7.5rem; }
+    .op-tray:not(:empty) ~ .move_to_end { left: auto; right: 12px; bottom: 7.5rem; }
 }
 span.big.blue-text {
     cursor: pointer;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1976,6 +1976,12 @@ label.checkbox input:disabled ~ .checkmark {
     box-sizing: border-box;
     box-shadow: 0 0.5rem 2rem var(--bg-opacity-30);
 }
+/* SweetAlert adds 40px bottom padding when no buttons show (our running state);
+   the sheet manages its own padding, so cancel it. Matches swal's selector plus
+   .nchan to outspecify it. */
+.sweet-alert.nchan[data-has-confirm-button=false][data-has-cancel-button=false] {
+    padding-bottom: 0;
+}
 .sweet-alert.nchan > h2 {
     flex: 0 0 auto;
     margin: 0;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2014,12 +2014,9 @@ label.checkbox input:disabled ~ .checkmark {
     max-height: none;
     overflow: auto;
     margin: 0;
-    padding: 0.8rem 0.9rem;
+    padding: 0;
     text-align: left;
     font-size: 1.2rem;
-    background: var(--shade-bg-color);
-    border: 1px solid var(--border-color);
-    border-radius: 0.4rem;
 }
 /* Slim footer with a full-width Dismiss. A single centered button looked lonely
    and the default container (margin-top + centered flex + a hidden loader) ate

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1968,8 +1968,8 @@ label.checkbox input:disabled ~ .checkmark {
     flex-direction: column;
     width: 90vw;
     max-width: 60rem;
-    height: auto;          /* override swal's @media(max-width:1200px){height:95vh} so the modal hugs its content */
-    max-height: 85vh;
+    height: 34rem;         /* fixed, moderate height (overrides swal's @media 95vh) so the log scrolls in place and the Dismiss button never moves */
+    max-height: 85vh;      /* but don't exceed the viewport on short screens */
     margin: 0;
     padding: 0;
     text-align: left;
@@ -2020,7 +2020,7 @@ label.checkbox input:disabled ~ .checkmark {
 .sweet-alert.nchan .nchan-state.nchan-error   { background: rgba(226,75,74,.14); }
 .sweet-alert.nchan .nchan-state.nchan-error i { color: #e24b4a; }
 .sweet-alert.nchan > p {
-    flex: 0 1 auto;            /* size to the log, don't stretch the modal */
+    flex: 1 1 auto;            /* fill the fixed height so the footer stays pinned to the bottom */
     min-height: 0;
     margin: 0;
     padding: 1rem 1.2rem;
@@ -2029,7 +2029,7 @@ label.checkbox input:disabled ~ .checkmark {
     text-align: left;
 }
 .sweet-alert.nchan #swaltext {
-    flex: 0 1 auto;
+    flex: 1 1 auto;
     min-height: 0;
     max-height: none;
     overflow: auto;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2143,10 +2143,12 @@ label.checkbox input:disabled ~ .checkmark {
         padding-bottom: 2px;
     }
     .op-tray::-webkit-scrollbar { display: none; }
+    /* each tile is a bit under full width so the neighbour peeks in — a visual
+       cue that the tray is swipeable */
     .op-tray .op-task,
     .op-tray .op-tray-head {
-        flex: 0 0 100%;
-        scroll-snap-align: center;
+        flex: 0 0 85%;
+        scroll-snap-align: end;
         box-sizing: border-box;
     }
     /* taller tiles + larger action hit areas so they're easy to tap on touch */

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1955,41 +1955,27 @@ label.checkbox input:disabled ~ .checkmark {
     text-decoration: none;
 }
 .op-tray .op-act:hover { color: var(--brand-orange); }
-/* The foreground task modal is restyled as a right-docked sidebar/sheet to mirror
-   the Unraid notifications sidebar. Every color is a theme token so it adapts to
-   white / azure / black / gray:
-     surface = --dynamix-sweet-alert-icon-bg-color (the modal's own themed bg)
-     text    = --dynamix-sweet-alert-text-color   muted = --alt-text-color
-     card    = --shade-bg-color   lines = --border-color   accent = --brand-orange */
+/* The foreground task modal: a compact, centered card (a transient progress log
+   shouldn't take over the screen, so it is NOT a full-height sidebar). The base
+   swal keeps the centering + rounded corners; here we just shrink it and lay it
+   out as header / scrolling log / footer. All colors are theme tokens so it
+   adapts to white / azure / black / gray:
+     surface = --dynamix-sweet-alert-icon-bg-color   text = --dynamix-sweet-alert-text-color
+     muted = --alt-text-color   card = --shade-bg-color   lines = --border-color
+     accent = --brand-orange. Mobile goes fullscreen (below). */
 .sweet-alert.nchan {
     display: flex !important;
     flex-direction: column;
-    left: auto;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    transform: none;
-    -webkit-transform: none;
-    width: 46rem;
-    max-width: 95vw;
-    height: 100vh;
-    height: 100dvh;
-    min-height: 100vh;
-    min-height: 100dvh;
-    max-height: 100vh;
-    max-height: 100dvh;
+    width: 90vw;
+    max-width: 42rem;
+    max-height: 85vh;
     margin: 0;
     padding: 0;
-    border: 0;
-    border-left: 1px solid var(--border-color);
-    border-radius: 0;
-    box-shadow: -0.5rem 0 1.5rem var(--bg-opacity-30);
     text-align: left;
     overflow: hidden;
     box-sizing: border-box;
-    animation: nchanSlideIn .22s ease-out;
+    box-shadow: 0 0.5rem 2rem var(--bg-opacity-30);
 }
-@keyframes nchanSlideIn { from { transform: translateX(100%); } to { transform: translateX(0); } }
 .sweet-alert.nchan > h2 {
     flex: 0 0 auto;
     margin: 0;
@@ -2074,14 +2060,22 @@ label.checkbox input:disabled ~ .checkmark {
     background: var(--brand-orange);
     border-color: var(--brand-orange);
 }
-/* Mobile: full-width sheet (flush, still slides in from the right). */
+/* Mobile: fullscreen (a centered card is cramped on phones). Overrides the base
+   swal centering to fill the viewport. */
 @media (max-width: 767px) {
     .sweet-alert.nchan {
         left: 0;
+        top: 0;
         right: 0;
+        bottom: 0;
+        transform: none;
+        -webkit-transform: none;
         width: 100vw;
         max-width: 100vw;
-        border-left: 0;
+        height: 100dvh;
+        max-height: 100dvh;
+        border: 0;
+        border-radius: 0;
     }
     .sweet-alert.nchan .nchan-close { width: 2.9rem; height: 2.9rem; font-size: 1.6rem; }
 }

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2026,6 +2026,8 @@ label.checkbox input:disabled ~ .checkmark {
    vertical space. */
 .sweet-alert.nchan .sa-button-container {
     flex: 0 0 auto;
+    display: flex;
+    justify-content: flex-end;
     margin: 0;
     padding: 0.7rem 1.2rem;
     border-top: 1px solid var(--border-color);

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2149,6 +2149,17 @@ label.checkbox input:disabled ~ .checkmark {
         scroll-snap-align: center;
         box-sizing: border-box;
     }
+    /* taller tiles + larger action hit areas so they're easy to tap on touch */
+    .op-tray .op-task { padding: .85rem 1rem; min-height: 3.4rem; font-size: 1.45rem; gap: .75rem; }
+    .op-tray .op-actions { gap: .25rem; }
+    .op-tray .op-act {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 3rem;
+        min-height: 3rem;
+        font-size: 1.6rem;
+    }
     .op-tray:not(:empty) ~ .back_to_top { left: auto; right: 40px; bottom: 6rem; }
     .op-tray:not(:empty) ~ .move_to_end { left: auto; right: 12px; bottom: 6rem; }
 }

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1995,15 +1995,23 @@ label.checkbox input:disabled ~ .checkmark {
     line-height: 1.35;
     font-weight: 600;
     text-align: left;
+}
+/* colored state strip below the title: a distinct status section, not a subline */
+.sweet-alert.nchan .nchan-state {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0.5rem 1.2rem;
+    font-size: 1.15rem;
+    font-weight: 500;
+    border-top: 1px solid var(--border-color);
     border-bottom: 1px solid var(--border-color);
 }
-.sweet-alert.nchan #pluginProgressTitle {
-    display: block;
-    margin-top: 0.3rem;
-    font-size: 1.15rem;
-    font-weight: 400;
-    color: var(--alt-text-color);
-}
+.sweet-alert.nchan .nchan-state.nchan-running { background: var(--blue-100);  color: var(--blue-900); }
+.sweet-alert.nchan .nchan-state.nchan-done    { background: var(--green-100); color: var(--green-900); }
+.sweet-alert.nchan .nchan-state.nchan-error   { background: var(--red-100);   color: var(--red-900); }
 .sweet-alert.nchan > p {
     flex: 0 1 auto;            /* size to the log, don't stretch the modal */
     min-height: 0;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1968,6 +1968,7 @@ label.checkbox input:disabled ~ .checkmark {
     flex-direction: column;
     width: 90vw;
     max-width: 60rem;
+    height: auto;          /* override swal's @media(max-width:1200px){height:95vh} so the modal hugs its content */
     max-height: 85vh;
     margin: 0;
     padding: 0;
@@ -1996,7 +1997,9 @@ label.checkbox input:disabled ~ .checkmark {
     font-weight: 600;
     text-align: left;
 }
-/* colored state strip below the title: a distinct status section, not a subline */
+/* status state strip below the title: a subtle theme-adaptive tint + a colored
+   icon, with normal (theme) text. Tints are translucent so they read over the
+   modal surface in every theme without the dated pale-banner look. */
 .sweet-alert.nchan .nchan-state {
     flex: 0 0 auto;
     display: flex;
@@ -2004,14 +2007,18 @@ label.checkbox input:disabled ~ .checkmark {
     gap: 0.5rem;
     margin: 0;
     padding: 0.5rem 1.2rem;
-    font-size: 1.15rem;
+    font-size: 1.1rem;
     font-weight: 500;
-    border-top: 1px solid var(--border-color);
+    color: var(--text-color);
     border-bottom: 1px solid var(--border-color);
 }
-.sweet-alert.nchan .nchan-state.nchan-running { background: var(--blue-100);  color: var(--blue-900); }
-.sweet-alert.nchan .nchan-state.nchan-done    { background: var(--green-100); color: var(--green-900); }
-.sweet-alert.nchan .nchan-state.nchan-error   { background: var(--red-100);   color: var(--red-900); }
+.sweet-alert.nchan .nchan-state i { font-size: 1.05em; }
+.sweet-alert.nchan .nchan-state.nchan-running { background: rgba(59,130,196,.14); }
+.sweet-alert.nchan .nchan-state.nchan-running i { color: #3b82c4; }
+.sweet-alert.nchan .nchan-state.nchan-done    { background: rgba(58,156,71,.16); }
+.sweet-alert.nchan .nchan-state.nchan-done i  { color: #3a9c47; }
+.sweet-alert.nchan .nchan-state.nchan-error   { background: rgba(226,75,74,.14); }
+.sweet-alert.nchan .nchan-state.nchan-error i { color: #e24b4a; }
 .sweet-alert.nchan > p {
     flex: 0 1 auto;            /* size to the log, don't stretch the modal */
     min-height: 0;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1969,6 +1969,44 @@ label.checkbox input:disabled ~ .checkmark {
     z-index: 2;
 }
 .sweet-alert .nchan-close:hover { opacity: 1; color: var(--brand-orange); }
+/* Mobile: the foreground task modal goes fullscreen instead of a centered,
+   rounded card (which looks cramped/"circular" on small screens). Scoped to
+   .nchan so ordinary confirm/warning dialogs keep their dialog look. The title
+   stays pinned at the top, the log fills and scrolls, and the minimize / Dismiss
+   controls stay reachable at the corners/bottom. */
+@media (max-width: 767px) {
+    .sweet-alert.nchan {
+        display: flex !important;
+        flex-direction: column;
+        left: 0;
+        top: 0;
+        width: 100vw;
+        max-width: 100vw;
+        height: 100vh;
+        height: 100dvh;
+        max-height: 100vh;
+        max-height: 100dvh;
+        margin: 0;
+        padding: 1.25rem 1rem;
+        border: 0;
+        border-radius: 0;
+        transform: none !important;
+        -webkit-transform: none !important;
+        box-sizing: border-box;
+    }
+    .sweet-alert.nchan > h2 { flex: 0 0 auto; padding-right: 2.5rem; }
+    .sweet-alert.nchan > p  { flex: 1 1 auto; min-height: 0; display: flex; margin: 0; }
+    .sweet-alert.nchan #swaltext {
+        flex: 1 1 auto;
+        min-height: 0;
+        max-height: none;
+        overflow: auto;
+        margin: 0;
+        text-align: left;
+    }
+    .sweet-alert.nchan .sa-button-container { flex: 0 0 auto; margin-top: 1rem; }
+    .sweet-alert.nchan .nchan-close { top: 1.1rem; right: 1.1rem; font-size: 1.7rem; opacity: .85; }
+}
 .back_to_top {
     right: 40px;
 }

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2030,14 +2030,14 @@ label.checkbox input:disabled ~ .checkmark {
     padding: 0.7rem 1.2rem;
     border-top: 1px solid var(--border-color);
 }
-.sweet-alert.nchan .sa-confirm-button-container { display: block; }
+.sweet-alert.nchan .sa-confirm-button-container { display: flex; justify-content: flex-end; }
 .sweet-alert.nchan .la-ball-fall { display: none; }
 /* !important overrides SweetAlert's inline background-color:transparent / sizing */
 .sweet-alert.nchan button.confirm {
-    display: block;
-    width: 100%;
+    display: inline-block;
+    width: auto;
     margin: 0;
-    padding: 0.6rem 1rem;
+    padding: 0.5rem 1.4rem;
     font-size: 1.25rem;
     color: var(--white) !important;
     background: var(--brand-orange) !important;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1897,7 +1897,7 @@ label.checkbox input:disabled ~ .checkmark {
     display: flex;
     flex-direction: column;
     gap: .25rem;
-    z-index: 999;
+    z-index: 1000;
 }
 /* Lift the tray above the fixed footer so it isn't clipped behind it.
    Mirrors the media queries that make #footer position:fixed. */
@@ -2086,6 +2086,41 @@ label.checkbox input:disabled ~ .checkmark {
 }
 .move_to_end {
     right:12px;
+}
+/* The scroll-to-top/bottom buttons share the bottom-right corner with the task
+   tray. When the tray has tasks (it is an earlier sibling of the buttons, see
+   MiscElementsBottom), move the buttons clear of it: to the bottom-left on
+   desktop. */
+.op-tray:not(:empty) ~ .back_to_top { right: auto; left: 40px; }
+.op-tray:not(:empty) ~ .move_to_end { right: auto; left: 12px; }
+/* Mobile: the tray becomes a full-width, swipeable carousel of task tiles (one
+   at a time) instead of a bottom-right stack, and the scroll buttons lift above
+   it so they never cover a tile. */
+@media (max-width: 767px) {
+    .op-tray {
+        left: 1rem;
+        right: 1rem;
+        width: auto;
+        max-width: none;
+        max-height: none;
+        flex-flow: row nowrap;
+        overflow-x: auto;
+        overflow-y: hidden;
+        gap: .5rem;
+        scroll-snap-type: x mandatory;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        padding-bottom: 2px;
+    }
+    .op-tray::-webkit-scrollbar { display: none; }
+    .op-tray .op-task,
+    .op-tray .op-tray-head {
+        flex: 0 0 100%;
+        scroll-snap-align: center;
+        box-sizing: border-box;
+    }
+    .op-tray:not(:empty) ~ .back_to_top { left: auto; right: 40px; bottom: 6rem; }
+    .op-tray:not(:empty) ~ .move_to_end { left: auto; right: 12px; bottom: 6rem; }
 }
 span.big.blue-text {
     cursor: pointer;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1967,7 +1967,7 @@ label.checkbox input:disabled ~ .checkmark {
     display: flex !important;
     flex-direction: column;
     width: 90vw;
-    max-width: 42rem;
+    max-width: 60rem;
     max-height: 85vh;
     margin: 0;
     padding: 0;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1955,6 +1955,20 @@ label.checkbox input:disabled ~ .checkmark {
     text-decoration: none;
 }
 .op-tray .op-act:hover { color: var(--brand-orange); }
+/* top-corner minimize on the foreground task modal (backgrounds the task) */
+.sweet-alert .nchan-close {
+    position: absolute;
+    top: .6rem;
+    right: .9rem;
+    font-size: 1.3rem;
+    line-height: 1;
+    color: var(--text-color);
+    opacity: .6;
+    cursor: pointer;
+    text-decoration: none;
+    z-index: 2;
+}
+.sweet-alert .nchan-close:hover { opacity: 1; color: var(--brand-orange); }
 .back_to_top {
     right: 40px;
 }

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1939,6 +1939,7 @@ label.checkbox input:disabled ~ .checkmark {
 .op-tray .op-icon { flex: 0 0 auto; }
 .op-tray .op-title {
     flex: 1 1 auto;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1970,10 +1970,12 @@ label.checkbox input:disabled ~ .checkmark {
     bottom: 0;
     transform: none;
     -webkit-transform: none;
-    width: 34rem;
-    max-width: 92vw;
+    width: 46rem;
+    max-width: 95vw;
     height: 100vh;
     height: 100dvh;
+    min-height: 100vh;
+    min-height: 100dvh;
     max-height: 100vh;
     max-height: 100dvh;
     margin: 0;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2005,7 +2005,7 @@ label.checkbox input:disabled ~ .checkmark {
     color: var(--alt-text-color);
 }
 .sweet-alert.nchan > p {
-    flex: 1 1 auto;
+    flex: 0 1 auto;            /* size to the log, don't stretch the modal */
     min-height: 0;
     margin: 0;
     padding: 1rem 1.2rem;
@@ -2014,7 +2014,7 @@ label.checkbox input:disabled ~ .checkmark {
     text-align: left;
 }
 .sweet-alert.nchan #swaltext {
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     min-height: 0;
     max-height: none;
     overflow: auto;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1909,8 +1909,22 @@ label.checkbox input:disabled ~ .checkmark {
 }
 .op-tray .op-tray-head {
     display: flex;
-    justify-content: flex-end;
-    padding: 0 .25rem .1rem;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+    padding: 0 .35rem .15rem;
+}
+.op-tray .op-tray-count {
+    font-size: 1.05rem;
+    color: var(--text-color);
+    opacity: .6;
+    text-transform: uppercase;
+    letter-spacing: .03em;
+}
+.op-tray .op-tray-head-acts {
+    display: flex;
+    align-items: center;
+    gap: .65rem;
 }
 .op-tray .op-tray-head .op-act {
     font-size: 1.1rem;
@@ -1920,6 +1934,10 @@ label.checkbox input:disabled ~ .checkmark {
     text-decoration: none;
 }
 .op-tray .op-tray-head .op-act:hover { opacity: 1; color: var(--brand-orange); }
+/* The collapse chevron and the count badge are part of the mobile stacked-card
+   interaction; desktop always shows the full vertical list, so hide them there. */
+.op-tray .op-tray-head .op-collapse { display: none; }
+.op-tray .op-stack-badge { display: none; }
 .op-tray .op-task {
     display: flex;
     align-items: center;
@@ -2123,35 +2141,19 @@ label.checkbox input:disabled ~ .checkmark {
    desktop. */
 .op-tray:not(:empty) ~ .back_to_top { right: auto; left: 40px; }
 .op-tray:not(:empty) ~ .move_to_end { right: auto; left: 12px; }
-/* Mobile: the tray becomes a full-width, swipeable carousel of task tiles (one
-   at a time) instead of a bottom-right stack, and the scroll buttons lift above
-   it so they never cover a tile. */
+/* Mobile: the tray is a grouped-notification stack (iOS/Android pattern). When
+   there are multiple tasks it collapses to the newest card with the rest peeking
+   behind it; a tap expands the full vertical list so all of them can be viewed
+   and cleared at once. The scroll buttons lift above it so they never overlap. */
 @media (max-width: 767px) {
     .op-tray {
         left: 1rem;
         right: 1rem;
         width: auto;
         max-width: none;
-        max-height: none;
-        flex-flow: row nowrap;
-        overflow-x: auto;
-        overflow-y: hidden;
         gap: .5rem;
-        scroll-snap-type: x mandatory;
-        -webkit-overflow-scrolling: touch;
-        scrollbar-width: none;
-        padding-bottom: 2px;
     }
-    .op-tray::-webkit-scrollbar { display: none; }
-    /* each tile is a bit under full width so the neighbour peeks in — a visual
-       cue that the tray is swipeable */
-    .op-tray .op-task,
-    .op-tray .op-tray-head {
-        flex: 0 0 85%;
-        scroll-snap-align: end;
-        box-sizing: border-box;
-    }
-    /* taller tiles + larger action hit areas so they're easy to tap on touch */
+    /* larger tap targets on touch (applies in both collapsed and expanded) */
     .op-tray .op-task { padding: .85rem 1rem; min-height: 3.4rem; font-size: 1.45rem; gap: .75rem; }
     .op-tray .op-actions { gap: .25rem; }
     .op-tray .op-act {
@@ -2162,6 +2164,83 @@ label.checkbox input:disabled ~ .checkmark {
         min-height: 3rem;
         font-size: 1.6rem;
     }
+
+    /* ---- Collapsed: a single tappable card with stacked edges peeking under ---- */
+    .op-tray.op-collapsed {
+        display: block;
+        position: fixed;
+        max-height: none;
+        overflow: visible;
+        /* room under the front card for the two peeking stack edges + the badge */
+        padding-bottom: .9rem;
+        cursor: pointer;
+    }
+    .op-tray.op-collapsed .op-tray-head { display: none; }
+    .op-tray.op-collapsed .op-task { display: none; }
+    .op-tray.op-collapsed .op-task.op-top {
+        display: flex;
+        position: relative;
+        z-index: 2;
+        margin: 0;
+    }
+    /* collapsed = whole card means "expand"; its row actions are reachable once
+       expanded, so suppress them here to keep the tap target unambiguous */
+    .op-tray.op-collapsed .op-task.op-top .op-actions { display: none; }
+    /* two faux card edges fanned out below the front card to signal a stack */
+    .op-tray.op-collapsed.op-multi .op-task.op-top::before,
+    .op-tray.op-collapsed.op-multi .op-task.op-top::after {
+        content: '';
+        position: absolute;
+        left: 50%;
+        transform: translateX(-50%);
+        height: 1rem;
+        border: 1px solid var(--border-color);
+        border-top: 0;
+        border-bottom-left-radius: .5rem;
+        border-bottom-right-radius: .5rem;
+        background-color: var(--background-color);
+        z-index: -1;
+    }
+    .op-tray.op-collapsed.op-multi .op-task.op-top::after {
+        bottom: -.45rem;
+        width: 92%;
+        opacity: .8;
+    }
+    .op-tray.op-collapsed.op-multi .op-task.op-top::before {
+        bottom: -.9rem;
+        width: 84%;
+        opacity: .55;
+    }
+    /* count pill on the front card */
+    .op-tray.op-collapsed .op-stack-badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        position: absolute;
+        top: -.7rem;
+        right: -.4rem;
+        z-index: 3;
+        min-width: 1.6rem;
+        height: 1.6rem;
+        padding: 0 .45rem;
+        border-radius: .8rem;
+        background-color: var(--brand-orange);
+        color: #fff;
+        font-size: 1.05rem;
+        font-weight: 700;
+        box-shadow: 0 1px 3px rgba(0,0,0,.35);
+        cursor: pointer;
+    }
+
+    /* ---- Expanded: full vertical list, panned up from the bottom ---- */
+    .op-tray.op-expanded {
+        display: flex;
+        flex-direction: column;
+        max-height: 70vh;
+        overflow-y: auto;
+    }
+    .op-tray.op-expanded .op-tray-head .op-collapse { display: inline-flex; }
+
     .op-tray:not(:empty) ~ .back_to_top { left: auto; right: 40px; bottom: 6rem; }
     .op-tray:not(:empty) ~ .move_to_end { left: auto; right: 12px; bottom: 6rem; }
 }

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2015,19 +2015,24 @@ label.checkbox input:disabled ~ .checkmark {
     border: 1px solid var(--border-color);
     border-radius: 0.4rem;
 }
+/* Slim footer with a full-width Dismiss. A single centered button looked lonely
+   and the default container (margin-top + centered flex + a hidden loader) ate
+   vertical space. */
 .sweet-alert.nchan .sa-button-container {
     flex: 0 0 auto;
     margin: 0;
-    padding: 0.9rem 1.2rem;
+    padding: 0.7rem 1.2rem;
     border-top: 1px solid var(--border-color);
-    text-align: left;
 }
-/* !important overrides SweetAlert's inline `background-color: transparent`
-   (its default confirmButtonColor), which otherwise leaves white-on-white. */
+.sweet-alert.nchan .sa-confirm-button-container { display: block; }
+.sweet-alert.nchan .la-ball-fall { display: none; }
+/* !important overrides SweetAlert's inline background-color:transparent / sizing */
 .sweet-alert.nchan button.confirm {
+    display: block;
+    width: 100%;
     margin: 0;
-    padding: 0.6rem 1.5rem;
-    font-size: 1.3rem;
+    padding: 0.6rem 1rem;
+    font-size: 1.25rem;
     color: var(--white) !important;
     background: var(--brand-orange) !important;
     border: 0 !important;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -1955,20 +1955,35 @@ label.checkbox input:disabled ~ .checkmark {
     text-decoration: none;
 }
 .op-tray .op-act:hover { color: var(--brand-orange); }
-/* top-corner minimize on the foreground task modal (backgrounds the task) */
+/* top-corner minimize/close on the foreground task modal. The modal is a dark
+   surface, so the control is a light, bordered circular button (not a faint
+   theme-colored glyph) with a brand-orange hover so it reads clearly as an
+   action. */
 .sweet-alert .nchan-close {
     position: absolute;
-    top: .6rem;
-    right: .9rem;
-    font-size: 1.3rem;
+    top: .8rem;
+    right: .8rem;
+    width: 2.4rem;
+    height: 2.4rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    font-size: 1.4rem;
     line-height: 1;
-    color: var(--text-color);
-    opacity: .6;
+    color: rgba(255,255,255,.85);
+    background: rgba(255,255,255,.1);
+    border: 1px solid rgba(255,255,255,.28);
     cursor: pointer;
     text-decoration: none;
+    transition: background-color .15s, border-color .15s, color .15s;
     z-index: 2;
 }
-.sweet-alert .nchan-close:hover { opacity: 1; color: var(--brand-orange); }
+.sweet-alert .nchan-close:hover {
+    color: #fff;
+    background: var(--brand-orange);
+    border-color: var(--brand-orange);
+}
 /* Mobile: the foreground task modal goes fullscreen instead of a centered,
    rounded card (which looks cramped/"circular" on small screens). Scoped to
    .nchan so ordinary confirm/warning dialogs keep their dialog look. The title
@@ -2005,7 +2020,7 @@ label.checkbox input:disabled ~ .checkmark {
         text-align: left;
     }
     .sweet-alert.nchan .sa-button-container { flex: 0 0 auto; margin-top: 1rem; }
-    .sweet-alert.nchan .nchan-close { top: 1.1rem; right: 1.1rem; font-size: 1.7rem; opacity: .85; }
+    .sweet-alert.nchan .nchan-close { top: 1rem; right: 1rem; width: 2.9rem; height: 2.9rem; font-size: 1.6rem; }
 }
 .back_to_top {
     right: 40px;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2022,17 +2022,19 @@ label.checkbox input:disabled ~ .checkmark {
     border-top: 1px solid var(--border-color);
     text-align: left;
 }
+/* !important overrides SweetAlert's inline `background-color: transparent`
+   (its default confirmButtonColor), which otherwise leaves white-on-white. */
 .sweet-alert.nchan button.confirm {
     margin: 0;
     padding: 0.6rem 1.5rem;
     font-size: 1.3rem;
-    color: var(--white);
-    background: var(--brand-orange);
-    border: 0;
+    color: var(--white) !important;
+    background: var(--brand-orange) !important;
+    border: 0 !important;
     border-radius: 0.4rem;
-    box-shadow: none;
+    box-shadow: none !important;
 }
-.sweet-alert.nchan button.confirm:hover { background: var(--orange-800); }
+.sweet-alert.nchan button.confirm:hover { background: var(--orange-800) !important; }
 /* top-corner minimize (running) / close (finished) control — theme-token colors
    so it stays visible on the modal surface in every theme */
 .sweet-alert .nchan-close {


### PR DESCRIPTION
> **Built on #2665** (base = `feat/backend-task-queue`). It edits `foregroundTask()` / the task tray, which only exist in #2665, so it targets that branch until #2665 merges (then GitHub auto-retargets to `master`).

## Summary

Fixes the foreground task modal's behavior and gives it a compact, theme-aware restyle. The behavioral issues were rooted in one place — the modal drove a single button off an inverted per-type `button` flag in `foregroundTask()`, which for **docker/vmaction** hid the close button for the whole running phase (can't background) and left the confirm button `[disabled]`, surfacing SweetAlert's `la-ball-fall` loader (the "bouncing dots").

## Behavior

- **Backgroundable ops** — a top-corner minimize backgrounds any running task (it keeps running under the daemon, stays in the tray). Fixes docker being non-backgroundable. No disabled-button loader, so the bouncing dots are gone.
- **Status-driven buttons** — running shows the corner minimize; on done/error the corner becomes a plain close (keeps the task in the tray) and a primary **Dismiss** appears (clears it). Mirrors the tray tile's `Show` + `Dismiss`.
- **Esc while running** backgrounds instead of deleting.

## Look

- **Compact centered modal** (deliberately *not* a full-height sidebar — a transient progress log shouldn't take over the screen). `max-width: 42rem`, `max-height: 85vh`, log scrolls inside.
- **Smaller header** (`1.6rem`, left-aligned) with the status on a muted subline.
- **Themed throughout** — all colors are theme tokens (`--dynamix-sweet-alert-*`, `--shade-bg-color`, `--alt-text-color`, `--border-color`, `--brand-orange`), so it adapts across white / azure / black / gray. (Notably, azure/white override the sweet-alert tokens to a *light* surface — the earlier hardcoded-white close icon was invisible there; it now uses the modal's own text-color token.)
- **Log in a card**, brand-orange **Dismiss** button.
- **Mobile (≤767px) → fullscreen** (a centered card is cramped on phones).

## Files

- `BodyInlineJS.php` — status-driven `foregroundTask()`; `minimizeForegroundTask()`.
- `HeadInlineJS.php` — `openDone`/`openError` swap the corner control for the Dismiss primary.
- `default-base.css` — centered-card restyle + theme tokens + mobile fullscreen.

## Notes

- No caller passes the `button` flag, so no behavior contract changes; `task.button` is now inert (follow-up: drop it from the record + `open*` signatures).
- `php -l` clean; `swal` / `swal.close()` are globals in the bundled SweetAlert v1.
- Dogfooded on a dev box; warrants a live pass per theme before merge.

Closes OS-461