### PR TITLE
feat(ci): PR test plugins ship a patch so they stack on shared files (OS-469)

### DIFF
--- a/.github/scripts/generate-pr-plugin.sh
+++ b/.github/scripts/generate-pr-plugin.sh
@@ -107,7 +107,13 @@ if [ -f "$PLUGIN_DIR/text_files.txt" ]; then
     for other in /boot/config/plugins/webgui-pr-*; do
         [ -d "$other" ] || continue
         [ "$other" == "$PLUGIN_DIR" ] && continue
-        [ -f "$other/applied.patch" ] && patch -p1 -d / --forward < "$other/applied.patch" >/dev/null 2>&1 || true
+        [ -f "$other/applied.patch" ] || continue
+        # Non-blocking: all patches passed dry-run at install time, so failure here
+        # is a rare edge case worth surfacing rather than swallowing.
+        if ! patch -p1 -d / --forward --batch < "$other/applied.patch" >/dev/null 2>&1; then
+            echo "⚠️  Warning: could not re-apply $(basename "$other")'s changes; reinstall it or reboot to restore them"
+            logger -t webgui-pr "re-apply of $(basename "$other") patch failed during $(basename "$PLUGIN_DIR") rollback"
+        fi
     done
 fi
 rm -f "$PATCH_APPLIED"
@@ -178,7 +184,7 @@ tar -xzf "$TARBALL" -C "$PAYLOAD"
 # ---- Text changes: apply unified diff -------------------------------------
 if [ -s "$PAYLOAD/pr.patch" ]; then
     echo "Checking patch applies cleanly..."
-    if ! patch -p1 -d / --dry-run --forward < "$PAYLOAD/pr.patch" > /tmp/pr_patch_check.txt 2>&1; then
+    if ! patch -p1 -d / --dry-run --forward --batch < "$PAYLOAD/pr.patch" > /tmp/pr_patch_check.txt 2>&1; then
         echo ""
         echo "❌ Install aborted: this PR's changes do not apply cleanly."
         echo "   Another installed PR plugin likely edits the same lines."
@@ -191,7 +197,7 @@ if [ -s "$PAYLOAD/pr.patch" ]; then
     fi
     rm -f /tmp/pr_patch_check.txt
     echo "Applying patch..."
-    patch -p1 -d / --forward < "$PAYLOAD/pr.patch"
+    patch -p1 -d / --forward --batch < "$PAYLOAD/pr.patch"
     cp -f "$PAYLOAD/pr.patch" "$PATCH_APPLIED"
     # Persist the originals + file list so removal can rebuild deterministically
     rm -rf "$PLUGIN_DIR/orig"
@@ -315,7 +321,13 @@ if [ -f "$PLUGIN_DIR/text_files.txt" ]; then
     for other in /boot/config/plugins/webgui-pr-*; do
         [ -d "$other" ] || continue
         [ "$other" == "$PLUGIN_DIR" ] && continue
-        [ -f "$other/applied.patch" ] && patch -p1 -d / --forward < "$other/applied.patch" >/dev/null 2>&1 || true
+        [ -f "$other/applied.patch" ] || continue
+        # Non-blocking: all patches passed dry-run at install time, so failure here
+        # is a rare edge case worth surfacing rather than swallowing.
+        if ! patch -p1 -d / --forward --batch < "$other/applied.patch" >/dev/null 2>&1; then
+            echo "⚠️  Warning: could not re-apply $(basename "$other")'s changes; reinstall it or reboot to restore them"
+            logger -t webgui-pr "re-apply of $(basename "$other") patch failed during $(basename "$PLUGIN_DIR") rollback"
+        fi
     done
     echo "✅ Text changes restored"
 fi

--- a/.github/scripts/generate-pr-plugin.sh
+++ b/.github/scripts/generate-pr-plugin.sh
@@ -4,6 +4,15 @@ IFS=$'\n\t'
 
 # Generate PR plugin file for Unraid
 # Usage: ./generate-pr-plugin.sh <version> <pr_number> <commit_sha> <local_tarball> <remote_tarball> <txz_url> [plugin_url]
+#
+# The tarball payload contains:
+#   pr.patch          unified diff of all changed TEXT files (system-relative paths, apply with patch -p1 at /)
+#   binary/<path>     whole copies of changed BINARY files (cannot be diffed)
+#   binary_files.txt  list of binary paths (system-relative)
+#
+# Install applies pr.patch with `patch`, so several PR plugins can stack on the
+# same file as long as their hunks do not overlap. Binaries fall back to a
+# whole-file replace, guarded so two plugins never fight over the same binary.
 
 VERSION=$1
 PR_NUMBER=$2
@@ -45,24 +54,25 @@ cat > "$PLUGIN_NAME" << 'EOF'
   <!ENTITY github "https://github.com/unraid/webgui">
 ]>
 
