### PR TITLE
feat(notify): persistent/keyed notifications; reboot notice -> bell (OS-471)

### DIFF
--- a/.github/scripts/generate-pr-plugin.sh
+++ b/.github/scripts/generate-pr-plugin.sh
@@ -252,40 +252,33 @@ Link='nav-user'
 ---
 <script>
   $(function() {
-    // Check for updates (non-dismissible)
-    caPluginUpdateCheck("webgui-pr-PR_PLACEHOLDER.plg", {noDismiss: true},function(result){
+    // Surface the active PR test build as a persistent, keyed notification in the
+    // bell (not a banner): keyed so it dedupes across reloads, links to the
+    // Plugins page to remove it, and is cleared by the plugin's removal script.
+    function raisePrNotice() {
+      $.post('/webGui/include/Notify.php', {
+        cmd: 'add',
+        i: 'warning',
+        e: 'PR test build installed',
+        s: 'Modified GUI via webgui-pr-PR_PLACEHOLDER',
+        d: 'A pull-request test build is active. Remove it from Plugins before applying production updates.',
+        l: '/Plugins',
+        p: '1',
+        k: 'webgui-pr-PR_PLACEHOLDER'
+      });
+    }
+    // If the PR has been merged/removed upstream, clear the notice; otherwise raise it.
+    caPluginUpdateCheck("webgui-pr-PR_PLACEHOLDER.plg", {noDismiss: true}, function(result){
       try {
         let json = JSON.parse(result);
-        if ( ! json.version ) {
-          addBannerWarning("Note: webgui-pr-PR_PLACEHOLDER has either been merged or removed");
+        if (!json.version) {
+          $.post('/webGui/include/Notify.php', {cmd:'clear', k:'webgui-pr-PR_PLACEHOLDER'});
+          return;
         }
       } catch(e) {}
+      raisePrNotice();
     });
-
-    // Create banner with uninstall link (nondismissible)
-    let bannerMessage = "Modified GUI installed via <b>webgui-pr-PR_PLACEHOLDER</b> plugin. " +
-                       "<a onclick='uninstallPRPlugin()' style='cursor: pointer; text-decoration: underline;'>Click here to uninstall</a>";
-
-    // true = warning style, true = non-dismissible
-    addBannerWarning(bannerMessage, true, true);
-
-    // Define uninstall function
-    window.uninstallPRPlugin = function() {
-      swal({
-        title: "Uninstall PR Test Plugin?",
-        text: "This will reverse all of this PR's changes and remove the test plugin.",
-        type: "warning",
-        showCancelButton: true,
-        confirmButtonText: "Yes, uninstall",
-        cancelButtonText: "Cancel",
-        closeOnConfirm: false,
-        showLoaderOnConfirm: true
-      }, function(isConfirm) {
-        if (isConfirm) {
-          openPlugin("plugin remove webgui-pr-PR_PLACEHOLDER.plg", "Removing PR Test Plugin", "", "refresh");
-        }
-      });
-    };
+    raisePrNotice();
   });
 </script>
 ]]>
@@ -351,6 +344,9 @@ fi
 echo "Cleaning up plugin files..."
 rm -rf "/usr/local/emhttp/plugins/webgui-pr-PR_PLACEHOLDER"
 rm -rf "$PLUGIN_DIR"
+
+# Clear the persistent "PR test build installed" notification raised by the Banner page.
+/usr/local/emhttp/webGui/scripts/notify clear -k "webgui-pr-PR_PLACEHOLDER" 2>/dev/null || true
 
 echo ""
 echo "✅ Plugin removed successfully"

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/PluginAPI.php
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/PluginAPI.php
@@ -85,7 +85,7 @@ switch ($_POST['action']) {
 		// Surface "reboot required" as a persistent notification (sticky in the bell,
 		// keyed so repeated notices update rather than stack). It clears on reboot
 		// (RAM-backed /tmp is wiped) or via removeRebootNotice below.
-		exec("/usr/local/emhttp/webGui/scripts/notify add -p -k reboot-required -i alert -e ".escapeshellarg("Reboot required")." -s ".escapeshellarg("Reboot required")." -d ".escapeshellarg($message)." &>/dev/null");
+		exec("/usr/local/emhttp/webGui/scripts/notify -p -k reboot-required -i alert -e ".escapeshellarg("Reboot required")." -s ".escapeshellarg("Reboot required")." -d ".escapeshellarg($message)." &>/dev/null");
 		break;
 
 	case 'removeRebootNotice':

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/PluginAPI.php
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/PluginAPI.php
@@ -82,6 +82,10 @@ switch ($_POST['action']) {
 		$existing = (array)@file("/tmp/reboot_notifications",FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 		$existing[] = $message;
 		file_put_contents("/tmp/reboot_notifications",implode("\n",array_unique($existing)));
+		// Surface "reboot required" as a persistent notification (sticky in the bell,
+		// keyed so repeated notices update rather than stack). It clears on reboot
+		// (RAM-backed /tmp is wiped) or via removeRebootNotice below.
+		exec("/usr/local/emhttp/webGui/scripts/notify add -p -k reboot-required -i alert -e ".escapeshellarg("Reboot required")." -s ".escapeshellarg("Reboot required")." -d ".escapeshellarg($message)." &>/dev/null");
 		break;
 
 	case 'removeRebootNotice':
@@ -89,6 +93,8 @@ switch ($_POST['action']) {
 		$existing = file_get_contents("/tmp/reboot_notifications");
 		$newReboots = str_replace($message,"",$existing);
 		file_put_contents("/tmp/reboot_notifications",$newReboots);
+		// Once no reboot reasons remain, resolve the persistent notification.
+		if (trim($newReboots)==="") exec("/usr/local/emhttp/webGui/scripts/notify clear -k reboot-required &>/dev/null");
 		break;
 }
 ?>

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
@@ -389,6 +389,12 @@ var forcedBanner = false;
 // removeBannerWarning(id) clears the bell notification or dismisses the toast.
 var bannerToastSeq = 0;
 var bannerRegistry = {}; // id -> { persistent: bool, key?: string }
+// Per-page-load generation stamp. Legacy banners (CA, boot checks, ...) have no
+// explicit clear: they re-render every load while active and simply stop when
+// resolved. Each banner -> bell notification is stamped with this generation;
+// after the page settles we sweep any 'banner-' notification not re-raised this
+// load, so resolved banners clear on the next navigation.
+var bannerGen = String(Date.now());
 
 function bannerStableKey(text) {
   var h = 0;
@@ -426,7 +432,8 @@ function addBannerWarning(text, warning=true, noDismiss=false, forced=false) {
       d: '<?=_('This stays in your notifications until the condition is resolved')?>.',
       l: (parsed.link && parsed.link.href) ? parsed.link.href : '',
       p: '1',
-      k: key
+      k: key,
+      g: bannerGen
     });
     return id;
   }
@@ -459,6 +466,15 @@ function showBannerToast(parsed, importance, persist, id, attempt) {
 function dismissBannerWarning(entry,cookieText) {
   removeBannerWarning(entry);
 }
+
+// Reconcile banner -> bell notifications once the page has settled: clear any
+// 'banner-' notification not stamped with this load's generation (i.e. whose
+// producer stopped rendering it). Deferred past load so banners raised via ajax
+// (e.g. the boot-corrupt check) are re-stamped before the sweep runs.
+function sweepStaleBanners() {
+  $.post('/webGui/include/Notify.php', { cmd: 'banner-sweep', g: bannerGen });
+}
+$(window).on('load', function(){ setTimeout(sweepStaleBanners, 3000); });
 
 function removeBannerWarning(entry) {
   var info = bannerRegistry[entry];

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
@@ -379,35 +379,95 @@ var currentBannerWarning = 0;
 var osUpgradeWarning = false;
 var forcedBanner = false;
 
-function addBannerWarning(text, warning=true, noDismiss=false, forced=false) {
-  var cookieText = text.replace(/[^a-z0-9]/gi,'');
-  if ($.cookie(cookieText) == "true") return false;
-  if (warning) text = "<i class='fa fa-warning fa-fw' style='float:initial'></i> "+text;
-  if (bannerWarnings.indexOf(text) < 0) {
-    if (forced) {
-      var arrayEntry = 0; bannerWarnings = []; clearTimeout(timers.bannerWarning); timers.bannerWarning = null; forcedBanner = true;
-    } else {
-      var arrayEntry = bannerWarnings.push("placeholder") - 1;
-    }
-    if (!noDismiss) text += "<a class='bannerDismiss' onclick='dismissBannerWarning("+arrayEntry+",&quot;"+cookieText+"&quot;)'></a>";
-    bannerWarnings[arrayEntry] = text;
-  } else {
-    return bannerWarnings.indexOf(text);
+// The legacy fixed yellow ".upgrade_notice" bar is retired. addBannerWarning now
+// routes by intent:
+//   - Persistent conditions (noDismiss, not a transient "forced" in-progress
+//     banner) -> the notification bell, as a keyed (idempotent, deduped,
+//     header-reserved) notification that survives reloads and clears when
+//     resolved. Re-raising the same condition just updates the one entry.
+//   - Everything else -> a transient toast that auto-dismisses.
+// removeBannerWarning(id) clears the bell notification or dismisses the toast.
+var bannerToastSeq = 0;
+var bannerRegistry = {}; // id -> { persistent: bool, key?: string }
+
+function bannerStableKey(text) {
+  var h = 0;
+  for (var i=0;i<text.length;i++) h = ((h<<5)-h+text.charCodeAt(i))|0;
+  return 'banner-' + (h>>>0).toString(36);
+}
+
+// Split a banner's HTML blob into plain text + a single action link.
+function parseBanner(html) {
+  var tmp = document.createElement('div');
+  tmp.innerHTML = html;
+  var a = tmp.querySelector('a');
+  var link = null;
+  if (a) {
+    link = { href: a.getAttribute('href'), onclick: a.getAttribute('onclick'), label: (a.textContent||'').trim() };
+    a.remove();
   }
-  if (timers.bannerWarning==null) showBannerWarnings();
-  return arrayEntry;
+  return { text: (tmp.textContent||'').replace(/\s+/g,' ').trim(), link: link };
+}
+
+function addBannerWarning(text, warning=true, noDismiss=false, forced=false) {
+  var id = "banner-" + (++bannerToastSeq);
+  var parsed = parseBanner(text);
+  var importance = (warning || noDismiss) ? "warning" : "info";
+
+  if (noDismiss && !forced) {
+    // Persistent condition -> notification bell (keyed for idempotent re-raise).
+    var key = bannerStableKey(parsed.text);
+    bannerRegistry[id] = { persistent: true, key: key };
+    $.post('/webGui/include/Notify.php', {
+      cmd: 'add',
+      i: importance === "warning" ? "warning" : "normal",
+      e: parsed.text,
+      s: '<?=_('System notice')?>',
+      d: '<?=_('This stays in your notifications until the condition is resolved')?>.',
+      l: (parsed.link && parsed.link.href) ? parsed.link.href : '',
+      p: '1',
+      k: key
+    });
+    return id;
+  }
+
+  // Transient (or forced in-progress) -> toast.
+  bannerRegistry[id] = { persistent: false };
+  showBannerToast(parsed, importance, !!noDismiss, id, 0);
+  return id;
+}
+
+function showBannerToast(parsed, importance, persist, id, attempt) {
+  // globalThis.toast is registered when the toaster web component mounts; a
+  // banner may fire before then, so retry briefly.
+  if (!window.toast || !window.toast.warning) {
+    if (attempt < 40) setTimeout(function(){ showBannerToast(parsed, importance, persist, id, attempt+1); }, 150);
+    return;
+  }
+  var opts = { id: id, duration: persist ? Infinity : 8000, closeButton: true };
+  if (parsed.link) {
+    var l = parsed.link;
+    opts.action = { label: l.label || 'Open', onClick: function() {
+      if (l.href) window.location.href = l.href;
+      else if (l.onclick) { try { (new Function(l.onclick)).call(window); } catch(e) {} }
+    }};
+  }
+  var fn = window.toast[importance] || window.toast;
+  fn(parsed.text, opts);
 }
 
 function dismissBannerWarning(entry,cookieText) {
-  $.cookie(cookieText,"true",{expires:30}); // reset after 1 month
   removeBannerWarning(entry);
 }
 
 function removeBannerWarning(entry) {
-  if (forcedBanner) return;
-  bannerWarnings[entry] = false;
-  clearTimeout(timers.bannerWarning);
-  showBannerWarnings();
+  var info = bannerRegistry[entry];
+  if (info && info.persistent && info.key) {
+    $.post('/webGui/include/Notify.php', { cmd: 'clear', k: info.key });
+  } else if (window.toast && window.toast.dismiss) {
+    window.toast.dismiss(entry);
+  }
+  delete bannerRegistry[entry];
 }
 
 function bannerFilterArray(array) {
@@ -432,14 +492,12 @@ function showBannerWarnings() {
 }
 
 function addRebootNotice(message="<?=_('You must reboot for changes to take effect')?>") {
-  addBannerWarning("<i class='fa fa-warning' style='float:initial;'></i> "+message,false,true);
+  // PluginAPI raises a persistent, keyed "reboot-required" bell notification
+  // (and persists it server-side), so no separate client banner is needed.
   $.post("/plugins/dynamix.plugin.manager/scripts/PluginAPI.php",{action:'addRebootNotice',message:message});
 }
 
 function removeRebootNotice(message="<?=_('You must reboot for changes to take effect')?>") {
-  var bannerIndex = bannerWarnings.indexOf("<i class='fa fa-warning' style='float:initial;'></i> "+message);
-  if (bannerIndex < 0) return;
-  removeBannerWarning(bannerIndex);
   $.post("/plugins/dynamix.plugin.manager/scripts/PluginAPI.php",{action:'removeRebootNotice',message:message});
 }
 
@@ -493,7 +551,7 @@ function digits(number) {
 
 function flashReport() {
   $.post('/webGui/include/Report.php',{cmd:'config'},function(check){
-    if (check>0) addBannerWarning("<?=_('Your boot drive is corrupted or offline').'. '._('Post your diagnostics in the forum for help').'.'?> <a target='_blank' href='https://docs.unraid.net/go/changing-the-flash-device/'><?=_('See also here')?></a>");
+    if (check>0) addBannerWarning("<?=_('Your boot drive is corrupted or offline').'. '._('Post your diagnostics in the forum for help').'.'?> <a target='_blank' href='https://docs.unraid.net/go/changing-the-flash-device/'><?=_('See also here')?></a>",true,true);
   });
 }
 
@@ -522,11 +580,8 @@ $(function() {
   updateTime();
 
   Shadowbox.setup('a.sb-enable', {modal:true});
-// add any pre-existing reboot notices
-  $.post('/webGui/include/Report.php',{cmd:'notice'},function(notices){
-    notices = notices.split('\n');
-    for (var i=0,notice; notice=notices[i]; i++) addBannerWarning("<i class='fa fa-warning' style='float:initial;'></i> "+notice,false,true);
-  });
+// Pre-existing reboot notices now live in the notification bell (raised by
+// PluginAPI when the reboot reason was added), so no client-side re-display.
 // check for boot device offline / corrupted (delayed).
   timers.flashReport = setTimeout(flashReport,6000);
 });

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
@@ -430,7 +430,7 @@ function addBannerWarning(text, warning=true, noDismiss=false, forced=false) {
       i: importance === "warning" ? "warning" : "normal",
       e: parsed.text,
       s: '<?=_('System notice')?>',
-      d: '<?=_('This stays in your notifications until the condition is resolved')?>.',
+      d: '', // no description: the "Active" badge already conveys persistence
       l: (parsed.link && parsed.link.href) ? parsed.link.href : '',
       p: '1',
       k: key,

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
@@ -391,10 +391,11 @@ var bannerToastSeq = 0;
 var bannerRegistry = {}; // id -> { persistent: bool, key?: string }
 // Per-page-load generation stamp. Legacy banners (CA, boot checks, ...) have no
 // explicit clear: they re-render every load while active and simply stop when
-// resolved. Each banner -> bell notification is stamped with this generation;
-// after the page settles we sweep any 'banner-' notification not re-raised this
-// load, so resolved banners clear on the next navigation.
-var bannerGen = String(Date.now());
+// resolved. Each banner -> bell notification is stamped with this generation.
+// Exposed on window so the notification drawer can hand it to the API, which
+// authoritatively clears any 'banner-' notification not re-raised this load
+// (see reconcileBannerNotifications).
+var bannerGen = window.bannerGen = String(Date.now());
 
 function bannerStableKey(text) {
   var h = 0;
@@ -466,15 +467,6 @@ function showBannerToast(parsed, importance, persist, id, attempt) {
 function dismissBannerWarning(entry,cookieText) {
   removeBannerWarning(entry);
 }
-
-// Reconcile banner -> bell notifications once the page has settled: clear any
-// 'banner-' notification not stamped with this load's generation (i.e. whose
-// producer stopped rendering it). Deferred past load so banners raised via ajax
-// (e.g. the boot-corrupt check) are re-stamped before the sweep runs.
-function sweepStaleBanners() {
-  $.post('/webGui/include/Notify.php', { cmd: 'banner-sweep', g: bannerGen });
-}
-$(window).on('load', function(){ setTimeout(sweepStaleBanners, 3000); });
 
 function removeBannerWarning(entry) {
   var info = bannerRegistry[entry];

--- a/emhttp/plugins/dynamix/include/Notify.php
+++ b/emhttp/plugins/dynamix/include/Notify.php
@@ -36,6 +36,7 @@ case 'add':
     case 'm':
     case 'k':
     case 'l':
+    case 'g':
       $notify .= " -{$option} ".escapeshellarg($value);
       break;
     case 'x':
@@ -52,6 +53,12 @@ case 'clear':
   // Resolve a keyed (condition-style / persistent) notification.
   $key = $_POST['k']??'';
   if ($key !== '') shell_exec("$notify clear -k ".escapeshellarg($key));
+  break;
+case 'banner-sweep':
+  // Reconcile JS-sourced banner notifications: clear any 'banner-' keyed
+  // notification not re-raised in the current page-load generation.
+  $gen = $_POST['g']??'';
+  if ($gen !== '') shell_exec("$notify banner-sweep ".escapeshellarg($gen));
   break;
 case 'get':
   echo shell_exec("$notify get");

--- a/emhttp/plugins/dynamix/include/Notify.php
+++ b/emhttp/plugins/dynamix/include/Notify.php
@@ -34,15 +34,24 @@ case 'add':
     case 'd':
     case 'i':
     case 'm':
+    case 'k':
+    case 'l':
       $notify .= " -{$option} ".escapeshellarg($value);
       break;
     case 'x':
     case 't':
+    case 'p':
       $notify .= " -{$option}";
       break;
     }
   }
   shell_exec("$notify add");
+  break;
+
+case 'clear':
+  // Resolve a keyed (condition-style / persistent) notification.
+  $key = $_POST['k']??'';
+  if ($key !== '') shell_exec("$notify clear -k ".escapeshellarg($key));
   break;
 case 'get':
   echo shell_exec("$notify get");

--- a/emhttp/plugins/dynamix/include/Notify.php
+++ b/emhttp/plugins/dynamix/include/Notify.php
@@ -54,12 +54,6 @@ case 'clear':
   $key = $_POST['k']??'';
   if ($key !== '') shell_exec("$notify clear -k ".escapeshellarg($key));
   break;
-case 'banner-sweep':
-  // Reconcile JS-sourced banner notifications: clear any 'banner-' keyed
-  // notification not re-raised in the current page-load generation.
-  $gen = $_POST['g']??'';
-  if ($gen !== '') shell_exec("$notify banner-sweep ".escapeshellarg($gen));
-  break;
 case 'get':
   echo shell_exec("$notify get");
   break;

--- a/emhttp/plugins/dynamix/scripts/notify
+++ b/emhttp/plugins/dynamix/scripts/notify
@@ -148,11 +148,18 @@ extract(parse_plugin_cfg("dynamix",true));
 $path    = _var($notify,'path','/tmp/notifications');
 $unread  = "$path/unread";
 $archive = "$path/archive";
-// Persistent (condition-style) notifications live in their own directory so they
-// can be retrieved cheaply without scanning the whole unread set, and so bulk
-// archive/delete never touch them. 'notify get' unions this with unread so the
-// legacy nchan poller still surfaces them.
-$active  = "$path/active";
+// Condition-style notifications (e.g. "Modified GUI installed") are derived state:
+// true only while their condition holds, and re-raised on every page load. They live
+// in their own directory so they can be retrieved cheaply without scanning the whole
+// unread set, and so bulk archive/delete never touch them. 'notify get' unions this
+// with unread so the legacy nchan poller still surfaces them.
+//
+// This directory is ALWAYS tmpfs, never the user-configurable $path (which may point
+// at the flash boot device when "Store notifications to boot drive" is set). Persisting
+// a derived condition across reboots is what strands it forever when the condition is
+// gone (e.g. the plugin was removed); keeping it off-disk makes a reboot free GC — the
+// next page load re-raises only conditions that are still true.
+$active  = "/tmp/notifications/active";
 $agents_dir = "/boot/config/plugins/dynamix/notifications/agents";
 if (is_dir($agents_dir)) {
   $agents = [];

--- a/emhttp/plugins/dynamix/scripts/notify
+++ b/emhttp/plugins/dynamix/scripts/notify
@@ -267,7 +267,12 @@ case 'add':
   $idBase = $key !== '' ? $key : "{$event}-{$ticket}";
   $unread = "{$unread}/".safe_filename("{$idBase}.notify");
   $archive = "{$archive}/".safe_filename("{$idBase}.notify");
-  if (file_exists($archive)) break;
+  // Legacy dedup: don't recreate a notification the user already archived.
+  // Keyed (condition-style) notifications are exempt: re-raising a condition should
+  // re-pin it, so clear any stale archived copy and proceed instead of bailing.
+  if (file_exists($archive)) {
+    if ($key !== '') @unlink($archive); else break;
+  }
   $entity = $overrule===false ? $notify[$importance] : $overrule;
   $cleanSubject = clean_subject($subject);
   $archiveData = [

--- a/emhttp/plugins/dynamix/scripts/notify
+++ b/emhttp/plugins/dynamix/scripts/notify
@@ -216,8 +216,9 @@ case 'add':
   $noBrowser = false;
   $key = '';
   $persistent = false;
+  $gen = '';
 
-  $options = getopt("l:e:s:d:i:m:r:k:xtbp");
+  $options = getopt("l:e:s:d:i:m:r:k:g:xtbp");
   foreach ($options as $option => $value) {
     switch ($option) {
      case 'e':
@@ -253,6 +254,9 @@ case 'add':
       break;
      case 'p':
       $persistent = true;
+      break;
+     case 'g':
+      $gen = $value;
       break;
      case 'l':
       $nginx = (array)@parse_ini_file('/var/local/emhttp/nginx.ini');
@@ -297,6 +301,9 @@ case 'add':
     ];
     if ($key !== '') $unreadData['key'] = $key;
     if ($persistent) $unreadData['persistent'] = 'true';
+    // Generation stamp for JS-sourced banner notifications: lets 'banner-sweep'
+    // reconcile (clear) banners that were not re-raised on the latest page load.
+    if ($gen !== '') $unreadData['gen'] = $gen;
     file_put_contents($unread, build_ini_string($unreadData));
   }
   if (($entity & 2)==2 || $mailtest) generate_email($event, $cleanSubject, str_replace('<br>','. ',$description), $importance, $message, $recipients, $fqdnlink);
@@ -348,6 +355,30 @@ case 'clear':
   foreach ([$unread, $archive] as $dir) {
     $target = "$dir/$name";
     if (strpos(realpath($target) ?: '', $dir.'/')===0) @unlink($target);
+  }
+  break;
+
+case 'banner-sweep':
+  // Reconcile JS-sourced banner notifications (keys prefixed 'banner-'):
+  //   notify banner-sweep <generation>
+  // Legacy banners (CA, boot checks, ...) have no explicit clear - they signal
+  // "still active" by re-rendering on every page load. addBannerWarning stamps
+  // each re-raise with the current page-load generation; this sweep removes any
+  // banner notification NOT stamped with the current generation, i.e. one whose
+  // producer stopped rendering it. Non-banner keys (PR plugins, reboot, ...) own
+  // their lifecycle and are left untouched.
+  $currentGen = $argv[2] ?? '';
+  if ($currentGen === '') exit(usage());
+  foreach (glob("$unread/*.notify", GLOB_NOSORT) ?: [] as $file) {
+    $k = $g = '';
+    foreach (file($file, FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+      [$field,$val] = array_pad(explode('=', $line, 2), 2, '');
+      $field = trim($field);
+      if ($field === 'key') $k = ini_decode_value($val);
+      elseif ($field === 'gen') $g = ini_decode_value($val);
+    }
+    if (strpos($k, 'banner-') !== 0) continue;
+    if ($g !== $currentGen) @unlink($file);
   }
   break;
 }

--- a/emhttp/plugins/dynamix/scripts/notify
+++ b/emhttp/plugins/dynamix/scripts/notify
@@ -331,10 +331,14 @@ case 'archive':
 
 case 'clear':
   // Resolve a condition-style notification by its stable key:
-  //   notify clear -k <key>   (or)   notify clear <key>
-  $opt = getopt("k:");
-  $key = $opt['k'] ?? ($argv[2] ?? '');
-  if ($key === '' || $key === false) exit(usage());
+  //   notify clear <key>   (or)   notify clear -k <key>
+  // Parse argv directly: getopt() stops at the leading 'clear' sub-command.
+  $key = '';
+  if (isset($argv[2])) {
+    if ($argv[2] === '-k') $key = $argv[3] ?? '';
+    elseif ($argv[2][0] !== '-') $key = $argv[2];
+  }
+  if ($key === '') exit(usage());
   $name = safe_filename("{$key}.notify");
   foreach ([$unread, $archive] as $dir) {
     $target = "$dir/$name";

--- a/emhttp/plugins/dynamix/scripts/notify
+++ b/emhttp/plugins/dynamix/scripts/notify
@@ -148,6 +148,11 @@ extract(parse_plugin_cfg("dynamix",true));
 $path    = _var($notify,'path','/tmp/notifications');
 $unread  = "$path/unread";
 $archive = "$path/archive";
+// Persistent (condition-style) notifications live in their own directory so they
+// can be retrieved cheaply without scanning the whole unread set, and so bulk
+// archive/delete never touch them. 'notify get' unions this with unread so the
+// legacy nchan poller still surfaces them.
+$active  = "$path/active";
 $agents_dir = "/boot/config/plugins/dynamix/notifications/agents";
 if (is_dir($agents_dir)) {
   $agents = [];
@@ -160,13 +165,14 @@ if (is_dir($agents_dir)) {
 
 switch ($argv[1][0]=='-' ? 'add' : $argv[1]) {
 case 'init':
-  $files = glob("$unread/*.notify", GLOB_NOSORT);
+  $files = array_merge(glob("$unread/*.notify", GLOB_NOSORT) ?: [], glob("$active/*.notify", GLOB_NOSORT) ?: []);
   foreach ($files as $file) if (!is_readable($file)) chmod($file,0666);
   break;
 
 case 'smtp-init':
   @mkdir($unread,0755,true);
   @mkdir($archive,0755,true);
+  @mkdir($active,0755,true);
   $conf   = [];
   $conf[] = "# Generated settings:";
   $conf[] = "Root={$ssmtp['root']}";
@@ -189,6 +195,7 @@ case 'smtp-init':
 case 'cron-init':
   @mkdir($unread,0755,true);
   @mkdir($archive,0755,true);
+  @mkdir($active,0755,true);
   $text = empty($notify['status']) ? "" : "# Generated array status check schedule:\n{$notify['status']} $docroot/plugins/dynamix/scripts/statuscheck &> /dev/null\n\n";
   parse_cron_cfg("dynamix", "status-check", $text);
   $text = empty($notify['unraidos']) ? "" : "# Generated Unraid OS update check schedule:\n{$notify['unraidos']} $docroot/plugins/dynamix.plugin.manager/scripts/unraidcheck &> /dev/null\n\n";
@@ -269,14 +276,20 @@ case 'add':
   // Condition-style notifications use a stable key for the filename so raising the
   // same condition again overwrites it (idempotent) instead of stacking duplicates.
   $idBase = $key !== '' ? $key : "{$event}-{$ticket}";
-  $unread = "{$unread}/".safe_filename("{$idBase}.notify");
-  $archive = "{$archive}/".safe_filename("{$idBase}.notify");
+  $fileName = safe_filename("{$idBase}.notify");
+  // Persistent notifications live in 'active'; transient ones in 'unread'.
+  $targetDir = $persistent ? $active : $unread;
+  $unreadFile = "{$targetDir}/{$fileName}";
+  $archiveFile = "{$archive}/{$fileName}";
   // Legacy dedup: don't recreate a notification the user already archived.
   // Keyed (condition-style) notifications are exempt: re-raising a condition should
   // re-pin it, so clear any stale archived copy and proceed instead of bailing.
-  if (file_exists($archive)) {
-    if ($key !== '') @unlink($archive); else break;
+  if (file_exists($archiveFile)) {
+    if ($key !== '') @unlink($archiveFile); else break;
   }
+  // Clear any stale copy in the other store (e.g. a persistent notification that was
+  // previously written to unread before being relocated to active, or vice versa).
+  @unlink((($persistent ? $unread : $active))."/{$fileName}");
   $entity = $overrule===false ? $notify[$importance] : $overrule;
   $cleanSubject = clean_subject($subject);
   $archiveData = [
@@ -289,7 +302,7 @@ case 'add':
   if ($message) $archiveData['message'] = str_replace('\n','<br>',$message);
   // Persistent (condition-style) notifications are never archived - they clear when
   // their condition resolves - so skip writing the archive copy for them.
-  if (!$mailtest && !$persistent) file_put_contents($archive, build_ini_string($archiveData));
+  if (!$mailtest && !$persistent) file_put_contents($archiveFile, build_ini_string($archiveData));
   if (($entity & 1)==1 && !$mailtest && !$noBrowser) {
     $unreadData = [
       'timestamp' => $timestamp,
@@ -301,10 +314,11 @@ case 'add':
     ];
     if ($key !== '') $unreadData['key'] = $key;
     if ($persistent) $unreadData['persistent'] = 'true';
-    // Generation stamp for JS-sourced banner notifications: lets 'banner-sweep'
-    // reconcile (clear) banners that were not re-raised on the latest page load.
+    // Generation stamp for JS-sourced banner notifications: lets reconciliation
+    // clear banners that were not re-raised on the latest page load.
     if ($gen !== '') $unreadData['gen'] = $gen;
-    file_put_contents($unread, build_ini_string($unreadData));
+    @mkdir($targetDir, 0755, true);
+    file_put_contents($unreadFile, build_ini_string($unreadData));
   }
   if (($entity & 2)==2 || $mailtest) generate_email($event, $cleanSubject, str_replace('<br>','. ',$description), $importance, $message, $recipients, $fqdnlink);
   if (($entity & 4)==4 && !$mailtest) { if (is_array($agents)) {foreach ($agents as $agent) {exec("TIMESTAMP='$timestamp' EVENT=".escapeshellarg($event)." SUBJECT=".escapeshellarg($cleanSubject)." DESCRIPTION=".escapeshellarg($description)." IMPORTANCE=".escapeshellarg($importance)." CONTENT=".escapeshellarg($message)." LINK=".escapeshellarg($fqdnlink)." bash ".$agent);};}};
@@ -313,7 +327,9 @@ case 'add':
 case 'get':
   $output = [];
   $json = [];
-  $files = glob("$unread/*.notify", GLOB_NOSORT);
+  // Union persistent ('active') with transient ('unread') so the legacy nchan
+  // poller and any 'notify get' consumer still see condition-style notifications.
+  $files = array_merge(glob("$unread/*.notify", GLOB_NOSORT) ?: [], glob("$active/*.notify", GLOB_NOSORT) ?: []);
   usort($files, function($a,$b){return filemtime($a)-filemtime($b);});
   $i = 0;
   foreach ($files as $file) {
@@ -352,7 +368,9 @@ case 'clear':
   }
   if ($key === '') exit(usage());
   $name = safe_filename("{$key}.notify");
-  foreach ([$unread, $archive] as $dir) {
+  // Sweep all stores: persistent ('active') is the usual home, but also clear any
+  // stale unread/archive twin left from before the active/ split or a prior raise.
+  foreach ([$active, $unread, $archive] as $dir) {
     $target = "$dir/$name";
     if (strpos(realpath($target) ?: '', $dir.'/')===0) @unlink($target);
   }

--- a/emhttp/plugins/dynamix/scripts/notify
+++ b/emhttp/plugins/dynamix/scripts/notify
@@ -19,7 +19,7 @@ require_once "$docroot/webGui/include/Encryption.php";
 
 function usage() {
   echo <<<EOT
-notify [-e "event"] [-s "subject"] [-d "description"] [-i "normal|warning|alert"] [-m "message"] [-x] [-t] [-b] [add]
+notify [-e "event"] [-s "subject"] [-d "description"] [-i "normal|warning|alert"] [-m "message"] [-k "key"] [-p] [-x] [-t] [-b] [add]
   create a notification
   use -e to specify the event
   use -s to specify a subject
@@ -27,11 +27,16 @@ notify [-e "event"] [-s "subject"] [-d "description"] [-i "normal|warning|alert"
   use -i to specify the severity
   use -m to specify a message (long description)
   use -l to specify a link (clicking the notification will take you to that location)
+  use -k to specify a stable key; raising the same key again replaces the notification (idempotent)
+  use -p to make the notification persistent (sticky in the bell, not user-dismissible; clear it with 'notify clear -k key')
   use -x to create a single notification ticket
   use -r to specify recipients and not use default
   use -t to force send email only (for testing)
   use -b to NOT send a browser notification
   all options are optional
+
+notify clear -k "key"
+  Resolve a keyed (typically persistent) notification, removing it from the bell.
 
 notify init
   Initialize the notification subsystem.
@@ -209,8 +214,10 @@ case 'add':
   $mailtest = false;
   $overrule = false;
   $noBrowser = false;
+  $key = '';
+  $persistent = false;
 
-  $options = getopt("l:e:s:d:i:m:r:xtb");
+  $options = getopt("l:e:s:d:i:m:r:k:xtbp");
   foreach ($options as $option => $value) {
     switch ($option) {
      case 'e':
@@ -241,6 +248,12 @@ case 'add':
      case 'b':
       $noBrowser = true;
       break;
+     case 'k':
+      $key = $value;
+      break;
+     case 'p':
+      $persistent = true;
+      break;
      case 'l':
       $nginx = (array)@parse_ini_file('/var/local/emhttp/nginx.ini');
       $link = $value;
@@ -249,8 +262,11 @@ case 'add':
     }
   }
 
-  $unread = "{$unread}/".safe_filename("{$event}-{$ticket}.notify");
-  $archive = "{$archive}/".safe_filename("{$event}-{$ticket}.notify");
+  // Condition-style notifications use a stable key for the filename so raising the
+  // same condition again overwrites it (idempotent) instead of stacking duplicates.
+  $idBase = $key !== '' ? $key : "{$event}-{$ticket}";
+  $unread = "{$unread}/".safe_filename("{$idBase}.notify");
+  $archive = "{$archive}/".safe_filename("{$idBase}.notify");
   if (file_exists($archive)) break;
   $entity = $overrule===false ? $notify[$importance] : $overrule;
   $cleanSubject = clean_subject($subject);
@@ -262,7 +278,9 @@ case 'add':
     'importance' => $importance,
   ];
   if ($message) $archiveData['message'] = str_replace('\n','<br>',$message);
-  if (!$mailtest) file_put_contents($archive, build_ini_string($archiveData));
+  // Persistent (condition-style) notifications are never archived - they clear when
+  // their condition resolves - so skip writing the archive copy for them.
+  if (!$mailtest && !$persistent) file_put_contents($archive, build_ini_string($archiveData));
   if (($entity & 1)==1 && !$mailtest && !$noBrowser) {
     $unreadData = [
       'timestamp' => $timestamp,
@@ -272,6 +290,8 @@ case 'add':
       'importance' => $importance,
       'link' => $link,
     ];
+    if ($key !== '') $unreadData['key'] = $key;
+    if ($persistent) $unreadData['persistent'] = 'true';
     file_put_contents($unread, build_ini_string($unreadData));
   }
   if (($entity & 2)==2 || $mailtest) generate_email($event, $cleanSubject, str_replace('<br>','. ',$description), $importance, $message, $recipients, $fqdnlink);
@@ -307,6 +327,19 @@ case 'archive':
   if ($argc != 3) exit(usage());
   $file = $argv[2];
   if (strpos(realpath("$unread/$file"),$unread.'/')===0) @unlink("$unread/$file");
+  break;
+
+case 'clear':
+  // Resolve a condition-style notification by its stable key:
+  //   notify clear -k <key>   (or)   notify clear <key>
+  $opt = getopt("k:");
+  $key = $opt['k'] ?? ($argv[2] ?? '');
+  if ($key === '' || $key === false) exit(usage());
+  $name = safe_filename("{$key}.notify");
+  foreach ([$unread, $archive] as $dir) {
+    $target = "$dir/$name";
+    if (strpos(realpath($target) ?: '', $dir.'/')===0) @unlink($target);
+  }
   break;
 }
 

--- a/emhttp/plugins/dynamix/scripts/notify
+++ b/emhttp/plugins/dynamix/scripts/notify
@@ -357,30 +357,6 @@ case 'clear':
     if (strpos(realpath($target) ?: '', $dir.'/')===0) @unlink($target);
   }
   break;
-
-case 'banner-sweep':
-  // Reconcile JS-sourced banner notifications (keys prefixed 'banner-'):
-  //   notify banner-sweep <generation>
-  // Legacy banners (CA, boot checks, ...) have no explicit clear - they signal
-  // "still active" by re-rendering on every page load. addBannerWarning stamps
-  // each re-raise with the current page-load generation; this sweep removes any
-  // banner notification NOT stamped with the current generation, i.e. one whose
-  // producer stopped rendering it. Non-banner keys (PR plugins, reboot, ...) own
-  // their lifecycle and are left untouched.
-  $currentGen = $argv[2] ?? '';
-  if ($currentGen === '') exit(usage());
-  foreach (glob("$unread/*.notify", GLOB_NOSORT) ?: [] as $file) {
-    $k = $g = '';
-    foreach (file($file, FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
-      [$field,$val] = array_pad(explode('=', $line, 2), 2, '');
-      $field = trim($field);
-      if ($field === 'key') $k = ini_decode_value($val);
-      elseif ($field === 'gen') $g = ini_decode_value($val);
-    }
-    if (strpos($k, 'banner-') !== 0) continue;
-    if ($g !== $currentGen) @unlink($file);
-  }
-  break;
 }
 
 exit(0);


### PR DESCRIPTION
## Summary
Producer side of **persistent ("sticky until resolved") notifications** — the webgui half of replacing the floating yellow banner with the API notification **bell** ([OS-471](https://linear.app/lime-technology/issue/OS-471/persistent-sticky-until-resolved-notifications-to-replace-the-legacy)). Pairs with **unraid/api#2033** (which adds the `persistent`/`key` fields, idempotent keyed create, and `clearNotificationByKey`).

## Changes
- **`webGui/scripts/notify`** (canonical file; `webGui/scripts/notify` is a symlink to it):
  - `add` gains **`-k <key>`** — a stable key; keyed notices use the key as the filename so re-raising is **idempotent** (no dupes).
  - `add` gains **`-p`** — **persistent**: written as `persistent=true`, and *not* copied to the archive folder (it isn't an archival event).
  - new **`notify clear -k <key>`** — resolves a keyed notification (removes it from the bell).
  - `usage()` updated.
- **`PluginAPI.php`** — the **reboot-required** notice now also raises a persistent, keyed (`reboot-required`) **ALERT** notification, and **clears** it once no reboot reasons remain. It also clears naturally on reboot (RAM-backed `/tmp` is wiped and the bell repopulates from files).

## How it combines with the API PR
The API watches `/tmp/notifications/unread/*.notify`; these new fields flow straight through:
`notify add -p -k reboot-required …` → a sticky ALERT in the bell that the user can't dismiss and that auto-resolves. The API's `getLegacyScriptArgs` already passes `-k`/`-p`, so API-originated persistent notifications use this same script.

## Validation
- `php -l` clean on both files.
- End-to-end (reboot notice → bell, clear on resolve) is best verified on hardware with both PR test plugins installed (the diff-based stacking work makes that possible).

## Scope / follow-ups
This wires the clearest condition (reboot-required) end to end. Remaining banner call sites — **boot-device-corrupt** → persistent, and **transient** ones (popup blocked, etc.) → toaster — plus removing the `.upgrade_notice` element, are the documented next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stable-key persistent and conditional notifications, plus `notify clear -k` to dismiss specific keyed alerts.
  * Updated reboot-required and PR test build messaging to use keyed notification-bell persistence.
  * Replaced the legacy upgrade banner with a unified banner/notification system (persistent bell warnings and transient toast notifications).
* **Bug Fixes**
  * Reboot notifications no longer stack; repeated notices update the same bell entry.
  * Reboot notices automatically clear once all reboot reasons are resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->