### PR TITLE
feat(docker): expose memory (RAM) limit as an Advanced View field (OS-467)

### DIFF
--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -2367,6 +2367,12 @@ If you wish to append additional arguments AFTER the container definition, you c
 The content of this field is container specific.
 :end
 
+:docker_memory_limit_help:
+The maximum amount of memory the container is allowed to use (Docker <code>--memory</code>).<br>
+Use a plain number for bytes, or a suffix: <b>b</b>, <b>k</b>, <b>m</b>, <b>g</b> (for example <b>512m</b> or <b>2g</b>). The minimum allowed value is 6m.<br>
+Leave empty for no limit (default). If you also set <code>--memory</code> in Extra Parameters, that value takes precedence.
+:end
+
 :docker_cpu_pinning_help:
 Checking a CPU core(s) will limit the container to run on the selected cores only. Selecting no cores lets the container run on all available cores (default)
 :end

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -1148,6 +1148,11 @@ _(Extra Parameters)_:
 
 :docker_extra_parameters_help:
 
+_(Memory limit)_:
+: <input type="text" name="contMemory" placeholder="_(unlimited)_" pattern="[0-9]+[bkmgBKMG]?" title="_(Number of bytes, or a number followed by b, k, m or g (e.g. 512m, 2g))_">
+
+:docker_memory_limit_help:
+
 _(Post Arguments)_:
 : <input type="text" name="contPostArgs">
 