-<PLUGIN name="&name;-&version;" 
-        author="&author;" 
-        version="&version;" 
-        pluginURL="&pluginURL;" 
-        min="7.1.0" 
+<PLUGIN name="&name;-&version;"
+        author="&author;"
+        version="&version;"
+        pluginURL="&pluginURL;"
+        min="7.1.0"
         icon="wrench"
         support="&github;/pull/&pr;">
 
 <CHANGES>
 ##&version;
 - Test build for PR #&pr; (commit &commit;)
-- This plugin installs modified files from the PR for testing
-- Original files are backed up and restored upon removal
+- Applies the PR's changes as a patch, so multiple PR test plugins can be
+  installed together as long as they do not edit the same lines
+- Changes are reversed when the plugin is removed
 </CHANGES>
 
-<!-- FILE sections run in the listed order - Check if this is an update prior to installing -->
+<!-- FILE sections run in the listed order -->
 
-<!-- If this is an update - restore originals before installing the update -->
+<!-- If this is an update: reverse the previously applied patch / restore binaries first -->
 <FILE Run="/bin/bash" Method="install">
 <INLINE>
 <![CDATA[
@@ -72,54 +82,43 @@ echo "===================================="
 echo "Version: VERSION_PLACEHOLDER"
 echo ""
 
-BACKUP_DIR="/boot/config/plugins/webgui-pr-PR_PLACEHOLDER/backups"
-MANIFEST="/boot/config/plugins/webgui-pr-PR_PLACEHOLDER/installed_files.txt"
+PLUGIN_DIR="/boot/config/plugins/webgui-pr-PR_PLACEHOLDER"
+BACKUP_DIR="$PLUGIN_DIR/backups"
+MANIFEST="$PLUGIN_DIR/installed_files.txt"
+PATCH_APPLIED="$PLUGIN_DIR/applied.patch"
+PAYLOAD="$PLUGIN_DIR/payload"
 
-# Ensure required directories exist even on first-time install/update
-mkdir -p "/boot/config/plugins/webgui-pr-PR_PLACEHOLDER" "$BACKUP_DIR"
+mkdir -p "$PLUGIN_DIR" "$BACKUP_DIR"
 
-# First restore original files to ensure clean state
-if [ -f "$MANIFEST" ]; then
-    echo "Step 1: Restoring original files before update..."
-    echo "------------------------------------------------"
-    
-    while IFS='|' read -r system_file backup_file; do
-        if [ "$backup_file" == "NEW" ]; then
-            # This was a new file from previous version, remove it
-            if [ -e "$system_file" ] || [ -L "$system_file" ]; then
-                echo "Removing PR file: $system_file"
-                rm -f "$system_file"
-            fi
-        else
-            # Restore original from backup
-            if [ -f "$backup_file" ]; then
-                echo "Restoring original: $system_file"
-                cp -fp "$backup_file" "$system_file"
-            else
-                echo "⚠️  Missing backup for: $system_file"
-            fi
-        fi
-    done < "$MANIFEST"
-    
-    echo ""
-    echo "✅ Original files restored"
-    echo ""
-else
-    echo "⚠️  No previous manifest found, proceeding with fresh install"
-    echo ""
+# Reverse a previously applied patch so we start from a clean base
+if [ -f "$PATCH_APPLIED" ]; then
+    echo "Reverting previously applied patch..."
+    patch -R -p1 -d / --batch < "$PATCH_APPLIED" || echo "⚠️  Reverse-apply reported issues (continuing)"
+    rm -f "$PATCH_APPLIED"
 fi
 
-# Clear the old manifest for the new version (dir now guaranteed)
-> "$MANIFEST"
+# Restore any previously installed binary files
+if [ -f "$MANIFEST" ]; then
+    echo "Restoring binary files from previous version..."
+    while IFS='|' read -r system_file backup_file; do
+        [ -n "$system_file" ] || continue
+        if [ "$backup_file" == "NEW" ]; then
+            [ -e "$system_file" ] && { echo "Removing PR file: $system_file"; rm -f "$system_file"; }
+        elif [ -f "$backup_file" ]; then
+            echo "Restoring original: $system_file"
+            cp -fp "$backup_file" "$system_file"
+        fi
+    done < "$MANIFEST"
+fi
 
-echo "Step 2: Update will now proceed with installation of new PR files..."
-echo ""
-
-# The update continues by running the install method which will extract new files
+: > "$MANIFEST"
+rm -rf "$PAYLOAD"
+echo "Ready for fresh install of PR files."
 ]]>
 </INLINE>
 </FILE>
