### PR TITLE
feat(docker): live icon preview on the container Icon URL field (OS-466)

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -1134,7 +1134,7 @@ Template URL:
 </div>
 <div markdown="1" class="advanced">
 _(Icon URL)_:
-: <input type="text" name="contIcon">
+: <input type="text" name="contIcon"> <img id="contIconPreview" alt="" onerror="this.src='/plugins/dynamix.docker.manager/images/question.png'" style="display:none;height:32px;width:32px;vertical-align:middle;margin-left:8px;border-radius:4px;object-fit:contain">
 
 :docker_client_icon_url_help:
 
@@ -2023,6 +2023,16 @@ $(function() {
     echo "$('.advancedview').prop('checked','true'); $('.advancedview').change();";
     echo "$('.advancedview').siblings('.switch-button-background').click();";
   }?>
+  // Live preview of the container Icon URL (mirrors the icon shown in the container list)
+  (function(){
+    var $inp = $('input[name="contIcon"]'), $img = $('#contIconPreview');
+    function update(){
+      var url = ($inp.val()||'').trim();
+      if (url) $img.attr('src', url).show(); else $img.hide();
+    }
+    $inp.on('input change', update);
+    update();
+  })();
 });
 
 if (window.location.href.indexOf("/Apps/") > 0  && <? if (is_file($xmlTemplate)) echo "true"; else echo "false"; ?> ) {


### PR DESCRIPTION
## Summary
Implements [OS-466](https://linear.app/lime-technology/issue/OS-466/docker-live-icon-preview-next-to-the-container-icon-url-field) — a small QoL preview of the container icon next to the **Icon URL** field on the Docker Add/Edit form.

## Changes
- `emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php`:
  - Added a preview `<img id="contIconPreview">` next to the `contIcon` input, with `onerror` fallback to `/plugins/dynamix.docker.manager/images/question.png` (same fallback the container list uses).
  - Added a small JS block (inside the existing on-load `$(function(){…})`, after `Settings` population) that updates the preview `src` on `input`/`change` and hides it when empty. Initializing after population means it also shows the current icon when editing an existing container.

## Notes
- No change to how the icon is saved (`contIcon` → `<Icon>` label).
- `php -l` clean.

## Testing to do on hardware
- Type/paste an icon URL on Add Container → preview updates live.
- Empty or broken URL → question-mark fallback, no broken-image glyph.
- Edit an existing container with an icon → preview shows on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live preview for container icon URLs. Users can now see the icon image as they enter or modify the URL, with automatic fallback to a placeholder if the image fails to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->