### PR TITLE
fix(array-operation): start encrypted array on Enter in passphrase field (OS-462)

### DIFF
--- a/emhttp/plugins/dynamix/ArrayOperation.page
+++ b/emhttp/plugins/dynamix/ArrayOperation.page
@@ -54,8 +54,8 @@ function check_encryption() {
   echo mk_option(1,'text',_('Passphrase'));
   echo mk_option(1,'file',_('Keyfile'));
   echo "</select></td></tr>";
-  echo "<tr id='text'><td></td><td><label for='key-passphrase'>",_('Passphrase'),":</label></td><td><div class='flex flex-row items-center gap-2'><input id='key-passphrase' type='password' name='text' maxlength='512' value='' onkeyup='selectInput(this.form)' placeholder=\""._('use printable characters only')."\"><label class='inline-flex flex-row items-center gap-2 flex-shrink-0'><input name='showPass' type='checkbox' onchange='selectInput(this.form)'>"._('show passphrase')."</label></div></td></tr>";
-  echo "<tr id='copy' class='hidden'><td></td><td><label for='key-retype-passphrase'>",_('Retype passphrase'),":</label></td><td><input id='key-retype-passphrase' type='password' name='copy' maxlength='512' value='' onkeyup='selectInput(this.form)'></td></tr>";
+  echo "<tr id='text'><td></td><td><label for='key-passphrase'>",_('Passphrase'),":</label></td><td><div class='flex flex-row items-center gap-2'><input id='key-passphrase' type='password' name='text' maxlength='512' value='' onkeyup='selectInput(this.form)' onkeydown='submitOnEnter(event)' placeholder=\""._('use printable characters only')."\"><label class='inline-flex flex-row items-center gap-2 flex-shrink-0'><input name='showPass' type='checkbox' onchange='selectInput(this.form)'>"._('show passphrase')."</label></div></td></tr>";
+  echo "<tr id='copy' class='hidden'><td></td><td><label for='key-retype-passphrase'>",_('Retype passphrase'),":</label></td><td><input id='key-retype-passphrase' type='password' name='copy' maxlength='512' value='' onkeyup='selectInput(this.form)' onkeydown='submitOnEnter(event)'></td></tr>";
   echo "<tr id='file' class='hidden'><td></td><td><label for='key-file-upload'>",_('Keyfile'),":</label></td><td><input id='key-file-upload' type='file' name='local' onchange='getFileContent(event,this.form)'></td></tr>";
 }
 
@@ -151,6 +151,24 @@ function toggle_diskio(init) {
 
 function base64(str) {
   return window.btoa(unescape(encodeURIComponent(str)));
+}
+
+function submitOnEnter(event) {
+  if (event.key !== 'Enter') return;
+
+  const field = event.target.name;
+  if (field !== 'text' && field !== 'copy') return;
+
+  const start = $('#cmdStart');
+  if (start.length && !start.prop('disabled')) {
+    // Passphrase validated (and matches the retype field when shown): start.
+    event.preventDefault();
+    start.click();
+  } else if (field === 'text' && $('#copy').is(':visible')) {
+    // Set-new-passphrase flow: confirm in the retype field before starting.
+    event.preventDefault();
+    $('#key-retype-passphrase').focus();
+  }
 }
 
 function selectInput(form) {


### PR DESCRIPTION
## Summary

On the Array Operation page, when starting an encrypted array you must type the passphrase and then **click** the **Start** button — pressing <kbd>Enter</kbd> in the passphrase field does nothing. This adds Enter-to-start so the passphrase field behaves like a normal login form.

## Changes

- Added a small `submitOnEnter(event)` helper in `ArrayOperation.page` that, on <kbd>Enter</kbd>, clicks `#cmdStart` **only when it is enabled**.
- Wired `onkeydown='submitOnEnter(event)'` onto the **Passphrase** and **Retype passphrase** inputs.

Because it just clicks the existing Start button, it inherits all current validation: the button stays disabled until the passphrase is non-empty (and matches the retype field when shown), so Enter can't bypass any checks or fire while the array isn't ready to start. The keyfile flow is unaffected.

## Test plan

- Stopped, encrypted array → focus the **Passphrase** field, type a valid passphrase, press <kbd>Enter</kbd> → array starts (same as clicking **Start**).
- Empty passphrase + <kbd>Enter</kbd> → nothing happens (button still disabled).
- New-key / reformat case with **Retype passphrase** → Enter only starts once both fields match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Enter-key** support in the encryption **passphrase** and **retype passphrase** fields, so pressing Enter behaves like clicking the start button.
  * When the retype field is visible, Enter advances focus to the correct retype input; otherwise it initiates the operation automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Linear

- OS-462