-<!-- Create backup directory -->
+
+<!-- Create plugin directories -->
 <FILE Run="/bin/bash" Method="install">
 <INLINE>
 <![CDATA[
@@ -130,202 +129,89 @@ echo "Version: VERSION_PLACEHOLDER"
 echo "PR: #PR_PLACEHOLDER"
 echo "Commit: COMMIT_PLACEHOLDER"
 echo ""
-
-# Create directories
-mkdir -p /boot/config/plugins/webgui-pr-PR_PLACEHOLDER
 mkdir -p /boot/config/plugins/webgui-pr-PR_PLACEHOLDER/backups
-
 echo "Created plugin directories"
 ]]>
 </INLINE>
 </FILE>
 
-<!-- Download tarball from GitHub -->
+<!-- Download tarball from GitHub/R2 -->
 <FILE Name="/boot/config/plugins/webgui-pr-PR_PLACEHOLDER/REMOTE_TARBALL_PLACEHOLDER">
 <URL>TXZ_URL_PLACEHOLDER</URL>
 <SHA256>&sha256;</SHA256>
 </FILE>
 
-<!-- Backup and install files -->
+<!-- Apply patch + install binaries -->
 <FILE Run="/bin/bash" Method="install">
 <INLINE>
 <![CDATA[
-BACKUP_DIR="/boot/config/plugins/webgui-pr-PR_PLACEHOLDER/backups"
-TARBALL="/boot/config/plugins/webgui-pr-PR_PLACEHOLDER/REMOTE_TARBALL_PLACEHOLDER"
-MANIFEST="/boot/config/plugins/webgui-pr-PR_PLACEHOLDER/installed_files.txt"
+PLUGIN_DIR="/boot/config/plugins/webgui-pr-PR_PLACEHOLDER"
+BACKUP_DIR="$PLUGIN_DIR/backups"
+MANIFEST="$PLUGIN_DIR/installed_files.txt"
+PATCH_APPLIED="$PLUGIN_DIR/applied.patch"
+TARBALL="$PLUGIN_DIR/REMOTE_TARBALL_PLACEHOLDER"
+PAYLOAD="$PLUGIN_DIR/payload"
 
-echo "Starting file deployment..."
-echo "Tarball: $TARBALL"
-echo "Backup directory: $BACKUP_DIR"
+echo "Extracting payload..."
+rm -rf "$PAYLOAD"
+mkdir -p "$PAYLOAD"
+tar -xzf "$TARBALL" -C "$PAYLOAD"
+: > "$MANIFEST"
 
-# Clear manifest
-> "$MANIFEST"
-
-# Get file list first
-echo "Examining tarball contents..."
-tar -tzf "$TARBALL" | head -20
-echo ""
-
-# Count total files
-FILE_COUNT=$(tar -tzf "$TARBALL" | grep -v '/$' | wc -l)
-echo "Total files to process: $FILE_COUNT"
-echo ""
-
-# Get file list
-tar -tzf "$TARBALL" > /tmp/plugin_files.txt
-
-# Abort if any files are already managed by another PR plugin
-OTHER_MANIFESTS="/tmp/pr_plugin_existing_files.txt"
-> "$OTHER_MANIFESTS"
-for plugin_dir in /boot/config/plugins/webgui-pr-*; do
-    if [ ! -d "$plugin_dir" ]; then
-        continue
-    fi
-    if [ "$plugin_dir" == "/boot/config/plugins/webgui-pr-PR_PLACEHOLDER" ]; then
-        continue
-    fi
-    manifest="$plugin_dir/installed_files.txt"
-    if [ -f "$manifest" ]; then
-        plugin_name=$(basename "$plugin_dir")
-        while IFS='|' read -r other_file _; do
-            if [ -n "$other_file" ]; then
-                echo "${other_file}|${plugin_name}" >> "$OTHER_MANIFESTS"
-            fi
-        done < "$manifest"
-    fi
-done
-
-if [ -s "$OTHER_MANIFESTS" ]; then
-    declare -A existing_files
-    while IFS='|' read -r existing_file existing_plugin; do
-        if [ -z "$existing_file" ] || [ -z "$existing_plugin" ]; then
-            continue
-        fi
-        if [ -n "${existing_files[$existing_file]:-}" ]; then
-            if [[ ",${existing_files[$existing_file]}," != *",${existing_plugin},"* ]]; then
-                existing_files[$existing_file]="${existing_files[$existing_file]},${existing_plugin}"
-            fi
-        else
-            existing_files[$existing_file]="$existing_plugin"
-        fi
-    done < "$OTHER_MANIFESTS"
-
-    conflict_found=0
-    declare -A conflict_plugins
-    while IFS= read -r file; do
-        # Skip directories
-        if [[ "$file" == */ ]]; then
-            continue
-        fi
-
-        system_file="/${file}"
-        if [ -n "${existing_files[$system_file]:-}" ]; then
-            conflict_found=1
-            echo "Conflict: $system_file is already managed by ${existing_files[$system_file]}"
-            IFS=',' read -r -a plugin_list <<< "${existing_files[$system_file]}"
-            for plugin in "${plugin_list[@]}"; do
-                conflict_plugins[$plugin]=1
-            done
-        fi
-    done < /tmp/plugin_files.txt
-
-    if [ "$conflict_found" -eq 1 ]; then
+# ---- Text changes: apply unified diff -------------------------------------
+if [ -s "$PAYLOAD/pr.patch" ]; then
+    echo "Checking patch applies cleanly..."
+    if ! patch -p1 -d / --dry-run --forward < "$PAYLOAD/pr.patch" > /tmp/pr_patch_check.txt 2>&1; then
         echo ""
-        echo "❌ Install aborted."
-        echo "One or more files are already managed by another PR plugin."
-        echo "Please uninstall the conflicting plugin(s) and try again:"
-        for plugin in "${!conflict_plugins[@]}"; do
-            echo "  plugin remove ${plugin}.plg"
-        done
-        rm -f "$OTHER_MANIFESTS" /tmp/plugin_files.txt
+        echo "❌ Install aborted: this PR's changes do not apply cleanly."
+        echo "   Another installed PR plugin likely edits the same lines."
+        echo "------------------------------------------------------------"
+        grep -Ei 'FAILED|can.t find file|hunk' /tmp/pr_patch_check.txt || cat /tmp/pr_patch_check.txt
+        echo "------------------------------------------------------------"
+        echo "Remove the conflicting webgui-pr-* plugin and try again."
+        rm -f /tmp/pr_patch_check.txt
         exit 1
     fi
+    rm -f /tmp/pr_patch_check.txt
+    echo "Applying patch..."
+    patch -p1 -d / --forward < "$PAYLOAD/pr.patch"
+    cp -f "$PAYLOAD/pr.patch" "$PATCH_APPLIED"
+    echo "✅ Patch applied"
 fi
 
-rm -f "$OTHER_MANIFESTS"
-
-# Backup original files BEFORE extraction
-while IFS= read -r file; do
-    # Skip directories
-    if [[ "$file" == */ ]]; then
-        continue
-    fi
-    
-    # The tarball contains usr/local/emhttp/... (no leading slash)
-    # When we extract with -C /, it becomes /usr/local/emhttp/...
-    SYSTEM_FILE="/${file}"
-    BACKUP_FILE="$BACKUP_DIR/$(echo "$file" | tr '/' '_')"
-    
-    echo "Processing: $file"
-    
-    # Only backup if we haven't already backed up this file
-    # (preserves original backups across updates)
-    if [ -f "$BACKUP_FILE" ]; then
-        echo "  → Using existing backup: $BACKUP_FILE"
-        echo "$SYSTEM_FILE|$BACKUP_FILE" >> "$MANIFEST"
-    elif [ -f "$SYSTEM_FILE" ]; then
-        echo "  → Creating backup of original: $SYSTEM_FILE"
-        cp -p "$SYSTEM_FILE" "$BACKUP_FILE"
-        echo "$SYSTEM_FILE|$BACKUP_FILE" >> "$MANIFEST"
-    else
-        echo "  → Will create new: $SYSTEM_FILE"
-        echo "$SYSTEM_FILE|NEW" >> "$MANIFEST"
-    fi
-done < /tmp/plugin_files.txt
-
-# Clean up temp file
-rm -f /tmp/plugin_files.txt
-
-# Extract the tarball to root with verbose output
-# Since tarball contains usr/local/emhttp/..., extracting to / makes it /usr/local/emhttp/...
-echo ""
-echo "Extracting files to system (verbose mode)..."
-echo "----------------------------------------"
-tar -xzvf "$TARBALL" -C /
-EXTRACT_STATUS=$?
-echo "----------------------------------------"
-echo "Extraction completed with status: $EXTRACT_STATUS"
-echo ""
-
-# Verify extraction
-echo "Verifying installation..."
-INSTALLED_COUNT=0
-while IFS='|' read -r file backup; do
-    if [ -f "$file" ]; then
-        INSTALLED_COUNT=$((INSTALLED_COUNT + 1))
-    fi
-done < "$MANIFEST"
-
-echo "Successfully installed $INSTALLED_COUNT files"
-
-echo ""
-echo "✅ Installation complete!"
-echo ""
-echo "Summary:"
-echo "--------"
-echo "Files deployed: $INSTALLED_COUNT"
-echo ""
-if [ $INSTALLED_COUNT -gt 0 ]; then
-    echo "Modified files:"
-    while IFS='|' read -r file backup; do
-        if [ -f "$file" ]; then
-            if [ "$backup" == "NEW" ]; then
-                echo "  [NEW] $file"
-            else
-                echo "  [MOD] $file"
+# ---- Binary changes: whole-file replace (cannot be merged) -----------------
+if [ -s "$PAYLOAD/binary_files.txt" ]; then
+    # Guard: a binary may only be managed by one PR plugin at a time
+    while IFS= read -r sys; do
+        [ -n "$sys" ] || continue
+        for other in /boot/config/plugins/webgui-pr-*; do
+            [ -d "$other" ] || continue
+            [ "$other" == "$PLUGIN_DIR" ] && continue
+            if [ -f "$other/installed_files.txt" ] && grep -q "^/$sys|" "$other/installed_files.txt"; then
+                echo "❌ Install aborted: binary /$sys is already managed by $(basename "$other")."
+                echo "   Remove that plugin first: plugin remove $(basename "$other").plg"
+                exit 1
             fi
-        fi
-    done < "$MANIFEST"
-else
-    echo "⚠️  WARNING: No files were installed!"
-    echo "Check that the tarball structure matches the expected format."
+        done
+    done < "$PAYLOAD/binary_files.txt"
+
+    while IFS= read -r sys; do
+        [ -n "$sys" ] || continue
+        SYS="/$sys"
+        SRC="$PAYLOAD/binary/$sys"
+        BK="$BACKUP_DIR/$(echo "$sys" | tr '/' '_')"
+        mkdir -p "$(dirname "$SYS")"
+        if [ -f "$SYS" ] && [ ! -f "$BK" ]; then cp -p "$SYS" "$BK"; fi
+        if [ -f "$BK" ]; then echo "$SYS|$BK" >> "$MANIFEST"; else echo "$SYS|NEW" >> "$MANIFEST"; fi
+        cp -f "$SRC" "$SYS"
+        echo "Installed binary: $SYS"
+    done < "$PAYLOAD/binary_files.txt"
 fi
 
 echo ""
-echo "⚠️  This is a TEST plugin for PR #PR_PLACEHOLDER"
-echo "⚠️  Remove this plugin before applying production updates"
-echo ""
-echo "⚠️  NOTE: Under certain circumstances, it might be necessary to reboot the server for the code changes to take effect"
+echo "✅ Installation complete for PR #PR_PLACEHOLDER"
+echo "⚠️  This is a TEST plugin — remove it before applying production updates"
+echo "⚠️  A reboot may be required for some changes to take effect"
 ]]>
 </INLINE>
 </FILE>