--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -151,6 +151,7 @@ function postToXML($post, $setOwnership=false) {
   $xml->ExtraParams                = xml_encode($myMAC && !$extraNetwork ? removeMacAddressParam($post['contExtraParams']) : $post['contExtraParams']);
   $xml->PostArgs                   = xml_encode($post['contPostArgs']);
   $xml->CPUset                     = xml_encode($post['contCPUset']);
+  $xml->Memory                     = xml_encode(trim($post['contMemory']??''));
   $xml->DateInstalled              = xml_encode(time());
   $xml->DonateText                 = xml_encode($post['contDonateText']);
   $xml->DonateLink                 = xml_encode($post['contDonateLink']);
@@ -415,6 +416,7 @@ function xmlToCommand($xml, $create_paths=false) {
     foreach (explode(' ',str_replace(',',' ',$xml['MyIP'])) as $myIP) if ($myIP) $cmdMyIP .= (strpos($myIP,':') !== false ? '--ip6=' : '--ip=').escapeshellarg($myIP).' ';
   }
   $cmdCPUset     = strlen($xml['CPUset']) ? '--cpuset-cpus='.escapeshellarg($xml['CPUset']) : '';
+  $cmdMemory     = strlen($xml['Memory']??'') ? '--memory='.escapeshellarg($xml['Memory']) : '';
   $Volumes       = [''];
   $Ports         = [''];
   $Variables     = [''];
@@ -562,8 +564,8 @@ function xmlToCommand($xml, $create_paths=false) {
     $pid_limit = "";
   }
 
-  $cmd = sprintf($docroot.'/plugins/dynamix.docker.manager/scripts/docker create %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s',
-         $cmdName, $TS_entrypoint, $cmdNetwork, $cmdMyIP, $cmdCPUset, $pid_limit, $cmdPrivileged, implode(' -e ', $Variables), $TS_hostname, $TS_exitnode, $TS_exitnode_ip, $TS_lan_access, $TS_routes, $TS_accept_routes, $TS_ssh, $TS_userspace_networking, $TS_serve_funnel, $TS_serve_port, $TS_serve_target, $TS_serve_local_path, $TS_serve_protocol, $TS_serve_protocol_port, $TS_serve_path, $TS_daemon_params, $TS_extra_params, $TS_state_dir, $TS_troubleshooting, $TS_postargs, implode(' -l ', $Labels), $TS_web_ui, $TS_hostname_label, implode(' -p ', $Ports), implode(' -v ', $Volumes), $TS_hook, $TS_cap, $TS_tundev, implode(' --device=', $Devices), $xml['ExtraParams'], escapeshellarg($xml['Repository']), $xml['PostArgs']);
+  $cmd = sprintf($docroot.'/plugins/dynamix.docker.manager/scripts/docker create %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s',
+         $cmdName, $TS_entrypoint, $cmdNetwork, $cmdMyIP, $cmdCPUset, $cmdMemory, $pid_limit, $cmdPrivileged, implode(' -e ', $Variables), $TS_hostname, $TS_exitnode, $TS_exitnode_ip, $TS_lan_access, $TS_routes, $TS_accept_routes, $TS_ssh, $TS_userspace_networking, $TS_serve_funnel, $TS_serve_port, $TS_serve_target, $TS_serve_local_path, $TS_serve_protocol, $TS_serve_protocol_port, $TS_serve_path, $TS_daemon_params, $TS_extra_params, $TS_state_dir, $TS_troubleshooting, $TS_postargs, implode(' -l ', $Labels), $TS_web_ui, $TS_hostname_label, implode(' -p ', $Ports), implode(' -v ', $Volumes), $TS_hook, $TS_cap, $TS_tundev, implode(' --device=', $Devices), $xml['ExtraParams'], escapeshellarg($xml['Repository']), $xml['PostArgs']);
   return [preg_replace('/\s\s+/', ' ', $cmd), $xml['Name'], $xml['Repository']];
 }
 function stopContainer($name, $t=false, $echo=true) {

--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -229,6 +229,7 @@ function xmlToVar($xml) {
   $out['ExtraParams']                  = $extraParams;
   $out['PostArgs']                     = xml_decode($xml->PostArgs);
   $out['CPUset']                       = xml_decode($xml->CPUset);
+  $out['Memory']                       = xml_decode($xml->Memory ?? '');
   $out['DonateText']                   = xml_decode($xml->DonateText);
   $out['DonateLink']                   = xml_decode($xml->DonateLink);
   $out['Requires']                     = xml_decode($xml->Requires);


### PR DESCRIPTION
## Summary

Docker memory limits were only available through Extra Parameters; this adds a first-class Advanced View field and preserves it through template save, edit-mode loading, and Docker command generation.

## Why This Exists

[OS-467](https://linear.app/lime-technology/issue/OS-467/docker-expose-memory-ram-limit-as-an-advanced-view-field) asks for the existing `docker --memory` capability to be available in the Add/Edit Container UI. The initial implementation saved `<Memory>` to the user template, but QA found that `xmlToVar()` dropped the element before both edit-mode settings and `xmlToCommand()` consumed it.

## Resolution

The Advanced View form accepts a byte count or Docker byte suffix, `postToXML()` stores it as `<Memory>`, and `xmlToVar()` now decodes that element into the canonical settings array. `xmlToCommand()` emits the first-class `--memory` argument before Extra Parameters so the documented duplicate-flag precedence remains unchanged.

## Reviewer Considerations

- Confirm `Memory` belongs alongside `CPUset` in the common XML-to-settings conversion; that path feeds both edit-mode repopulation and command generation.
- Templates created before this feature omit `<Memory>`, so the conversion intentionally defaults the value to an empty string.
- A duplicate `--memory` in Extra Parameters remains later in the command and therefore wins; the help text documents this behavior.
- Docker enforces its 6 MiB minimum at container creation. Client validation checks the value shape without duplicating Docker runtime policy.

## Behavior Changes

- Advanced View shows a Memory limit field near Extra Parameters.
- Values such as `512m`, `2g`, or a raw byte count persist in the container XML and repopulate when editing.
- A non-empty value emits `--memory=<value>` in the Docker create command.
- An empty value keeps the existing unlimited default and emits no memory flag.
- Invalid shapes such as `512mb` are rejected by browser validation.

## Implementation Summary

- Add the `contMemory` Advanced View form field and localized help text.
- Save the submitted value as `<Memory>` in the container XML template.
- Decode `<Memory>` in `xmlToVar()` so settings and command generation receive it.
- Add the first-class memory flag before Extra Parameters in the Docker create command.

## Verification

- `php -d short_open_tag=1 -l emhttp/plugins/dynamix.docker.manager/include/Helpers.php` — passed.
- Targeted PHP regression harness — passed XML-to-settings preservation, missing-element empty default, first-class flag generation, duplicate-flag ordering, and empty-value omission.
- Initial hardware QA verified field visibility, browser validation, empty-limit behavior, Extra Parameters precedence, CPU pinning, and adjacent settings. Hardware re-verification of the corrected round trip is pending on the regenerated PR plugin.

## Risk

Low. The QA fix adds one optional XML mapping with an empty fallback; existing templates and containers keep their prior behavior when no memory value is present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Memory limit field when creating Docker containers.
  * Supports byte values with `b`, `k`, `m`, or `g` suffixes.
  * Allows leaving the field empty for no memory limit.
  * Applies the configured limit to newly created containers.
  * Documented the minimum supported value and precedence of Extra Parameters settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->