### PR TITLE
fix(docker): fall back to docker.cfg gateway for auto VLAN networks (OS-468)

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
@@ -118,13 +118,12 @@ function base_net($route) {
 // Derive the IPv4 gateway rc.docker would use when none is configured:
 // the subnet's first usable host (e.g. 192.168.10.0/24 -> 192.168.10.1).
 // Calls the same scripts/derive_gateway helper rc.docker uses, so the logic
-// is not duplicated. Invoked via bash so it works regardless of the file's
-// execute bit (PR test plugins can ship it 644). Returns '' if not derivable.
+// is not duplicated. Returns '' if not derivable.
 function derive_gw($route) {
   global $docroot;
   $route = trim((string)$route);
   if ($route === '') return '';
-  return exec("bash ".escapeshellarg($docroot."/plugins/dynamix.docker.manager/scripts/derive_gateway")." ".escapeshellarg($route));
+  return exec($docroot."/plugins/dynamix.docker.manager/scripts/derive_gateway ".escapeshellarg($route));
 }
 
 $bgcolor = $themeHelper->isLightTheme() ? '#f2f2f2' : '#1c1c1c'; // $themeHelper set in DefaultPageLayout.php

--- a/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
@@ -118,12 +118,13 @@ function base_net($route) {
 // Derive the IPv4 gateway rc.docker would use when none is configured:
 // the subnet's first usable host (e.g. 192.168.10.0/24 -> 192.168.10.1).
 // Calls the same scripts/derive_gateway helper rc.docker uses, so the logic
-// is not duplicated. Returns '' if not derivable.
+// is not duplicated. Invoked via bash so it works regardless of the file's
+// execute bit (PR test plugins can ship it 644). Returns '' if not derivable.
 function derive_gw($route) {
   global $docroot;
   $route = trim((string)$route);
   if ($route === '') return '';
-  return exec($docroot."/plugins/dynamix.docker.manager/scripts/derive_gateway ".escapeshellarg($route));
+  return exec("bash ".escapeshellarg($docroot."/plugins/dynamix.docker.manager/scripts/derive_gateway")." ".escapeshellarg($route));
 }
 
 $bgcolor = $themeHelper->isLightTheme() ? '#f2f2f2' : '#1c1c1c'; // $themeHelper set in DefaultPageLayout.php

--- a/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
@@ -117,14 +117,13 @@ function base_net($route) {
 
 // Derive the IPv4 gateway rc.docker would use when none is configured:
 // the subnet's first usable host (e.g. 192.168.10.0/24 -> 192.168.10.1).
-// Mirrors derive_gateway() in etc/rc.d/rc.docker. Returns '' if not derivable.
+// Calls the same scripts/derive_gateway helper rc.docker uses, so the logic
+// is not duplicated. Returns '' if not derivable.
 function derive_gw($route) {
-  $cidr = explode(' ',trim((string)$route))[0];
-  [$ip,$mask] = my_explode('/',$cidr);
-  if (!filter_var($ip,FILTER_VALIDATE_IP,FILTER_FLAG_IPV4)) return '';
-  if (!ctype_digit((string)$mask) || $mask<1 || $mask>30) return '';
-  $net = (ip2long($ip) >> (32-$mask)) << (32-$mask);
-  return long2ip(($net+1) & 0xFFFFFFFF);
+  global $docroot;
+  $route = trim((string)$route);
+  if ($route === '') return '';
+  return exec($docroot."/plugins/dynamix.docker.manager/scripts/derive_gateway ".escapeshellarg($route));
 }
 
 $bgcolor = $themeHelper->isLightTheme() ? '#f2f2f2' : '#1c1c1c'; // $themeHelper set in DefaultPageLayout.php

--- a/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
@@ -315,6 +315,7 @@ _(Preserve user defined networks)_:
 $net = normalize($network);
 $docker_auto = "DOCKER_AUTO_$net";
 $docker_dhcp = "DOCKER_DHCP_$net";
+$docker_gw   = "DOCKER_GATEWAY_$net";
 ?>
 <input type="hidden" name="<?=$docker_auto?>" value="<?=_var($dockercfg,$docker_auto)?>">
 
@@ -369,8 +370,9 @@ _(IPv4 custom network on interface)_ <?=$network?> (_(optional)_):
       <span class="<?=$ip4class?>">
         <strong><?=_('Subnet')?>:</strong> <?=str_replace(' ', '<br><b>'._('Subnet').': </b>', $route)?>
       </span>
-      <span class="<?=$gw4class?>">
-        <strong><?=_('Gateway')?>:</strong> <?=$gateway[$network] ?: '---'?>
+      <span class="<?=$gw4class?> flex flex-row items-center gap-2">
+        <strong><?=_('Gateway')?>:</strong>
+        <input type="text" id="<?=$docker_dhcp?>_gw" name="<?=$docker_gw?>" class="ip4" value="<?=htmlspecialchars(_var($dockercfg,$docker_gw))?>" placeholder="<?=htmlspecialchars($gateway[$network] ?: '')?>" title="_(IPv4 address A.B.C.D)_"<?=$autoDisabled?>>
       </span>
       <span class="flex flex-row items-center gap-2">
         <span class="flex flex-row items-center gap-2">
@@ -464,6 +466,7 @@ _(IPv4 custom network on interface)_ <?=$network?> (_(optional)_):
 $net = normalize($network);
 $docker_auto  = "DOCKER_AUTO_$net";
 $docker_dhcp6 = "DOCKER_DHCP6_$net";
+$docker_gw6   = "DOCKER_GATEWAY6_$net";
 ?>
 <?if ($network != 'wlan0' || lan_port('wlan0',true) == 1):?>
 
@@ -485,7 +488,10 @@ _(IPv6 custom network on interface)_ <?=$network?> (_(optional)_):
     </label>
     <span id="<?=$docker_dhcp6?>_line" class="<?=$auto6Disabled?>">
       <span class="ip6">**_(Subnet)_:** <?=str_replace(' ', '<br><b>'._('Subnet').': </b>', $route)?></span>
-      <span class="gw6">**_(Gateway)_:** <?=$gateway6[$network] ?: '---'?></span>
+      <span class="gw6 flex flex-row items-center gap-2">
+        <strong><?=_('Gateway')?>:</strong>
+        <input type="text" id="<?=$docker_dhcp6?>_gw" name="<?=$docker_gw6?>" class="gw6" value="<?=htmlspecialchars(_var($dockercfg,$docker_gw6))?>" placeholder="<?=htmlspecialchars($gateway6[$network] ?: '')?>" title="_(IPv6 address nnnn:xxxx::yyyy)_"<?=$auto6Disabled?>>
+      </span>
     </span>
   </span>
 
@@ -784,7 +790,9 @@ function prepareDocker(form) {
     $(mask).prop('disabled',true);
   });
   $(form).find('input[name^="DOCKER_GATEWAY_"]').each(function(){
-    var edit = '#'+$(this).attr('name').replace('GATEWAY','CUSTOM')+'_edit';
+    var custom = '#'+$(this).attr('name').replace('GATEWAY','CUSTOM')+'_edit';
+    var auto = '#'+$(this).attr('name').replace('GATEWAY','DHCP')+'_edit';
+    var edit = $(custom).length ? custom : auto;
     if (!$(edit).prop('checked')) $(this).val('').prop('disabled',false);
   });
   $(form).find('input[name^="DOCKER_RANGE_"]').each(function(){
@@ -809,7 +817,9 @@ function prepareDocker(form) {
     $(mask6).prop('disabled',true);
   });
   $(form).find('input[name^="DOCKER_GATEWAY6_"]').each(function(){
-    var edit6 = '#'+$(this).attr('name').replace('GATEWAY','CUSTOM')+'_edit';
+    var custom6 = '#'+$(this).attr('name').replace('GATEWAY','CUSTOM')+'_edit';
+    var auto6 = '#'+$(this).attr('name').replace('GATEWAY','DHCP')+'_edit';
+    var edit6 = $(custom6).length ? custom6 : auto6;
     if (!$(edit6).prop('checked')) $(this).val('').prop('disabled',false);
   });
   $(form).find('input[name^="DOCKER_RANGE6_"]').each(function(){
@@ -842,6 +852,7 @@ function changeEdit(id, ip) {
     auto.val(auto.val().replace(ip,''));
     if (auto.val() == '') auto.val('no');
   }
+  $(id1+'gw').prop('disabled',!checked);
   changeDHCP(id, ip, $('#'+id.replace('edit','dhcp')).prop('checked'));
 }
 

--- a/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
@@ -115,6 +115,18 @@ function base_net($route) {
   return substr(explode('/',$route)[0],0,-2);
 }
 
+// Derive the IPv4 gateway rc.docker would use when none is configured:
+// the subnet's first usable host (e.g. 192.168.10.0/24 -> 192.168.10.1).
+// Mirrors derive_gateway() in etc/rc.d/rc.docker. Returns '' if not derivable.
+function derive_gw($route) {
+  $cidr = explode(' ',trim((string)$route))[0];
+  [$ip,$mask] = my_explode('/',$cidr);
+  if (!filter_var($ip,FILTER_VALIDATE_IP,FILTER_FLAG_IPV4)) return '';
+  if (!ctype_digit((string)$mask) || $mask<1 || $mask>30) return '';
+  $net = (ip2long($ip) >> (32-$mask)) << (32-$mask);
+  return long2ip(($net+1) & 0xFFFFFFFF);
+}
+
 $bgcolor = $themeHelper->isLightTheme() ? '#f2f2f2' : '#1c1c1c'; // $themeHelper set in DefaultPageLayout.php
 
 //Check if docker.cfg does exist
@@ -372,7 +384,7 @@ _(IPv4 custom network on interface)_ <?=$network?> (_(optional)_):
       </span>
       <span class="<?=$gw4class?> flex flex-row items-center gap-2">
         <strong><?=_('Gateway')?>:</strong>
-        <input type="text" id="<?=$docker_dhcp?>_gw" name="<?=$docker_gw?>" class="ip4" value="<?=htmlspecialchars(_var($dockercfg,$docker_gw))?>" placeholder="<?=htmlspecialchars($gateway[$network] ?: '')?>" title="_(IPv4 address A.B.C.D)_"<?=$autoDisabled?>>
+        <input type="text" id="<?=$docker_dhcp?>_gw" name="<?=$docker_gw?>" class="ip4" value="<?=htmlspecialchars(_var($dockercfg,$docker_gw))?>" placeholder="<?=htmlspecialchars($gateway[$network] ?: derive_gw($route))?>" title="_(IPv4 address A.B.C.D)_"<?=$autoDisabled?>>
       </span>
       <span class="flex flex-row items-center gap-2">
         <span class="flex flex-row items-center gap-2">
@@ -597,7 +609,7 @@ $docker_dhcp = "DOCKER_DHCP_$net";
 _(IPv4 custom network on interface)_ <?=$network?>:
 : <span class="flex flex-row flex-wrap items-center gap-4">
     <span class="<?=$gw4class?>">**_(Subnet)_:** <?=str_replace(' ', '<br><b>'._('Subnet').': </b>', $route)?></span>
-    <span class="<?=$gw4class?>">**_(Gateway)_:** <?=$gateway[$network] ?: '---'?></span>
+    <span class="<?=$gw4class?>">**_(Gateway)_:** <?=$gateway[$network] ?: (_var($dockercfg,"DOCKER_GATEWAY_$net") ?: (derive_gw($route) ?: '---'))?></span>
     <span>**_(DHCP pool)_:** <?=_var($dockercfg,$docker_dhcp) ?: "_(not set)_"?><?if (isset($dockercfg[$docker_dhcp])):?>&nbsp;&nbsp;(<?=pow(2,32-my_explode('/',$dockercfg[$docker_dhcp])[1])?> _(hosts)_)<?endif;?></span>
   </span>
 

--- a/emhttp/plugins/dynamix.docker.manager/scripts/derive_gateway
+++ b/emhttp/plugins/dynamix.docker.manager/scripts/derive_gateway
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Derive the IPv4 gateway for a subnet: the first usable host address
+# (e.g. 192.168.10.0/24 -> 192.168.10.1). Prints nothing if not derivable.
+#
+# Restores the pre-Docker-28 behavior where macvlan/ipvlan networks created
+# without an explicit gateway implicitly used the subnet's first address.
+# Shared by etc/rc.d/rc.docker and the Docker Settings page so the logic
+# lives in one place.
+#
+# Usage: derive_gateway "<subnet-cidr>"   (a space-separated list is accepted;
+#        only the first subnet is used)
+CIDR=${1%% *}
+IP=${CIDR%/*}; MASK=${CIDR#*/}
+[[ $IP == *.*.*.* && $MASK =~ ^[0-9]+$ ]] || exit 0
+(( MASK >= 1 && MASK <= 30 )) || exit 0
+IFS=. read -r A B C D <<< "$IP"
+IPNUM=$(( (A<<24) + (B<<16) + (C<<8) + D ))
+MASKNUM=$(( (0xFFFFFFFF << (32-MASK)) & 0xFFFFFFFF ))
+NET=$(( IPNUM & MASKNUM ))
+HOST=$(( NET + 1 ))
+printf '%d.%d.%d.%d\n' $(( (HOST>>24)&255 )) $(( (HOST>>16)&255 )) $(( (HOST>>8)&255 )) $(( HOST&255 ))

--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -517,7 +517,7 @@ docker_network_start(){
         GATEWAY=$(ip -4 route show to default dev $NETWORK | awk '{print $3;exit}')
         [[ -n $GATEWAY ]] || GATEWAY=$(configured_gateway "$NETWORK" GATEWAY)
         [[ -n $GATEWAY ]] || { DEVICE=${NETWORK/./_}; DEVICE=${DEVICE^^}; DGW=DOCKER_GATEWAY_$DEVICE; GATEWAY=${!DGW}; }
-        [[ -n $GATEWAY ]] || GATEWAY=$(/usr/local/emhttp/plugins/dynamix.docker.manager/scripts/derive_gateway "$SUBNET")
+        [[ -n $GATEWAY ]] || GATEWAY=$(bash /usr/local/emhttp/plugins/dynamix.docker.manager/scripts/derive_gateway "$SUBNET")
         SERVER=${IPV4%/*}
         DHCP=${NETWORK/./_}
         DHCP=DOCKER_DHCP_${DHCP^^}

--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -516,6 +516,7 @@ docker_network_start(){
         SUBNET=$(ip -4 route show dev $NETWORK | sort | awk -v ORS=" " '$1 !~ /^default/ {print $1}' | sed 's/ $//')
         GATEWAY=$(ip -4 route show to default dev $NETWORK | awk '{print $3;exit}')
         [[ -n $GATEWAY ]] || GATEWAY=$(configured_gateway "$NETWORK" GATEWAY)
+        [[ -n $GATEWAY ]] || { DEVICE=${NETWORK/./_}; DEVICE=${DEVICE^^}; DGW=DOCKER_GATEWAY_$DEVICE; GATEWAY=${!DGW}; }
         SERVER=${IPV4%/*}
         DHCP=${NETWORK/./_}
         DHCP=DOCKER_DHCP_${DHCP^^}
@@ -528,6 +529,7 @@ docker_network_start(){
         SUBNET6=$(ip -6 route show dev $NETWORK | sort | awk -v ORS=" " '$1 !~ /^(default|fe80)/ {print $1}' | sed 's/ $//')
         GATEWAY6=$(ip -6 route show to default dev $NETWORK | awk '{print $3;exit}')
         [[ -n $GATEWAY6 ]] || GATEWAY6=$(configured_gateway "$NETWORK" GATEWAY6)
+        [[ -n $GATEWAY6 ]] || { DEVICE=${NETWORK/./_}; DEVICE=${DEVICE^^}; DGW=DOCKER_GATEWAY6_$DEVICE; GATEWAY6=${!DGW}; }
       fi
     else
       # add user defined networks

--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -255,24 +255,6 @@ configured_gateway(){
   )
 }
 
-# Derive an IPv4 gateway from a subnet: the first usable host address.
-# Restores the pre-Docker-28 behavior where macvlan/ipvlan networks created
-# without an explicit gateway implicitly used the subnet's first address, so
-# VLAN auto-networks with no route/configured gateway still get a default route.
-# $1 = subnet in CIDR form (e.g. 192.168.10.0/24); prints e.g. 192.168.10.1
-derive_gateway(){
-  local CIDR=$1 IP MASK A B C D IPNUM MASKNUM NET HOST
-  IP=${CIDR%/*}; MASK=${CIDR#*/}
-  [[ $IP == *.*.*.* && $MASK =~ ^[0-9]+$ ]] || return
-  (( MASK >= 1 && MASK <= 30 )) || return
-  IFS=. read -r A B C D <<< "$IP"
-  IPNUM=$(( (A<<24) + (B<<16) + (C<<8) + D ))
-  MASKNUM=$(( (0xFFFFFFFF << (32-MASK)) & 0xFFFFFFFF ))
-  NET=$(( IPNUM & MASKNUM ))
-  HOST=$(( NET + 1 ))
-  printf '%d.%d.%d.%d\n' $(( (HOST>>24)&255 )) $(( (HOST>>16)&255 )) $(( (HOST>>8)&255 )) $(( HOST&255 ))
-}
-
 # Is container running?
 container_running(){
   local CONTAINER
@@ -535,7 +517,7 @@ docker_network_start(){
         GATEWAY=$(ip -4 route show to default dev $NETWORK | awk '{print $3;exit}')
         [[ -n $GATEWAY ]] || GATEWAY=$(configured_gateway "$NETWORK" GATEWAY)
         [[ -n $GATEWAY ]] || { DEVICE=${NETWORK/./_}; DEVICE=${DEVICE^^}; DGW=DOCKER_GATEWAY_$DEVICE; GATEWAY=${!DGW}; }
-        [[ -n $GATEWAY ]] || GATEWAY=$(derive_gateway "${SUBNET%% *}")
+        [[ -n $GATEWAY ]] || GATEWAY=$(/usr/local/emhttp/plugins/dynamix.docker.manager/scripts/derive_gateway "$SUBNET")
         SERVER=${IPV4%/*}
         DHCP=${NETWORK/./_}
         DHCP=DOCKER_DHCP_${DHCP^^}

--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -517,7 +517,7 @@ docker_network_start(){
         GATEWAY=$(ip -4 route show to default dev $NETWORK | awk '{print $3;exit}')
         [[ -n $GATEWAY ]] || GATEWAY=$(configured_gateway "$NETWORK" GATEWAY)
         [[ -n $GATEWAY ]] || { DEVICE=${NETWORK/./_}; DEVICE=${DEVICE^^}; DGW=DOCKER_GATEWAY_$DEVICE; GATEWAY=${!DGW}; }
-        [[ -n $GATEWAY ]] || GATEWAY=$(bash /usr/local/emhttp/plugins/dynamix.docker.manager/scripts/derive_gateway "$SUBNET")
+        [[ -n $GATEWAY ]] || GATEWAY=$(/usr/local/emhttp/plugins/dynamix.docker.manager/scripts/derive_gateway "$SUBNET")
         SERVER=${IPV4%/*}
         DHCP=${NETWORK/./_}
         DHCP=DOCKER_DHCP_${DHCP^^}

--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -255,6 +255,24 @@ configured_gateway(){
   )
 }
 
+# Derive an IPv4 gateway from a subnet: the first usable host address.
+# Restores the pre-Docker-28 behavior where macvlan/ipvlan networks created
+# without an explicit gateway implicitly used the subnet's first address, so
+# VLAN auto-networks with no route/configured gateway still get a default route.
+# $1 = subnet in CIDR form (e.g. 192.168.10.0/24); prints e.g. 192.168.10.1
+derive_gateway(){
+  local CIDR=$1 IP MASK A B C D IPNUM MASKNUM NET HOST
+  IP=${CIDR%/*}; MASK=${CIDR#*/}
+  [[ $IP == *.*.*.* && $MASK =~ ^[0-9]+$ ]] || return
+  (( MASK >= 1 && MASK <= 30 )) || return
+  IFS=. read -r A B C D <<< "$IP"
+  IPNUM=$(( (A<<24) + (B<<16) + (C<<8) + D ))
+  MASKNUM=$(( (0xFFFFFFFF << (32-MASK)) & 0xFFFFFFFF ))
+  NET=$(( IPNUM & MASKNUM ))
+  HOST=$(( NET + 1 ))
+  printf '%d.%d.%d.%d\n' $(( (HOST>>24)&255 )) $(( (HOST>>16)&255 )) $(( (HOST>>8)&255 )) $(( HOST&255 ))
+}
+
 # Is container running?
 container_running(){
   local CONTAINER
@@ -517,6 +535,7 @@ docker_network_start(){
         GATEWAY=$(ip -4 route show to default dev $NETWORK | awk '{print $3;exit}')
         [[ -n $GATEWAY ]] || GATEWAY=$(configured_gateway "$NETWORK" GATEWAY)
         [[ -n $GATEWAY ]] || { DEVICE=${NETWORK/./_}; DEVICE=${DEVICE^^}; DGW=DOCKER_GATEWAY_$DEVICE; GATEWAY=${!DGW}; }
+        [[ -n $GATEWAY ]] || GATEWAY=$(derive_gateway "${SUBNET%% *}")
         SERVER=${IPV4%/*}
         DHCP=${NETWORK/./_}
         DHCP=DOCKER_DHCP_${DHCP^^}


### PR DESCRIPTION
## Summary

Fixes [OS-468](https://linear.app/lime-technology/issue/OS-468/731-vlan-docker-auto-networks-omit-gateway-after-docker-29-upgrade) — macvlan/ipvlan containers on **auto-created** VLAN networks (e.g. `br0.x`) lose outbound/intervlan internet access after upgrading to Docker 28+.

Docker 27 implicitly injected a default route into macvlan/ipvlan containers even when the network had no gateway (it used the subnet's first address). Docker 28+ removed that, so a network created without `--gateway` leaves containers with no default route.

## Root cause

`rc.docker`'s auto network-creation path resolved the gateway only from (1) the live interface default route and (2) `network.cfg` (the OS-206 `configured_gateway` fallback). Multi-VLAN setups intentionally leave VLAN gateways **out** of `network.cfg`, because `rc.inet1`'s `add_default_gateways()` turns every `network.cfg` `GATEWAY` into a host-level default route, which corrupts host routing. So those VLANs created Docker networks with no gateway.

## Changes (3 commits)

1. **`etc/rc.d/rc.docker` — docker.cfg fallback.** Extend the auto path to fall through to the Docker-specific `DOCKER_GATEWAY_<DEVICE>` / `DOCKER_GATEWAY6_<DEVICE>` from `docker.cfg` (the same source the user-defined custom-network path already uses).

2. **`DockerSettings.page` — UI field.** The page showed the gateway for an active (auto) VLAN interface as **read-only** text from the live default route, so a VLAN with no host default route showed `Gateway: ---` with no way to set one. Turn it into an input (`DOCKER_GATEWAY_<NET>` / `DOCKER_GATEWAY6_<NET>`) in both auto sections, route gateway as placeholder, enabled by the existing Edit toggle, validated by `checkIP()`, persisted by `prepareDocker()` (its gateway submit handlers were generalized to honor the auto-section toggle, not just the custom one).

3. **`etc/rc.d/rc.docker` — auto-derivation.** As a final fallback, when no gateway is found anywhere, derive the IPv4 gateway as the subnet's first usable host (`192.168.10.0/24` → `192.168.10.1`). This restores the pre-Docker-28 behavior so gateway-less VLANs work with **zero config**. IPv6 is left explicit-only (a derived `::1` is almost never the real link-local router).

**Resolution order:** live default route → `network.cfg` → `docker.cfg` (UI field) → derived first host. Explicit config always wins; derivation only fills a genuine gap.

The host-access shim/vhost default-route blocks are intentionally untouched; those add host-level routes and must keep deriving from the real host default route only.

## Test plan

- `bash -n etc/rc.d/rc.docker` and `php -l DockerSettings.page` pass. `derive_gateway` unit-checked across /24, /25, /22, /8 (and declines empty/garbage/<=/31).
- Zero-config: a VLAN `br0.x` with a standard `.1` gateway, no route/network.cfg/UI config → after restarting Docker, `docker network inspect br0.x` shows `.1` and a container gets a default route + outbound access.
- UI override: for a VLAN whose gateway is not `.1`, set it in Settings → Docker, Apply, restart Docker → network uses the entered value.
- Regression: an interface with a real default route still uses the route; host routing unchanged. Derivation declines on subnets it can't parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gateway configuration for custom Docker networks is now editable in the settings UI.
  * Implemented automatic gateway detection with intelligent fallback for both IPv4 and IPv6 custom networks.
  * Gateway values are intelligently pre-filled from saved configuration or detected defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->