@@ -360,7 +246,7 @@ Link='nav-user'
     window.uninstallPRPlugin = function() {
       swal({
         title: "Uninstall PR Test Plugin?",
-        text: "This will restore all original files and remove the test plugin.",
+        text: "This will reverse all of this PR's changes and remove the test plugin.",
         type: "warning",
         showCancelButton: true,
         confirmButtonText: "Yes, uninstall",
@@ -369,8 +255,6 @@ Link='nav-user'
         showLoaderOnConfirm: true
       }, function(isConfirm) {
         if (isConfirm) {
-          // Execute plugin removal using openPlugin (Unraid's standard method)
-          // The "refresh" parameter will automatically reload the page when uninstall is completed
           openPlugin("plugin remove webgui-pr-PR_PLACEHOLDER.plg", "Removing PR Test Plugin", "", "refresh");
         }
       });
@@ -390,48 +274,40 @@ echo "WebGUI PR Test Plugin Removal"
 echo "===================================="
 echo ""
 
-BACKUP_DIR="/boot/config/plugins/webgui-pr-PR_PLACEHOLDER/backups"
-MANIFEST="/boot/config/plugins/webgui-pr-PR_PLACEHOLDER/installed_files.txt"
+PLUGIN_DIR="/boot/config/plugins/webgui-pr-PR_PLACEHOLDER"
+MANIFEST="$PLUGIN_DIR/installed_files.txt"
+PATCH_APPLIED="$PLUGIN_DIR/applied.patch"
 
-if [ -f "$MANIFEST" ]; then
-    echo "Restoring original files..."
-    
-    while IFS='|' read -r system_file backup_file; do
-        if [ "$backup_file" == "NEW" ]; then
-            # This was a new file, remove it
-            if [ -e "$system_file" ] || [ -L "$system_file" ]; then
-                echo "Removing new file: $system_file"
-                rm -f "$system_file"
-            fi
-        else
-            # Restore from backup
-            if [ -f "$backup_file" ]; then
-                echo "Restoring: $system_file"
-                cp -fp "$backup_file" "$system_file"
-            else
-                echo "⚠️  Missing backup for: $system_file"
-            fi
-        fi
-    done < "$MANIFEST"
-    
-    echo ""
-    echo "✅ Original files restored"
-else
-    echo "⚠️  No manifest found, cannot restore files"
+# Reverse the applied patch (text changes)
+if [ -f "$PATCH_APPLIED" ]; then
+    echo "Reverting patch..."
+    patch -R -p1 -d / --batch < "$PATCH_APPLIED" || echo "⚠️  Reverse-apply reported issues"
+    echo "✅ Patch reverted"
 fi
 
-# Clean up
+# Restore binary files
+if [ -f "$MANIFEST" ]; then
+    echo "Restoring binary files..."
+    while IFS='|' read -r system_file backup_file; do
+        [ -n "$system_file" ] || continue
+        if [ "$backup_file" == "NEW" ]; then
+            [ -e "$system_file" ] && { echo "Removing new file: $system_file"; rm -f "$system_file"; }
+        elif [ -f "$backup_file" ]; then
+            echo "Restoring: $system_file"
+            cp -fp "$backup_file" "$system_file"
+        else
+            echo "⚠️  Missing backup for: $system_file"
+        fi
+    done < "$MANIFEST"
+fi
+
 echo "Cleaning up plugin files..."
-# Remove the banner
 rm -rf "/usr/local/emhttp/plugins/webgui-pr-PR_PLACEHOLDER"
-# Remove the plugin directory (which includes the tarball and backups)
-rm -rf "/boot/config/plugins/webgui-pr-PR_PLACEHOLDER"
-# Note: The .plg file is handled automatically by the plugin system and should not be removed here
+rm -rf "$PLUGIN_DIR"
 
 echo ""
 echo "✅ Plugin removed successfully"
-echo ""
-echo "⚠️  A reboot of the server might be required under certain circumstances to completely remove all traces of this plugin"
+echo "⚠️  A reboot may be required to fully clear all changes"
 ]]>
 </INLINE>
 </FILE>

--- a/.github/scripts/generate-pr-plugin.sh
+++ b/.github/scripts/generate-pr-plugin.sh
@@ -90,12 +90,29 @@ PAYLOAD="$PLUGIN_DIR/payload"
 
 mkdir -p "$PLUGIN_DIR" "$BACKUP_DIR"
 
-# Reverse a previously applied patch so we start from a clean base
-if [ -f "$PATCH_APPLIED" ]; then
-    echo "Reverting previously applied patch..."
-    patch -R -p1 -d / --batch < "$PATCH_APPLIED" || echo "⚠️  Reverse-apply reported issues (continuing)"
-    rm -f "$PATCH_APPLIED"
+# Roll back THIS plugin's previous text changes by restoring the shipped
+# originals, then re-applying the other still-installed PR plugins so their
+# changes survive. (Deterministic: does not depend on reverse-patch context.)
+if [ -f "$PLUGIN_DIR/text_files.txt" ]; then
+    echo "Rolling back previous text changes..."
+    while IFS= read -r sys; do
+        [ -n "$sys" ] || continue
+        SYS="/$sys"
+        if [ -f "$PLUGIN_DIR/orig/$sys" ]; then
+            mkdir -p "$(dirname "$SYS")"; cp -f "$PLUGIN_DIR/orig/$sys" "$SYS"
+        else
+            rm -f "$SYS"   # file was newly added by this PR
+        fi
+    done < "$PLUGIN_DIR/text_files.txt"
+    for other in /boot/config/plugins/webgui-pr-*; do
+        [ -d "$other" ] || continue
+        [ "$other" == "$PLUGIN_DIR" ] && continue
+        [ -f "$other/applied.patch" ] && patch -p1 -d / --forward < "$other/applied.patch" >/dev/null 2>&1 || true
+    done
 fi
+rm -f "$PATCH_APPLIED"
+rm -rf "$PLUGIN_DIR/orig"
+: > "$PLUGIN_DIR/text_files.txt"
 
 # Restore any previously installed binary files
 if [ -f "$MANIFEST" ]; then
@@ -176,6 +193,10 @@ if [ -s "$PAYLOAD/pr.patch" ]; then
     echo "Applying patch..."
     patch -p1 -d / --forward < "$PAYLOAD/pr.patch"
     cp -f "$PAYLOAD/pr.patch" "$PATCH_APPLIED"
+    # Persist the originals + file list so removal can rebuild deterministically
+    rm -rf "$PLUGIN_DIR/orig"
+    [ -d "$PAYLOAD/orig" ] && cp -a "$PAYLOAD/orig" "$PLUGIN_DIR/orig"
+    [ -f "$PAYLOAD/text_files.txt" ] && cp -f "$PAYLOAD/text_files.txt" "$PLUGIN_DIR/text_files.txt"
     echo "✅ Patch applied"
 fi
 
@@ -278,11 +299,25 @@ PLUGIN_DIR="/boot/config/plugins/webgui-pr-PR_PLACEHOLDER"
 MANIFEST="$PLUGIN_DIR/installed_files.txt"
 PATCH_APPLIED="$PLUGIN_DIR/applied.patch"
 
-# Reverse the applied patch (text changes)
-if [ -f "$PATCH_APPLIED" ]; then
-    echo "Reverting patch..."
-    patch -R -p1 -d / --batch < "$PATCH_APPLIED" || echo "⚠️  Reverse-apply reported issues"
-    echo "✅ Patch reverted"
+# Restore this plugin's text files to their shipped originals, then re-apply the
+# other still-installed PR plugins so their (non-overlapping) changes survive.
+if [ -f "$PLUGIN_DIR/text_files.txt" ]; then
+    echo "Restoring text files..."
+    while IFS= read -r sys; do
+        [ -n "$sys" ] || continue
+        SYS="/$sys"
+        if [ -f "$PLUGIN_DIR/orig/$sys" ]; then
+            mkdir -p "$(dirname "$SYS")"; cp -f "$PLUGIN_DIR/orig/$sys" "$SYS"
+        else
+            rm -f "$SYS"   # file was newly added by this PR
+        fi
+    done < "$PLUGIN_DIR/text_files.txt"
+    for other in /boot/config/plugins/webgui-pr-*; do
+        [ -d "$other" ] || continue
+        [ "$other" == "$PLUGIN_DIR" ] && continue
+        [ -f "$other/applied.patch" ] && patch -p1 -d / --forward < "$other/applied.patch" >/dev/null 2>&1 || true
+    done
+    echo "✅ Text changes restored"
 fi
 
 # Restore binary files

--- a/.github/workflows/pr-plugin-build.yml
+++ b/.github/workflows/pr-plugin-build.yml
@@ -81,58 +81,79 @@ jobs:
       
       - name: Create plugin package
         if: steps.changed-files.outputs.has_changes == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          # Create build directory
-          mkdir -p build/usr/local
-          
-          # Copy changed files preserving directory structure
+          set -euo pipefail
+          # Payload layout:
+          #   build/pr.patch          unified diff of all changed TEXT files (system-relative paths)
+          #   build/binary/<path>     whole copies of changed BINARY files (cannot be diffed)
+          #   build/binary_files.txt  list of binary paths (system-relative)
+          # The plugin applies pr.patch with `patch` so multiple PR plugins can
+          # stack on the same file; binaries fall back to whole-file replace.
+          mkdir -p build old new
+
+          # Map a repo path to its system-relative install path (no leading slash),
+          # matching the historical install layout.
+          map_path() {
+            case "$1" in
+              etc/rc.d/*) echo "usr/local/etc/rc.d/${1#etc/rc.d/}" ;;
+              etc/*)      echo "$1" ;;
+              sbin/*)     echo "usr/local/sbin/${1#sbin/}" ;;
+              share/*)    echo "usr/local/share/${1#share/}" ;;
+              emhttp/*)   echo "usr/local/$1" ;;
+              *)          echo "" ;;
+            esac
+          }
+
+          : > build/binary_files.txt
+          has_text=0
+
           while IFS= read -r file; do
-            if [ -f "$file" ]; then
-              # Create directory structure in build with target mappings
-              case "$file" in
-                etc/rc.d/*)
-                  target_dir="build/usr/local/etc/rc.d"
-                  ;;
-                etc/*)
-                  target_dir="build/${file%/*}"
-                  ;;
-                sbin/*)
-                  target_dir="build/usr/local/sbin/${file#sbin/}"
-                  target_dir="${target_dir%/*}"
-                  ;;
-                share/*)
-                  target_dir="build/usr/local/share/${file#share/}"
-                  target_dir="${target_dir%/*}"
-                  ;;
-                emhttp/*)
-                  target_dir="build/usr/local/${file%/*}"
-                  ;;
-                *)
-                  echo "Skipping unsupported path: $file"
-                  continue
-                  ;;
-              esac
-              mkdir -p "$target_dir"
-              cp "$file" "$target_dir/"
-              echo "Added: $file"
+            [ -n "$file" ] || continue
+            sys=$(map_path "$file")
+            if [ -z "$sys" ]; then echo "Skipping unsupported path: $file"; continue; fi
+
+            # numstat reports "-\t-" for binary files (one line per single file)
+            if git diff --numstat "$BASE_SHA" HEAD -- "$file" | grep -qP '^-\t-\t'; then
+              if [ -f "$file" ]; then
+                mkdir -p "build/binary/$(dirname "$sys")"
+                cp "$file" "build/binary/$sys"
+                echo "$sys" >> build/binary_files.txt
+                echo "Binary: $file -> $sys"
+              else
+                echo "Skipping deleted binary (unsupported): $file"
+              fi
+              continue
             fi
+
+            # Text: stage base version under old/, head version under new/
+            if git cat-file -e "$BASE_SHA:$file" 2>/dev/null; then
+              mkdir -p "old/$(dirname "$sys")"
+              git show "$BASE_SHA:$file" > "old/$sys"
+            fi
+            if [ -f "$file" ]; then
+              mkdir -p "new/$(dirname "$sys")"
+              cp "$file" "new/$sys"
+            fi
+            has_text=1
+            echo "Text: $file -> $sys"
           done < changed_files.txt
-          
-          # Generate file list for plugin/tar (relative paths)
+
+          # Unified diff with old/<sys> and new/<sys> headers (apply with patch -p1 at /).
+          # diff exits 1 when differences exist; only 2 is a real error.
+          if [ "$has_text" -eq 1 ]; then
+            diff -ruN old new > build/pr.patch || [ $? -eq 1 ]
+            echo "pr.patch hunks: $(grep -c '^@@' build/pr.patch || echo 0)"
+          fi
+
           find build -type f | sed 's|^build/||' > file_list.txt
-          echo "File list for plugin:"
-          cat file_list.txt
-          
-          # Create tarball - consistent filename for updates
-          cd build
-          echo "Creating tarball with contents:"
-          cat ../file_list.txt
-          tar -czf ../${{ steps.version.outputs.local_txz }} -T ../file_list.txt
-          cd ..
-          
-          # Verify tarball contents
+          echo "Payload contents:"; cat file_list.txt
+
+          # Tarball the payload (extracted to a temp dir by the plugin, not to /)
+          tar -czf "${{ steps.version.outputs.local_txz }}" -C build .
           echo "Tarball contents:"
-          tar -tzf ${{ steps.version.outputs.local_txz }}
+          tar -tzf "${{ steps.version.outputs.local_txz }}"
       
       - name: Generate plugin file
         if: steps.changed-files.outputs.has_changes == 'true'

--- a/.github/workflows/pr-plugin-build.yml
+++ b/.github/workflows/pr-plugin-build.yml
@@ -107,6 +107,7 @@ jobs:
           }
 
           : > build/binary_files.txt
+          : > build/text_files.txt
           has_text=0
 
           while IFS= read -r file; do
@@ -137,6 +138,7 @@ jobs:
               cp "$file" "new/$sys"
             fi
             has_text=1
+            echo "$sys" >> build/text_files.txt
             echo "Text: $file -> $sys"
           done < changed_files.txt
 
@@ -145,6 +147,11 @@ jobs:
           if [ "$has_text" -eq 1 ]; then
             diff -ruN old new > build/pr.patch || [ $? -eq 1 ]
             echo "pr.patch hunks: $(grep -c '^@@' build/pr.patch || echo 0)"
+            # Ship the base (original) version of each text file so removal can
+            # rebuild deterministically: restore originals + re-apply the other
+            # still-installed PR plugins' patches.
+            mkdir -p build/orig
+            cp -a old/. build/orig/ 2>/dev/null || true
           fi
 
           find build -type f | sed 's|^build/||' > file_list.txt


### PR DESCRIPTION
## Summary
Implements [OS-469](https://linear.app/lime-technology/issue/OS-469/pr-test-plugin-ship-a-diffpatch-so-multiple-pr-plugins-can-stack-on). The per-PR test plugin used to package changed files as **whole-file copies**, overwrite them on install, and **abort** if another `webgui-pr-*` plugin already managed any of the same files — so two PRs touching one file (e.g. [#2672](https://github.com/unraid/webgui/pull/2672) + [#2673](https://github.com/unraid/webgui/pull/2673), both editing `CreateDocker.php`) couldn't be tested together.

Now it ships a **unified diff** and `patch`-applies it, so non-overlapping edits to the same file stack.

## How it works
- **Build** (`pr-plugin-build.yml`): for changed **text** files, stage base + head versions in system layout and emit `pr.patch` (`diff -ruN`, paths apply with `patch -p1` at `/`). Changed **binary** files are copied whole into `binary/` with a `binary_files.txt` list. Both go in the same tarball.
- **Plugin** (`generate-pr-plugin.sh`): on install, `patch -p1 --dry-run --forward` first — **abort with a clear message on a real reject** (overlapping change), otherwise apply and save `applied.patch`. Binaries are whole-file replaced with a per-binary conflict guard. On remove (and before update), reverse the patch (`patch -R`) and restore binary backups.
- **Upload/R2 plumbing unchanged** — still a single tarball with the same URL/SHA wiring.

## Validation (local simulation)
- Two patches editing the same file at different lines → **both apply, both changes coexist**.
- Reversing one → **only that change is removed, the other stays**.
- Overlapping edits → **dry-run fails → install aborts** cleanly.
- Generated `.plg` is well-formed XML (all placeholders substituted); `bash -n` + YAML parse clean.

## Notes / still to verify
- Real validation needs CI + an Unraid box installing two stacked PR plugins. Conveniently, **this PR touches `.github/**`, so it will itself build a PR test plugin with the new code** — a live smoke test of the generator.
- Binary deletions aren't handled (rare); text add/modify/delete are.
- `patch` is present in the Unraid base; uses `--forward`/`--batch` for non-interactive apply with fuzz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved plugin install/update and uninstall to use a deterministic, patch-based manifest workflow for safer reversibility.
  * Enhanced plugin package generation to build a patch-oriented payload, distinguishing text changes from full binary replacements.
  * Updated the uninstall confirmation flow to reflect the new removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->