### PR TITLE
feat(flash-backup): streaming download + save-to-server, with compression & progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,4 +116,3 @@ emhttp/plugins/pnpm-lock.yaml
 /etc/rc.d/rc0.d
 /etc/rc.d/rc6.d/K10flash-backup
 /etc/rc.d/rc6.d/K20unraid-api
-.gstack/

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ emhttp/plugins/pnpm-lock.yaml
 /etc/rc.d/rc0.d
 /etc/rc.d/rc6.d/K10flash-backup
 /etc/rc.d/rc6.d/K20unraid-api
+.gstack/

--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -442,11 +442,7 @@ array or the cache disk/pool.
 :end
 
 :flash_backup_help:
-Use *Boot device backup* to create a single zip file of the current contents of the boot device.
-
-Choose a *Backup mode*: *Download to your computer* streams the archive directly to your browser as it is built (nothing is stored on the server), while *Save to the server* runs in the background and writes the archive to a pool or array share, keeping it there - useful when your connection to the server is slow. Either way a progress bar shows how far along it is.
-
-Choose a *Compression level* too: *None* is the fastest but produces the largest file, while *Maximum* is the slowest but produces the smallest file. The previous OS release and other non-essential files are excluded to keep the backup small.
+Use *Boot device backup* to create a single zip file of the current contents of the boot device and store it locally on your computer.
 :end
 
 :syslinux_cfg_help:

--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -442,9 +442,9 @@ array or the cache disk/pool.
 :end
 
 :flash_backup_help:
-Use *Boot device backup* to create a single zip file of the current contents of the boot device and store it locally on your computer.
+Use *Boot device backup* to create a single zip file of the current contents of the boot device and download it to your computer.
 
-The backup runs in the background and reports its progress, then downloads automatically when finished. Choose a *Compression level* before starting: *None* is the fastest but produces the largest file, while *Maximum* is the slowest but produces the smallest file.
+The archive is streamed directly to your browser as it is built, so the download begins shortly after you start it and nothing is stored on the server. Choose a *Compression level* first: *None* is the fastest but produces the largest file, while *Maximum* is the slowest but produces the smallest file. The previous OS release and other non-essential files are excluded to keep the backup small.
 :end
 
 :syslinux_cfg_help:

--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -442,9 +442,11 @@ array or the cache disk/pool.
 :end
 
 :flash_backup_help:
-Use *Boot device backup* to create a single zip file of the current contents of the boot device and download it to your computer.
+Use *Boot device backup* to create a single zip file of the current contents of the boot device.
 
-The archive is streamed directly to your browser as it is built, so the download begins shortly after you start it and nothing is stored on the server. Choose a *Compression level* first: *None* is the fastest but produces the largest file, while *Maximum* is the slowest but produces the smallest file. The previous OS release and other non-essential files are excluded to keep the backup small.
+Choose a *Backup mode*: *Download to your computer* streams the archive directly to your browser as it is built (nothing is stored on the server), while *Save to the server* runs in the background and writes the archive to a pool or array share, keeping it there - useful when your connection to the server is slow. Either way a progress bar shows how far along it is.
+
+Choose a *Compression level* too: *None* is the fastest but produces the largest file, while *Maximum* is the slowest but produces the smallest file. The previous OS release and other non-essential files are excluded to keep the backup small.
 :end
 
 :syslinux_cfg_help:

--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -443,6 +443,8 @@ array or the cache disk/pool.
 
 :flash_backup_help:
 Use *Boot device backup* to create a single zip file of the current contents of the boot device and store it locally on your computer.
+
+The backup runs in the background and reports its progress, then downloads automatically when finished. Choose a *Compression level* before starting: *None* is the fastest but produces the largest file, while *Maximum* is the slowest but produces the smallest file.
 :end
 
 :syslinux_cfg_help:

--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -141,25 +141,26 @@ _(Compression level)_:
 
 <?
 // List boot backups already saved on the server (save-to-server mode keeps them
-// on a pool/array/boot mount). Show where each lives, with download + file
-// manager links, so they are discoverable later and easy to clean up.
+// on a pool/array/boot mount). Build a single inline value string so it stays in
+// the definition-list value column like the rows above (a multi-line block here
+// breaks out of the markdown definition list and renders full-width).
 $fb_saved = [];
 foreach (array_merge(glob("/mnt/*/*-boot-backup-*.zip"), glob("/mnt/user/*/*-boot-backup-*.zip"), glob("/boot/*-boot-backup-*.zip")) as $fb_f) {
   $fb_r = realpath($fb_f);
   if ($fb_r && is_file($fb_r)) $fb_saved[$fb_r] = filesize($fb_r);
 }
 krsort($fb_saved);
+$fb_rows = [];
+foreach ($fb_saved as $fb_path => $fb_size) {
+  $fb_bn = basename($fb_path); $fb_dir = dirname($fb_path);
+  $fb_rows[] = "<code>".htmlspecialchars($fb_path, ENT_QUOTES, 'UTF-8')."</code> (".number_format($fb_size/1073741824, 2)." GB) &nbsp;"
+    ."<a href='/webGui/include/FlashBackup.php?serve=".urlencode($fb_bn)."'><i class='fa fa-download'></i> "._('Download')."</a>"
+    ." &nbsp;&middot;&nbsp; <a href='/Main/Browse?dir=".urlencode($fb_dir)."'><i class='fa fa-folder-open'></i> "._('File Manager')."</a>";
+}
+$fb_html = implode('<br>', $fb_rows);
 ?>
-<?if ($fb_saved):?>
+<?if ($fb_html):?>
 _(Saved backups on this server)_:
-: <div class="inline-block">
-  <?foreach ($fb_saved as $fb_path => $fb_size): $fb_bn = basename($fb_path); $fb_dir = dirname($fb_path);?>
-    <div style="margin-bottom:6px">
-      <code><?=htmlspecialchars($fb_path, ENT_QUOTES, 'UTF-8')?></code>
-      (<?=number_format($fb_size/1073741824, 2)?> GB)<br>
-      <a href="/webGui/include/FlashBackup.php?serve=<?=urlencode($fb_bn)?>"><i class="fa fa-download"></i> _(Download)_</a>
-      &nbsp;&middot;&nbsp; <a href="/Main/Browse?dir=<?=urlencode($fb_dir)?>"><i class="fa fa-folder-open"></i> _(File Manager)_</a>
-    </div>
-  <?endforeach;?>
-  </div>
+: <?=$fb_html?>
+
 <?endif;?>

--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -17,25 +17,32 @@ Tag="usb"
 <?$tpmEnabled = !empty($var['flashGUID']) && strpos($var['flashGUID'], '01-') !== 0 && !empty($var['tpmGUID']) ? true : false;?>
 <script>
 // The backup is streamed straight to the browser as it is built - no staging
-// file, no size limit, and it works with the array stopped. We show a light
-// status while the archive is being prepared and clear it as soon as the
-// download starts, detected via a cookie the server sets once it begins
-// streaming the response.
+// file, no size limit, and it works with the array stopped. The download itself
+// has no known size (it is compressed on the fly), so the server reports
+// progress over the 'flash_backup' nchan channel and we show a real bar.
+var nchan_backup = new NchanSubscriber('/sub/flash_backup',{subscriber:'websocket'});
+nchan_backup.on('message', function(data) {
+  if (data == '_DONE_') {
+    setBackupProgress(100);
+    nchan_backup.stop();
+    setTimeout(function(){ swal.close(); }, 1200);
+    return;
+  }
+  var pct = parseInt(data, 10);
+  if (!isNaN(pct)) setBackupProgress(pct);
+});
+
+function setBackupProgress(pct) {
+  $('#fbBar').css('width', pct + '%');
+  $('#fbPct').text(pct + '%');
+}
+
 function backup() {
   var level = $('#backupLevel').val();
-  var token = '' + Date.now() + Math.floor(Math.random()*1e6);
-  swal({title:"_(Boot device backup)_",text:"_(Preparing backup - your download will begin shortly)_... <i class='fa fa-refresh fa-spin'></i>",html:true,animation:'none',showConfirmButton:false});
+  nchan_backup.start();
+  swal({title:"_(Boot device backup)_",text:"<div style='background:var(--border-color,#ccc);border-radius:3px;overflow:hidden;height:18px;margin:10px 0'><div id='fbBar' style='height:100%;width:0%;background:#ff8c2f;transition:width .3s'></div></div><div id='fbPct'>0%</div><div style='margin-top:8px'>_(Your download will begin shortly)_</div>",html:true,animation:'none',showConfirmButton:false});
   // Attachment response keeps us on this page while the browser downloads.
-  window.location = '/webGui/include/FlashBackup.php?level='+level+'&download='+token;
-  // Dismiss the status once the stream starts (cookie appears) or after a wait.
-  var tries = 0;
-  var timer = setInterval(function() {
-    if (document.cookie.indexOf('flashBackup='+token) >= 0 || ++tries > 120) {
-      clearInterval(timer);
-      document.cookie = 'flashBackup=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
-      swal.close();
-    }
-  }, 500);
+  window.location = '/webGui/include/FlashBackup.php?level='+level;
 }
 </script>
 _(Active GUID)_:

--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -24,33 +24,37 @@ Tag="usb"
 //  - Save to server: a tracked background job (scripts/flash_backup_save via
 //    StartCommand.php) writes the archive to a pool/array and keeps it, then
 //    reports the saved path. Useful when the download link is slow.
+//
+// Each run is tagged with a token. nchan retains the last message, so a fresh
+// run would otherwise immediately receive a stale "100"/"_DONE_" from a previous
+// run and jump to 100%. We keep ONE subscriber connected for the page lifetime
+// (no per-click start/stop, which raced) and ignore any message not from the
+// current run.
 var backupMode = 'download';
+var fbRun = '';
 var nchan_backup = new NchanSubscriber('/sub/flash_backup',{subscriber:'websocket'});
 nchan_backup.on('message', function(data) {
-  if (data.startsWith('_SAVED_')) {        // save mode finished - show the path
+  var i = data.indexOf(':');
+  if (i < 0 || data.slice(0,i) !== fbRun) return; // stale or other run
+  var msg = data.slice(i+1);
+  if (msg.startsWith('_SAVED_')) {           // save mode finished - show the path
     setBackupProgress(100);
-    nchan_backup.stop();
-    $('#fbMsg').html("_(Saved to)_: <code>"+data.substring(7)+"</code>");
+    $('#fbMsg').html("_(Saved to)_: <code>"+msg.substring(7)+"</code>");
     $('button.confirm').prop('disabled',false);
-    return;
-  }
-  if (data.startsWith('_ERROR_')) {
-    nchan_backup.stop();
+  } else if (msg.startsWith('_ERROR_')) {
     $('#fbFrame').remove();
-    swal({title:"_(Creation error)_",text:data.substring(7),type:'error',html:true,confirmButtonText:"_(Ok)_"});
-    return;
-  }
-  if (data == '_DONE_') {                   // download mode finished
-    if (backupMode != 'download') return;   // save mode already handled by _SAVED_
+    swal({title:"_(Creation error)_",text:msg.substring(7),type:'error',html:true,confirmButtonText:"_(Ok)_"});
+  } else if (msg === '_DONE_') {             // download mode finished
+    if (backupMode !== 'download') return;   // save mode already handled by _SAVED_
     setBackupProgress(100);
-    nchan_backup.stop();
     $('#fbFrame').remove();
     setTimeout(function(){ swal.close(); }, 1200);
-    return;
+  } else {
+    var pct = parseInt(msg, 10);
+    if (!isNaN(pct)) setBackupProgress(pct);
   }
-  var pct = parseInt(data, 10);
-  if (!isNaN(pct)) setBackupProgress(pct);
 });
+nchan_backup.start();
 
 function setBackupProgress(pct) {
   $('#fbBar').css('width', pct + '%');
@@ -60,21 +64,20 @@ function setBackupProgress(pct) {
 function backup() {
   backupMode = $('#backupMode').val();
   var level = $('#backupLevel').val();
-  var saving = backupMode == 'save';
-  nchan_backup.start();
+  var saving = backupMode === 'save';
+  fbRun = '' + Date.now();
   swal({title:"_(Boot device backup)_",text:"<div style='background:var(--border-color,#ccc);border-radius:3px;overflow:hidden;height:18px;margin:10px 0'><div id='fbBar' style='height:100%;width:0%;background:#ff8c2f;transition:width .3s'></div></div><div id='fbPct'>0%</div><div id='fbMsg' style='margin-top:8px'>"+(saving?"_(Saving boot device backup to the server)_...":"_(Backing up the boot device)_...")+"</div>",html:true,animation:'none',showConfirmButton:true,confirmButtonText:"_(Close)_"},function(){
-    nchan_backup.stop();
-    $('#fbFrame').remove();
+    $('#fbFrame').remove(); // cancel an in-progress download; subscriber stays alive
   });
   if (saving) {
     // Tracked background job; it writes the archive to disk and keeps it.
-    $.post('/webGui/include/StartCommand.php',{cmd:'flash_backup_save '+level,start:0});
+    $.post('/webGui/include/StartCommand.php',{cmd:'flash_backup_save '+level+' '+fbRun,start:0});
   } else {
     // Download via a hidden iframe (not window.location): a top-level navigation
     // fires 'beforeunload', which makes NchanSubscriber stop itself and kills the
     // progress updates.
     $('#fbFrame').remove();
-    $('<iframe>',{id:'fbFrame',src:'/webGui/include/FlashBackup.php?level='+level}).hide().appendTo('body');
+    $('<iframe>',{id:'fbFrame',src:'/webGui/include/FlashBackup.php?level='+level+'&run='+fbRun}).hide().appendTo('body');
   }
 }
 </script>

--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -16,13 +16,32 @@ Tag="usb"
 ?>
 <?$tpmEnabled = !empty($var['flashGUID']) && strpos($var['flashGUID'], '01-') !== 0 && !empty($var['tpmGUID']) ? true : false;?>
 <script>
-// The backup is streamed straight to the browser as it is built - no staging
-// file, no size limit, and it works with the array stopped. The download itself
-// has no known size (it is compressed on the fly), so the server reports
-// progress over the 'flash_backup' nchan channel and we show a real bar.
+// Two backup modes share one progress bar, fed by the 'flash_backup' nchan
+// channel:
+//  - Download: streamed straight to the browser as it is built (no staging file,
+//    no size limit, works with the array stopped). include/FlashBackup.php
+//    publishes a percentage as it streams.
+//  - Save to server: a tracked background job (scripts/flash_backup_save via
+//    StartCommand.php) writes the archive to a pool/array and keeps it, then
+//    reports the saved path. Useful when the download link is slow.
+var backupMode = 'download';
 var nchan_backup = new NchanSubscriber('/sub/flash_backup',{subscriber:'websocket'});
 nchan_backup.on('message', function(data) {
-  if (data == '_DONE_') {
+  if (data.startsWith('_SAVED_')) {        // save mode finished - show the path
+    setBackupProgress(100);
+    nchan_backup.stop();
+    $('#fbMsg').html("_(Saved to)_: <code>"+data.substring(7)+"</code>");
+    $('button.confirm').prop('disabled',false);
+    return;
+  }
+  if (data.startsWith('_ERROR_')) {
+    nchan_backup.stop();
+    $('#fbFrame').remove();
+    swal({title:"_(Creation error)_",text:data.substring(7),type:'error',html:true,confirmButtonText:"_(Ok)_"});
+    return;
+  }
+  if (data == '_DONE_') {                   // download mode finished
+    if (backupMode != 'download') return;   // save mode already handled by _SAVED_
     setBackupProgress(100);
     nchan_backup.stop();
     $('#fbFrame').remove();
@@ -39,14 +58,24 @@ function setBackupProgress(pct) {
 }
 
 function backup() {
+  backupMode = $('#backupMode').val();
   var level = $('#backupLevel').val();
+  var saving = backupMode == 'save';
   nchan_backup.start();
-  swal({title:"_(Boot device backup)_",text:"<div style='background:var(--border-color,#ccc);border-radius:3px;overflow:hidden;height:18px;margin:10px 0'><div id='fbBar' style='height:100%;width:0%;background:#ff8c2f;transition:width .3s'></div></div><div id='fbPct'>0%</div><div style='margin-top:8px'>_(Backing up the boot device)_...</div>",html:true,animation:'none',showConfirmButton:true,confirmButtonText:"_(Close)_"});
-  // Download via a hidden iframe (not window.location) so the page never starts
-  // to navigate: a top-level navigation fires 'beforeunload', which makes the
-  // NchanSubscriber stop itself - killing the progress updates.
-  $('#fbFrame').remove();
-  $('<iframe>',{id:'fbFrame',src:'/webGui/include/FlashBackup.php?level='+level}).hide().appendTo('body');
+  swal({title:"_(Boot device backup)_",text:"<div style='background:var(--border-color,#ccc);border-radius:3px;overflow:hidden;height:18px;margin:10px 0'><div id='fbBar' style='height:100%;width:0%;background:#ff8c2f;transition:width .3s'></div></div><div id='fbPct'>0%</div><div id='fbMsg' style='margin-top:8px'>"+(saving?"_(Saving boot device backup to the server)_...":"_(Backing up the boot device)_...")+"</div>",html:true,animation:'none',showConfirmButton:true,confirmButtonText:"_(Close)_"},function(){
+    nchan_backup.stop();
+    $('#fbFrame').remove();
+  });
+  if (saving) {
+    // Tracked background job; it writes the archive to disk and keeps it.
+    $.post('/webGui/include/StartCommand.php',{cmd:'flash_backup_save '+level,start:0});
+  } else {
+    // Download via a hidden iframe (not window.location): a top-level navigation
+    // fires 'beforeunload', which makes NchanSubscriber stop itself and kills the
+    // progress updates.
+    $('#fbFrame').remove();
+    $('<iframe>',{id:'fbFrame',src:'/webGui/include/FlashBackup.php?level='+level}).hide().appendTo('body');
+  }
 }
 </script>
 _(Active GUID)_:
@@ -83,6 +112,12 @@ _(TPM GUID)_:
 <?endif;?>
 
 :flash_backup_help:
+
+_(Backup mode)_:
+: <select id="backupMode">
+    <option value="download" selected>_(Download to your computer)_</option>
+    <option value="save">_(Save to the server)_</option>
+  </select>
 
 _(Compression level)_:
 : <select id="backupLevel">

--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -16,71 +16,20 @@ Tag="usb"
 ?>
 <?$tpmEnabled = !empty($var['flashGUID']) && strpos($var['flashGUID'], '01-') !== 0 && !empty($var['tpmGUID']) ? true : false;?>
 <script>
-// Two backup modes share one progress bar, fed by the 'flash_backup' nchan
-// channel:
-//  - Download: streamed straight to the browser as it is built (no staging file,
-//    no size limit, works with the array stopped). include/FlashBackup.php
-//    publishes a percentage as it streams.
-//  - Save to server: a tracked background job (scripts/flash_backup_save via
-//    StartCommand.php) writes the archive to a pool/array and keeps it, then
-//    reports the saved path. Useful when the download link is slow.
-//
-// Each run is tagged with a token. nchan retains the last message, so a fresh
-// run would otherwise immediately receive a stale "100"/"_DONE_" from a previous
-// run and jump to 100%. We keep ONE subscriber connected for the page lifetime
-// (no per-click start/stop, which raced) and ignore any message not from the
-// current run.
-var backupMode = 'download';
-var fbRun = '';
-var nchan_backup = new NchanSubscriber('/sub/flash_backup',{subscriber:'websocket'});
-nchan_backup.on('message', function(data) {
-  var i = data.indexOf(':');
-  if (i < 0 || data.slice(0,i) !== fbRun) return; // stale or other run
-  var msg = data.slice(i+1);
-  if (msg.startsWith('_SAVED_')) {           // save mode finished - show path + download
-    setBackupProgress(100);
-    var p = msg.substring(7), name = p.substring(p.lastIndexOf('/')+1), dir = p.substring(0,p.lastIndexOf('/'));
-    $('#fbMsg').html("_(Saved to)_: <code>"+p+"</code><br><span style='display:inline-block;margin-top:10px'>"
-      +"<a href='/webGui/include/FlashBackup.php?serve="+encodeURIComponent(name)+"'><i class='fa fa-download'></i> _(Download)_</a>"
-      +" &nbsp;&middot;&nbsp; <a href='/Main/Browse?dir="+encodeURIComponent(dir)+"'><i class='fa fa-folder-open'></i> _(File Manager)_</a></span>");
-    $('button.confirm').prop('disabled',false);
-  } else if (msg.startsWith('_ERROR_')) {
-    $('#fbFrame').remove();
-    swal({title:"_(Creation error)_",text:msg.substring(7),type:'error',html:true,confirmButtonText:"_(Ok)_"});
-  } else if (msg === '_DONE_') {             // download mode finished
-    if (backupMode !== 'download') return;   // save mode already handled by _SAVED_
-    setBackupProgress(100);
-    $('#fbFrame').remove();
-    setTimeout(function(){ swal.close(); }, 1200);
-  } else {
-    var pct = parseInt(msg, 10);
-    if (!isNaN(pct)) setBackupProgress(pct);
-  }
-});
-nchan_backup.start();
-
-function setBackupProgress(pct) {
-  $('#fbBar').css('width', pct + '%');
-  $('#fbPct').text(pct + '%');
-}
-
 function backup() {
-  backupMode = $('#backupMode').val();
   var level = $('#backupLevel').val();
-  var saving = backupMode === 'save';
-  fbRun = '' + Date.now();
-  swal({title:"_(Boot device backup)_",text:"<div style='background:var(--gray-300);border-radius:3px;overflow:hidden;height:18px;margin:10px 0'><div id='fbBar' style='height:100%;width:0%;background:var(--orange-500);transition:width .3s'></div></div><div id='fbPct'>0%</div><div id='fbMsg' style='margin-top:8px'>"+(saving?"_(Saving boot device backup to the server)_...":"_(Backing up the boot device)_...")+"</div>",html:true,animation:'none',showConfirmButton:true,confirmButtonText:"_(Close)_"},function(){
-    $('#fbFrame').remove(); // cancel an in-progress download; subscriber stays alive
-  });
-  if (saving) {
-    // Tracked background job; it writes the archive to disk and keeps it.
-    $.post('/webGui/include/StartCommand.php',{cmd:'flash_backup_save '+level+' '+fbRun,start:0});
+  if ($('#backupMode').val() === 'save') {
+    // Background job tracked by the shared task tray (openPlugin -> TaskQueue):
+    // it shows in the tray, opens the standard progress modal, and keeps running
+    // when the modal is closed. flash_backup_save publishes progress on the
+    // standard 'plugins' task channel and exits 0/non-zero for done/error.
+    openPlugin('flash_backup_save '+level, "_(Boot device backup)_", '', '', 1);
   } else {
-    // Download via a hidden iframe (not window.location): a top-level navigation
-    // fires 'beforeunload', which makes NchanSubscriber stop itself and kills the
-    // progress updates.
+    // Stream straight to the browser; the browser's own download indicator shows
+    // progress. A hidden iframe (not window.location) keeps us on this page.
     $('#fbFrame').remove();
-    $('<iframe>',{id:'fbFrame',src:'/webGui/include/FlashBackup.php?level='+level+'&run='+fbRun}).hide().appendTo('body');
+    $('<iframe>',{id:'fbFrame',src:'/webGui/include/FlashBackup.php?level='+level}).hide().appendTo('body');
+    swal({title:"_(Boot device backup)_",text:"_(Your download will begin shortly)_",type:'info',html:true,animation:'none',timer:4000,showConfirmButton:false});
   }
 }
 </script>

--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -25,6 +25,7 @@ nchan_backup.on('message', function(data) {
   if (data == '_DONE_') {
     setBackupProgress(100);
     nchan_backup.stop();
+    $('#fbFrame').remove();
     setTimeout(function(){ swal.close(); }, 1200);
     return;
   }
@@ -40,9 +41,12 @@ function setBackupProgress(pct) {
 function backup() {
   var level = $('#backupLevel').val();
   nchan_backup.start();
-  swal({title:"_(Boot device backup)_",text:"<div style='background:var(--border-color,#ccc);border-radius:3px;overflow:hidden;height:18px;margin:10px 0'><div id='fbBar' style='height:100%;width:0%;background:#ff8c2f;transition:width .3s'></div></div><div id='fbPct'>0%</div><div style='margin-top:8px'>_(Your download will begin shortly)_</div>",html:true,animation:'none',showConfirmButton:false});
-  // Attachment response keeps us on this page while the browser downloads.
-  window.location = '/webGui/include/FlashBackup.php?level='+level;
+  swal({title:"_(Boot device backup)_",text:"<div style='background:var(--border-color,#ccc);border-radius:3px;overflow:hidden;height:18px;margin:10px 0'><div id='fbBar' style='height:100%;width:0%;background:#ff8c2f;transition:width .3s'></div></div><div id='fbPct'>0%</div><div style='margin-top:8px'>_(Backing up the boot device)_...</div>",html:true,animation:'none',showConfirmButton:true,confirmButtonText:"_(Close)_"});
+  // Download via a hidden iframe (not window.location) so the page never starts
+  // to navigate: a top-level navigation fires 'beforeunload', which makes the
+  // NchanSubscriber stop itself - killing the progress updates.
+  $('#fbFrame').remove();
+  $('<iframe>',{id:'fbFrame',src:'/webGui/include/FlashBackup.php?level='+level}).hide().appendTo('body');
 }
 </script>
 _(Active GUID)_:

--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -16,51 +16,26 @@ Tag="usb"
 ?>
 <?$tpmEnabled = !empty($var['flashGUID']) && strpos($var['flashGUID'], '01-') !== 0 && !empty($var['tpmGUID']) ? true : false;?>
 <script>
-// Run the flash backup as a tracked background job through StartCommand.php
-// (same mechanism as plugin/docker operations) and stream progress into the
-// standard nchan progress window. The script publishes a _FILE_<name> message
-// so we know which archive to download once it reports _DONE_.
-var backupFile = "";
-var nchan_backup = new NchanSubscriber('/sub/flash_backup',{subscriber:'websocket', reconnectTimeout:5000});
-
-nchan_backup.on('message', function(data) {
-  if (!data) return;
-  if (data.startsWith('_FILE_')) { backupFile = data.substring(6); return; }
-  if (openError(data)) { nchan_backup.stop(); return; }
-  if (openDone(data)) {
-    nchan_backup.stop();
-    if (backupFile) {
-      // archive ready: trigger the browser download, then clean it up afterwards
-      location = '/'+backupFile;
-      setTimeout(cleanUpBackup,6000);
-    }
-    return;
-  }
-  var box = $('pre#swaltext');
-  box.html(box.html()+'<br>'+data).scrollTop(box[0].scrollHeight);
-});
-
-function cleanUpBackup() {
-  if (document.hasFocus()) {
-    $.post('/webGui/include/Download.php',{cmd:'unlink',file:backupFile});
-    backupFile = "";
-  } else {
-    setTimeout(cleanUpBackup,2000);
-  }
-}
-
+// The backup is streamed straight to the browser as it is built - no staging
+// file, no size limit, and it works with the array stopped. We show a light
+// status while the archive is being prepared and clear it as soon as the
+// download starts, detected via a cookie the server sets once it begins
+// streaming the response.
 function backup() {
-  backupFile = "";
   var level = $('#backupLevel').val();
-  nchan_backup.start();
-  $.post('/webGui/include/StartCommand.php',{cmd:'flash_backup '+level+' nchan',start:0},function() {
-    swal({title:"_(Boot device backup)_ - <span id='pluginProgressTitle'>_(In Progress)_ <i class='fa fa-refresh fa-spin'></i></span>",text:"<pre id='swaltext'></pre><hr>",html:true,animation:'none',showConfirmButton:true,confirmButtonText:"_(Close)_"},function(){
-      nchan_backup.stop();
-      $('.sweet-alert').hide('fast').removeClass('nchan');
-    });
-    $('.sweet-alert').addClass('nchan');
-    $('button.confirm').prop('disabled',true);
-  });
+  var token = '' + Date.now() + Math.floor(Math.random()*1e6);
+  swal({title:"_(Boot device backup)_",text:"_(Preparing backup - your download will begin shortly)_... <i class='fa fa-refresh fa-spin'></i>",html:true,animation:'none',showConfirmButton:false});
+  // Attachment response keeps us on this page while the browser downloads.
+  window.location = '/webGui/include/FlashBackup.php?level='+level+'&download='+token;
+  // Dismiss the status once the stream starts (cookie appears) or after a wait.
+  var tries = 0;
+  var timer = setInterval(function() {
+    if (document.cookie.indexOf('flashBackup='+token) >= 0 || ++tries > 120) {
+      clearInterval(timer);
+      document.cookie = 'flashBackup=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+      swal.close();
+    }
+  }, 500);
 }
 </script>
 _(Active GUID)_:

--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -40,7 +40,7 @@ nchan_backup.on('message', function(data) {
   if (msg.startsWith('_SAVED_')) {           // save mode finished - show path + download
     setBackupProgress(100);
     var p = msg.substring(7), name = p.substring(p.lastIndexOf('/')+1);
-    $('#fbMsg').html("_(Saved to)_: <code>"+p+"</code><br><a href='/"+encodeURIComponent(name)+"' style='display:inline-block;margin-top:10px'><i class='fa fa-download'></i> _(Download)_</a>");
+    $('#fbMsg').html("_(Saved to)_: <code>"+p+"</code><br><a href='/webGui/include/FlashBackup.php?serve="+encodeURIComponent(name)+"' style='display:inline-block;margin-top:10px'><i class='fa fa-download'></i> _(Download)_</a>");
     $('button.confirm').prop('disabled',false);
   } else if (msg.startsWith('_ERROR_')) {
     $('#fbFrame').remove();

--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -69,7 +69,7 @@ function backup() {
   var level = $('#backupLevel').val();
   var saving = backupMode === 'save';
   fbRun = '' + Date.now();
-  swal({title:"_(Boot device backup)_",text:"<div style='background:var(--border-color,#ccc);border-radius:3px;overflow:hidden;height:18px;margin:10px 0'><div id='fbBar' style='height:100%;width:0%;background:#ff8c2f;transition:width .3s'></div></div><div id='fbPct'>0%</div><div id='fbMsg' style='margin-top:8px'>"+(saving?"_(Saving boot device backup to the server)_...":"_(Backing up the boot device)_...")+"</div>",html:true,animation:'none',showConfirmButton:true,confirmButtonText:"_(Close)_"},function(){
+  swal({title:"_(Boot device backup)_",text:"<div style='background:var(--gray-300);border-radius:3px;overflow:hidden;height:18px;margin:10px 0'><div id='fbBar' style='height:100%;width:0%;background:var(--orange-500);transition:width .3s'></div></div><div id='fbPct'>0%</div><div id='fbMsg' style='margin-top:8px'>"+(saving?"_(Saving boot device backup to the server)_...":"_(Backing up the boot device)_...")+"</div>",html:true,animation:'none',showConfirmButton:true,confirmButtonText:"_(Close)_"},function(){
     $('#fbFrame').remove(); // cancel an in-progress download; subscriber stays alive
   });
   if (saving) {
@@ -154,11 +154,11 @@ krsort($fb_saved);
 _(Saved backups on this server)_:
 : <div class="inline-block">
   <?foreach ($fb_saved as $fb_path => $fb_size): $fb_bn = basename($fb_path); $fb_dir = dirname($fb_path);?>
-    <div style="margin-bottom:4px">
+    <div style="margin-bottom:6px">
       <code><?=htmlspecialchars($fb_path, ENT_QUOTES, 'UTF-8')?></code>
-      (<?=number_format($fb_size/1073741824, 2)?> GB)
-      &nbsp;<a href="/webGui/include/FlashBackup.php?serve=<?=urlencode($fb_bn)?>"><i class="fa fa-download"></i> _(Download)_</a>
-      &nbsp;<a href="/Main/Browse?dir=<?=urlencode($fb_dir)?>"><i class="fa fa-folder-open"></i> _(File Manager)_</a>
+      (<?=number_format($fb_size/1073741824, 2)?> GB)<br>
+      <a href="/webGui/include/FlashBackup.php?serve=<?=urlencode($fb_bn)?>"><i class="fa fa-download"></i> _(Download)_</a>
+      &nbsp;&middot;&nbsp; <a href="/Main/Browse?dir=<?=urlencode($fb_dir)?>"><i class="fa fa-folder-open"></i> _(File Manager)_</a>
     </div>
   <?endforeach;?>
   </div>

--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -16,53 +16,51 @@ Tag="usb"
 ?>
 <?$tpmEnabled = !empty($var['flashGUID']) && strpos($var['flashGUID'], '01-') !== 0 && !empty($var['tpmGUID']) ? true : false;?>
 <script>
+// Run the flash backup as a tracked background job through StartCommand.php
+// (same mechanism as plugin/docker operations) and stream progress into the
+// standard nchan progress window. The script publishes a _FILE_<name> message
+// so we know which archive to download once it reports _DONE_.
 var backupFile = "";
-var nchan_backup = new NchanSubscriber('/sub/flash_backup',{subscriber:'websocket'});
+var nchan_backup = new NchanSubscriber('/sub/flash_backup',{subscriber:'websocket', reconnectTimeout:5000});
 
 nchan_backup.on('message', function(data) {
-  if (data == '_DONE_') {
+  if (!data) return;
+  if (data.startsWith('_FILE_')) { backupFile = data.substring(6); return; }
+  if (openError(data)) { nchan_backup.stop(); return; }
+  if (openDone(data)) {
     nchan_backup.stop();
-    resetBackupButton();
     if (backupFile) {
-      // archive ready: trigger the browser download then clean up afterwards
-      swal.close();
+      // archive ready: trigger the browser download, then clean it up afterwards
       location = '/'+backupFile;
-      setTimeout(cleanUp,6000);
+      setTimeout(cleanUpBackup,6000);
     }
-  } else if (data.startsWith('_FILE_')) {
-    backupFile = data.substring(6);
-  } else if (data.startsWith('_ERROR_')) {
-    nchan_backup.stop();
-    resetBackupButton();
-    swal({title:"_(Creation error)_",text:data.substring(7),type:'error',html:true,confirmButtonText:"_(Ok)_"});
-  } else if (data) {
-    var box = $('pre#backuptext');
-    box.html(box.html()+'<br>'+data).scrollTop(box[0].scrollHeight);
+    return;
   }
+  var box = $('pre#swaltext');
+  box.html(box.html()+'<br>'+data).scrollTop(box[0].scrollHeight);
 });
 
-function resetBackupButton() {
-  $('input.backup-btn').val("_(Boot device backup)_").prop('disabled',false);
-  $('#backupLevel').prop('disabled',false);
-}
-
-function cleanUp() {
+function cleanUpBackup() {
   if (document.hasFocus()) {
     $.post('/webGui/include/Download.php',{cmd:'unlink',file:backupFile});
     backupFile = "";
   } else {
-    setTimeout(cleanUp,2000);
+    setTimeout(cleanUpBackup,2000);
   }
 }
 
 function backup() {
   backupFile = "";
-  $('input.backup-btn').val('_(Creating boot device backup)_...').prop('disabled',true);
-  $('#backupLevel').prop('disabled',true);
   var level = $('#backupLevel').val();
   nchan_backup.start();
-  swal({title:"_(Creating boot device backup)_...",text:"<hr><pre id='backuptext'></pre>",html:true,animation:'none',showConfirmButton:false});
-  $.post('/webGui/include/Download.php',{cmd:'backup',level:level});
+  $.post('/webGui/include/StartCommand.php',{cmd:'flash_backup '+level+' nchan',start:0},function() {
+    swal({title:"_(Boot device backup)_ - <span id='pluginProgressTitle'>_(In Progress)_ <i class='fa fa-refresh fa-spin'></i></span>",text:"<pre id='swaltext'></pre><hr>",html:true,animation:'none',showConfirmButton:true,confirmButtonText:"_(Close)_"},function(){
+      nchan_backup.stop();
+      $('.sweet-alert').hide('fast').removeClass('nchan');
+    });
+    $('.sweet-alert').addClass('nchan');
+    $('button.confirm').prop('disabled',true);
+  });
 }
 </script>
 _(Active GUID)_:
@@ -110,6 +108,6 @@ _(Compression level)_:
 
 &nbsp;
 : <span class="inline-block">
-    <input type="button" class="backup-btn" value="_(Boot device backup)_" onclick="backup()">
+    <input type="button" value="_(Boot device backup)_" onclick="backup()">
     <input type="button" value="_(Done)_" onclick="done()">
   </span>

--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -37,9 +37,10 @@ nchan_backup.on('message', function(data) {
   var i = data.indexOf(':');
   if (i < 0 || data.slice(0,i) !== fbRun) return; // stale or other run
   var msg = data.slice(i+1);
-  if (msg.startsWith('_SAVED_')) {           // save mode finished - show the path
+  if (msg.startsWith('_SAVED_')) {           // save mode finished - show path + download
     setBackupProgress(100);
-    $('#fbMsg').html("_(Saved to)_: <code>"+msg.substring(7)+"</code>");
+    var p = msg.substring(7), name = p.substring(p.lastIndexOf('/')+1);
+    $('#fbMsg').html("_(Saved to)_: <code>"+p+"</code><br><a href='/"+encodeURIComponent(name)+"' style='display:inline-block;margin-top:10px'><i class='fa fa-download'></i> _(Download)_</a>");
     $('button.confirm').prop('disabled',false);
   } else if (msg.startsWith('_ERROR_')) {
     $('#fbFrame').remove();

--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -16,36 +16,55 @@ Tag="usb"
 ?>
 <?$tpmEnabled = !empty($var['flashGUID']) && strpos($var['flashGUID'], '01-') !== 0 && !empty($var['tpmGUID']) ? true : false;?>
 <script>
-function cleanUp(zip) {
+var backupFile = "";
+var nchan_backup = new NchanSubscriber('/sub/flash_backup',{subscriber:'websocket'});
+
+nchan_backup.on('message', function(data) {
+  if (data == '_DONE_') {
+    nchan_backup.stop();
+    resetBackupButton();
+    if (backupFile) {
+      // archive ready: trigger the browser download then clean up afterwards
+      swal.close();
+      location = '/'+backupFile;
+      setTimeout(cleanUp,6000);
+    }
+  } else if (data.startsWith('_FILE_')) {
+    backupFile = data.substring(6);
+  } else if (data.startsWith('_ERROR_')) {
+    nchan_backup.stop();
+    resetBackupButton();
+    swal({title:"_(Creation error)_",text:data.substring(7),type:'error',html:true,confirmButtonText:"_(Ok)_"});
+  } else if (data) {
+    var box = $('pre#backuptext');
+    box.html(box.html()+'<br>'+data).scrollTop(box[0].scrollHeight);
+  }
+});
+
+function resetBackupButton() {
+  $('input.backup-btn').val("_(Boot device backup)_").prop('disabled',false);
+  $('#backupLevel').prop('disabled',false);
+}
+
+function cleanUp() {
   if (document.hasFocus()) {
-    $('input[value="_(Creating boot device backup)_..."]').val("_(Boot device backup)_").prop('disabled',false);
-    $('div.spinner').hide('slow');
-    $('#pleaseWait').hide('slow');
-    $.post('/webGui/include/Download.php',{cmd:'unlink',file:zip});
+    $.post('/webGui/include/Download.php',{cmd:'unlink',file:backupFile});
+    backupFile = "";
   } else {
-    setTimeout(function(){cleanUp(zip);},2000);
+    setTimeout(cleanUp,2000);
   }
 }
+
 function backup() {
-  $('input[value="_(Boot device backup)_"]').val('_(Creating boot device backup)_...').prop('disabled',true);
-  $('div.spinner').show('slow');
-  $('#pleaseWait').show('slow');
-  $.post('/webGui/include/Download.php',{cmd:'backup'},function(zip) {
-    if (zip) {
-      location = '/'+zip;
-      setTimeout(function(){cleanUp(zip);},6000);
-    } else {
-      var $btn = $('input[value="_(Creating boot device backup)_..."]');
-      $btn.val("_(Boot device backup)_").prop('disabled',false);
-      $('div.spinner').hide('slow');
-      $('#pleaseWait').hide('slow');
-      swal({title:"_(Creation error)_",text:"_(Insufficient free disk space available)_",type:'error',html:true,confirmButtonText:"_(Ok)_"});
-    }
-  });
+  backupFile = "";
+  $('input.backup-btn').val('_(Creating boot device backup)_...').prop('disabled',true);
+  $('#backupLevel').prop('disabled',true);
+  var level = $('#backupLevel').val();
+  nchan_backup.start();
+  swal({title:"_(Creating boot device backup)_...",text:"<hr><pre id='backuptext'></pre>",html:true,animation:'none',showConfirmButton:false});
+  $.post('/webGui/include/Download.php',{cmd:'backup',level:level});
 }
 </script>
-<div id="pleaseWait" style="display:none;text-align:center;margin-bottom:24px"><span class="red-text strong">_(Please wait)_... _(creating boot device backup zip file (this may take several minutes))_</span></div>
-
 _(Active GUID)_:
 : <?if (!empty($var['flashGUID'])):?>
     <?=htmlspecialchars($var['flashGUID'], ENT_QUOTES, 'UTF-8');?>
@@ -81,8 +100,16 @@ _(TPM GUID)_:
 
 :flash_backup_help:
 
+_(Compression level)_:
+: <select id="backupLevel">
+    <option value="0">_(None - fastest)_</option>
+    <option value="1">_(Low)_</option>
+    <option value="6" selected>_(Normal)_</option>
+    <option value="9">_(Maximum - smallest)_</option>
+  </select>
+
 &nbsp;
 : <span class="inline-block">
-    <input type="button" value="_(Boot device backup)_" onclick="backup()">
+    <input type="button" class="backup-btn" value="_(Boot device backup)_" onclick="backup()">
     <input type="button" value="_(Done)_" onclick="done()">
   </span>

--- a/emhttp/plugins/dynamix/BootInfo.page
+++ b/emhttp/plugins/dynamix/BootInfo.page
@@ -39,8 +39,10 @@ nchan_backup.on('message', function(data) {
   var msg = data.slice(i+1);
   if (msg.startsWith('_SAVED_')) {           // save mode finished - show path + download
     setBackupProgress(100);
-    var p = msg.substring(7), name = p.substring(p.lastIndexOf('/')+1);
-    $('#fbMsg').html("_(Saved to)_: <code>"+p+"</code><br><a href='/webGui/include/FlashBackup.php?serve="+encodeURIComponent(name)+"' style='display:inline-block;margin-top:10px'><i class='fa fa-download'></i> _(Download)_</a>");
+    var p = msg.substring(7), name = p.substring(p.lastIndexOf('/')+1), dir = p.substring(0,p.lastIndexOf('/'));
+    $('#fbMsg').html("_(Saved to)_: <code>"+p+"</code><br><span style='display:inline-block;margin-top:10px'>"
+      +"<a href='/webGui/include/FlashBackup.php?serve="+encodeURIComponent(name)+"'><i class='fa fa-download'></i> _(Download)_</a>"
+      +" &nbsp;&middot;&nbsp; <a href='/Main/Browse?dir="+encodeURIComponent(dir)+"'><i class='fa fa-folder-open'></i> _(File Manager)_</a></span>");
     $('button.confirm').prop('disabled',false);
   } else if (msg.startsWith('_ERROR_')) {
     $('#fbFrame').remove();
@@ -136,3 +138,28 @@ _(Compression level)_:
     <input type="button" value="_(Boot device backup)_" onclick="backup()">
     <input type="button" value="_(Done)_" onclick="done()">
   </span>
+
+<?
+// List boot backups already saved on the server (save-to-server mode keeps them
+// on a pool/array/boot mount). Show where each lives, with download + file
+// manager links, so they are discoverable later and easy to clean up.
+$fb_saved = [];
+foreach (array_merge(glob("/mnt/*/*-boot-backup-*.zip"), glob("/mnt/user/*/*-boot-backup-*.zip"), glob("/boot/*-boot-backup-*.zip")) as $fb_f) {
+  $fb_r = realpath($fb_f);
+  if ($fb_r && is_file($fb_r)) $fb_saved[$fb_r] = filesize($fb_r);
+}
+krsort($fb_saved);
+?>
+<?if ($fb_saved):?>
+_(Saved backups on this server)_:
+: <div class="inline-block">
+  <?foreach ($fb_saved as $fb_path => $fb_size): $fb_bn = basename($fb_path); $fb_dir = dirname($fb_path);?>
+    <div style="margin-bottom:4px">
+      <code><?=htmlspecialchars($fb_path, ENT_QUOTES, 'UTF-8')?></code>
+      (<?=number_format($fb_size/1073741824, 2)?> GB)
+      &nbsp;<a href="/webGui/include/FlashBackup.php?serve=<?=urlencode($fb_bn)?>"><i class="fa fa-download"></i> _(Download)_</a>
+      &nbsp;<a href="/Main/Browse?dir=<?=urlencode($fb_dir)?>"><i class="fa fa-folder-open"></i> _(File Manager)_</a>
+    </div>
+  <?endforeach;?>
+  </div>
+<?endif;?>

--- a/emhttp/plugins/dynamix/include/Download.php
+++ b/emhttp/plugins/dynamix/include/Download.php
@@ -49,12 +49,5 @@ case 'unlink':
   if ($backup = readlink("$docroot/$file")) unlink($backup);
   @unlink("$docroot/$file");
   break;
-case 'backup':
-  // Run the flash backup detached; progress is streamed over the
-  // 'flash_backup' nchan channel and the GUI triggers the download on _DONE_.
-  $level = isset($_POST['level']) && is_numeric($_POST['level']) ? (int)$_POST['level'] : 6;
-  $level = max(0, min(9, $level));
-  exec("nohup $docroot/webGui/scripts/flash_backup $level 1>/dev/null 2>&1 &");
-  break;
 }
 ?>

--- a/emhttp/plugins/dynamix/include/Download.php
+++ b/emhttp/plugins/dynamix/include/Download.php
@@ -50,7 +50,11 @@ case 'unlink':
   @unlink("$docroot/$file");
   break;
 case 'backup':
-  echo exec("$docroot/webGui/scripts/flash_backup");
+  // Run the flash backup detached; progress is streamed over the
+  // 'flash_backup' nchan channel and the GUI triggers the download on _DONE_.
+  $level = isset($_POST['level']) && is_numeric($_POST['level']) ? (int)$_POST['level'] : 6;
+  $level = max(0, min(9, $level));
+  exec("nohup $docroot/webGui/scripts/flash_backup $level 1>/dev/null 2>&1 &");
   break;
 }
 ?>

--- a/emhttp/plugins/dynamix/include/FlashBackup.php
+++ b/emhttp/plugins/dynamix/include/FlashBackup.php
@@ -11,29 +11,22 @@
  */
 ?>
 <?
-/* Stream a boot-device (flash) backup straight to the browser as it is built,
- * so nothing is ever staged on disk or in RAM. The zip is produced by
- * webGui/scripts/flash_backup (writing to stdout); we pipe it to the client and,
- * as bytes flow, publish a percentage to the 'flash_backup' nchan channel so the
- * GUI can show a real progress bar. The percentage is bytes-sent over the total
- * flash size reported by `flash_backup size` (the boot device is mostly already-
- * compressed OS files, so output closely tracks input - the bar is accurate in
- * practice and we cap it at 99% until the stream actually finishes).
+/* Boot-device (flash) backup download endpoint.
  *
- * Query params:
- *   level   zip compression level 0..9 (default 6)
- *   run     opaque per-run token; progress is published as "<run>:<pct>" so the
- *           GUI can ignore stale messages left in the channel by a previous run
+ *   ?level=0..9   stream a freshly-built zip of the boot device straight to the
+ *                 browser as it is built (nothing staged on disk/RAM). The
+ *                 browser's own download indicator shows progress.
+ *   ?serve=<name> stream an already-saved backup file (the save-to-server
+ *                 Download button / notification link). Strictly validated.
+ *
+ * `X-Accel-Buffering: no` tells nginx to stream the response instead of spooling
+ * it to a temp file. nginx requires a logged-in session to reach this endpoint.
  */
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
-require_once "$docroot/webGui/include/publish.php";
 
-// "serve" mode: stream an already-saved backup for download (the save-to-server
-// Download button / notification link). Strictly validated - only a file whose
-// name matches the flash-backup pattern AND that resolves onto a pool/array/boot
-// mount - so it can't be coerced into an arbitrary file read. nginx already
-// requires a logged-in session to reach this endpoint at all; this avoids
-// leaving a persistent symlink to the full-flash backup in the web root.
+// "serve" mode: stream an already-saved backup. Strictly validated - only a file
+// whose name matches the flash-backup pattern AND that resolves onto a
+// pool/array/boot mount - so it can't be coerced into an arbitrary file read.
 if (isset($_GET['serve'])) {
   $name = basename($_GET['serve']);
   if (!preg_match('/-boot-backup-[0-9-]+\.zip$/', $name)) { http_response_code(404); exit; }
@@ -54,47 +47,22 @@ if (isset($_GET['serve'])) {
   exit;
 }
 
-$channel = 'flash_backup';
-$script = "$docroot/webGui/scripts/flash_backup";
-
+// Stream a freshly-built backup. Named server-version-date.zip.
 $var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
 $level = isset($_GET['level']) && is_numeric($_GET['level']) ? max(0, min(9, (int)$_GET['level'])) : 6;
-$run = preg_replace('/\D/', '', $_GET['run'] ?? '');
-
 $server = isset($var['NAME']) ? str_replace(' ', '_', strtolower($var['NAME'])) : 'tower';
 $osVersion = $var['version'] ?? 'unknown';
 $name = "$server-v$osVersion-boot-backup-".date('Ymd-Hi').".zip";
 
-// Total size of the included set, used as the progress denominator.
-$total = (int)trim(shell_exec(escapeshellarg($script).' size 2>/dev/null'));
-
-// Stream for as long as it takes, and let zip die if the user cancels.
 set_time_limit(0);
-ignore_user_abort(false);
+ignore_user_abort(false); // let zip die (SIGPIPE) if the user cancels the download
 
 header('Content-Type: application/zip');
 header('Content-Disposition: attachment; filename="'.$name.'"');
-header('X-Accel-Buffering: no'); // tell nginx to stream, not spool to a temp file
+header('X-Accel-Buffering: no');
 header('Cache-Control: no-store');
 while (ob_get_level()) ob_end_clean();
 
-$h = popen(escapeshellarg($script).' '.(int)$level.' 2>/dev/null', 'r');
-if ($h) {
-  $sent = 0; $last = 0;
-  while (!feof($h)) {
-    $buf = fread($h, 1 << 18);
-    if ($buf === '' || $buf === false) break;
-    echo $buf;
-    flush();
-    $sent += strlen($buf);
-    $now = microtime(true);
-    if ($total > 0 && $now - $last > 0.4) {
-      publish($channel, $run.':'.min(99, intdiv($sent * 100, $total)), 1, false);
-      $last = $now;
-    }
-  }
-  pclose($h);
-}
-publish($channel, $run.':_DONE_', 1, false);
+passthru(escapeshellarg("$docroot/webGui/scripts/flash_backup").' '.(int)$level.' 2>/dev/null');
 exit;
 ?>

--- a/emhttp/plugins/dynamix/include/FlashBackup.php
+++ b/emhttp/plugins/dynamix/include/FlashBackup.php
@@ -22,6 +22,8 @@
  *
  * Query params:
  *   level   zip compression level 0..9 (default 6)
+ *   run     opaque per-run token; progress is published as "<run>:<pct>" so the
+ *           GUI can ignore stale messages left in the channel by a previous run
  */
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/publish.php";
@@ -31,6 +33,7 @@ $script = "$docroot/webGui/scripts/flash_backup";
 
 $var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
 $level = isset($_GET['level']) && is_numeric($_GET['level']) ? max(0, min(9, (int)$_GET['level'])) : 6;
+$run = preg_replace('/\D/', '', $_GET['run'] ?? '');
 
 $server = isset($var['NAME']) ? str_replace(' ', '_', strtolower($var['NAME'])) : 'tower';
 $osVersion = $var['version'] ?? 'unknown';
@@ -60,12 +63,12 @@ if ($h) {
     $sent += strlen($buf);
     $now = microtime(true);
     if ($total > 0 && $now - $last > 0.4) {
-      publish($channel, (string)min(99, intdiv($sent * 100, $total)), 1, false);
+      publish($channel, $run.':'.min(99, intdiv($sent * 100, $total)), 1, false);
       $last = $now;
     }
   }
   pclose($h);
 }
-publish($channel, '_DONE_', 1, false);
+publish($channel, $run.':_DONE_', 1, false);
 exit;
 ?>

--- a/emhttp/plugins/dynamix/include/FlashBackup.php
+++ b/emhttp/plugins/dynamix/include/FlashBackup.php
@@ -1,0 +1,51 @@
+<?PHP
+/* Copyright 2005-2025, Lime Technology
+ * Copyright 2012-2023, Bergware International.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ */
+?>
+<?
+/* Stream a boot-device (flash) backup straight to the browser as it is built,
+ * so nothing is ever staged on disk or in RAM. The heavy lifting is done by
+ * webGui/scripts/flash_backup, which writes the zip to stdout; we just set the
+ * download headers and pass it through.
+ *
+ * Query params:
+ *   level     zip compression level 0..9 (default 6)
+ *   download  opaque token echoed back as a cookie once the stream starts, so
+ *             the GUI can tell the download began and clear its status spinner.
+ */
+$docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
+
+$var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
+$level = isset($_GET['level']) && is_numeric($_GET['level']) ? max(0, min(9, (int)$_GET['level'])) : 6;
+
+$server = isset($var['NAME']) ? str_replace(' ', '_', strtolower($var['NAME'])) : 'tower';
+$osVersion = $var['version'] ?? 'unknown';
+$name = "$server-v$osVersion-boot-backup-".date('Ymd-Hi').".zip";
+
+// Echo the download token back as a (non-HttpOnly) cookie so the page can detect
+// the download has started. Numeric-only to keep it harmless. Must be set before
+// any body output.
+$token = preg_replace('/\D/', '', $_GET['download'] ?? '');
+if ($token !== '') setcookie('flashBackup', $token, ['path' => '/']);
+
+// Stream for as long as it takes, and stop zip if the user cancels the download.
+set_time_limit(0);
+ignore_user_abort(false);
+
+header('Content-Type: application/zip');
+header('Content-Disposition: attachment; filename="'.$name.'"');
+header('X-Accel-Buffering: no'); // tell nginx to stream, not spool to a temp file
+header('Cache-Control: no-store');
+while (ob_get_level()) ob_end_clean();
+
+passthru(escapeshellarg("$docroot/webGui/scripts/flash_backup")." ".(int)$level);
+exit;
+?>

--- a/emhttp/plugins/dynamix/include/FlashBackup.php
+++ b/emhttp/plugins/dynamix/include/FlashBackup.php
@@ -28,6 +28,32 @@
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/publish.php";
 
+// "serve" mode: stream an already-saved backup for download (the save-to-server
+// Download button / notification link). Strictly validated - only a file whose
+// name matches the flash-backup pattern AND that resolves onto a pool/array/boot
+// mount - so it can't be coerced into an arbitrary file read. nginx already
+// requires a logged-in session to reach this endpoint at all; this avoids
+// leaving a persistent symlink to the full-flash backup in the web root.
+if (isset($_GET['serve'])) {
+  $name = basename($_GET['serve']);
+  if (!preg_match('/-boot-backup-[0-9-]+\.zip$/', $name)) { http_response_code(404); exit; }
+  $found = null;
+  foreach (array_merge(glob("/mnt/*/$name"), glob("/mnt/user/*/$name"), ["/boot/$name"]) as $cand) {
+    $rp = realpath($cand);
+    if ($rp && is_file($rp) && basename($rp) === $name &&
+        (strncmp($rp, '/mnt/', 5) === 0 || strncmp($rp, '/boot/', 6) === 0)) { $found = $rp; break; }
+  }
+  if (!$found) { http_response_code(404); exit; }
+  set_time_limit(0);
+  header('Content-Type: application/zip');
+  header('Content-Disposition: attachment; filename="'.$name.'"');
+  header('Content-Length: '.filesize($found));
+  header('X-Accel-Buffering: no');
+  while (ob_get_level()) ob_end_clean();
+  readfile($found);
+  exit;
+}
+
 $channel = 'flash_backup';
 $script = "$docroot/webGui/scripts/flash_backup";
 

--- a/emhttp/plugins/dynamix/include/FlashBackup.php
+++ b/emhttp/plugins/dynamix/include/FlashBackup.php
@@ -12,16 +12,22 @@
 ?>
 <?
 /* Stream a boot-device (flash) backup straight to the browser as it is built,
- * so nothing is ever staged on disk or in RAM. The heavy lifting is done by
- * webGui/scripts/flash_backup, which writes the zip to stdout; we just set the
- * download headers and pass it through.
+ * so nothing is ever staged on disk or in RAM. The zip is produced by
+ * webGui/scripts/flash_backup (writing to stdout); we pipe it to the client and,
+ * as bytes flow, publish a percentage to the 'flash_backup' nchan channel so the
+ * GUI can show a real progress bar. The percentage is bytes-sent over the total
+ * flash size reported by `flash_backup size` (the boot device is mostly already-
+ * compressed OS files, so output closely tracks input - the bar is accurate in
+ * practice and we cap it at 99% until the stream actually finishes).
  *
  * Query params:
- *   level     zip compression level 0..9 (default 6)
- *   download  opaque token echoed back as a cookie once the stream starts, so
- *             the GUI can tell the download began and clear its status spinner.
+ *   level   zip compression level 0..9 (default 6)
  */
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
+require_once "$docroot/webGui/include/publish.php";
+
+$channel = 'flash_backup';
+$script = "$docroot/webGui/scripts/flash_backup";
 
 $var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
 $level = isset($_GET['level']) && is_numeric($_GET['level']) ? max(0, min(9, (int)$_GET['level'])) : 6;
@@ -30,13 +36,10 @@ $server = isset($var['NAME']) ? str_replace(' ', '_', strtolower($var['NAME'])) 
 $osVersion = $var['version'] ?? 'unknown';
 $name = "$server-v$osVersion-boot-backup-".date('Ymd-Hi').".zip";
 
-// Echo the download token back as a (non-HttpOnly) cookie so the page can detect
-// the download has started. Numeric-only to keep it harmless. Must be set before
-// any body output.
-$token = preg_replace('/\D/', '', $_GET['download'] ?? '');
-if ($token !== '') setcookie('flashBackup', $token, ['path' => '/']);
+// Total size of the included set, used as the progress denominator.
+$total = (int)trim(shell_exec(escapeshellarg($script).' size 2>/dev/null'));
 
-// Stream for as long as it takes, and stop zip if the user cancels the download.
+// Stream for as long as it takes, and let zip die if the user cancels.
 set_time_limit(0);
 ignore_user_abort(false);
 
@@ -46,6 +49,23 @@ header('X-Accel-Buffering: no'); // tell nginx to stream, not spool to a temp fi
 header('Cache-Control: no-store');
 while (ob_get_level()) ob_end_clean();
 
-passthru(escapeshellarg("$docroot/webGui/scripts/flash_backup")." ".(int)$level);
+$h = popen(escapeshellarg($script).' '.(int)$level.' 2>/dev/null', 'r');
+if ($h) {
+  $sent = 0; $last = 0;
+  while (!feof($h)) {
+    $buf = fread($h, 1 << 18);
+    if ($buf === '' || $buf === false) break;
+    echo $buf;
+    flush();
+    $sent += strlen($buf);
+    $now = microtime(true);
+    if ($total > 0 && $now - $last > 0.4) {
+      publish($channel, (string)min(99, intdiv($sent * 100, $total)), 1, false);
+      $last = $now;
+    }
+  }
+  pclose($h);
+}
+publish($channel, '_DONE_', 1, false);
 exit;
 ?>

--- a/emhttp/plugins/dynamix/scripts/flash_backup
+++ b/emhttp/plugins/dynamix/scripts/flash_backup
@@ -14,14 +14,17 @@
 <?
 /* Create a backup zip of the boot device (USB flash).
  *
- * Usage: flash_backup [compression-level]
+ * Usage: flash_backup [compression-level] [nchan]
  *   compression-level  0 (store, fastest) .. 9 (smallest, slowest), default 6
+ *   nchan              trailing marker added by StartCommand.php; ignored here
  *
- * Designed to run detached in the background (see Download.php cmd=backup).
- * Progress is streamed to the 'flash_backup' nchan channel so the GUI can show
- * live status and trigger the download when finished. The work runs under
- * nice/ionice and uses the streaming `zip` binary, so it stays gentle on CPU,
- * disk and RAM even on large flash drives.
+ * Launched as a tracked background job via StartCommand.php (same mechanism as
+ * plugin/docker operations), so it gets a PID, run de-duplication and abort for
+ * free. Progress is streamed to the 'flash_backup' nchan channel using the
+ * standard _DONE_/_ERROR_ sentinels; a _FILE_<name> message tells the GUI which
+ * archive to download. The work runs under nice/ionice and uses the streaming
+ * `zip` binary, so it stays gentle on CPU, disk and RAM even on large flash
+ * drives.
  */
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/Wrappers.php";
@@ -66,8 +69,8 @@ if (!$zip) {
 }
 
 if (!$zip) {
-  write("_ERROR_"._('Insufficient free disk space available'));
-  write('_DONE_');
+  write(_('Insufficient free disk space available'));
+  write('_ERROR_');
   exit(1);
 }
 
@@ -94,8 +97,8 @@ foreach ($items as $i => $entry) {
 
 if (!$ok || !is_file($zip)) {
   @unlink($zip);
-  write("_ERROR_"._('Backup failed'));
-  write('_DONE_');
+  write(_('Backup failed'));
+  write('_ERROR_');
   exit(1);
 }
 

--- a/emhttp/plugins/dynamix/scripts/flash_backup
+++ b/emhttp/plugins/dynamix/scripts/flash_backup
@@ -62,27 +62,30 @@ $backup = "$server-v$osVersion-boot-backup-$mydate.zip";
 write(_('Preparing backup')."...");
 
 // Estimate required space (1.5x current flash usage) and pick a target, in
-// order: a cache/SSD pool first (fast, and writing straight to the pool mount
-// bypasses the slower /mnt/user FUSE layer), then the RAM-backed rootfs, then an
-// array-backed user share. This keeps it fast on typical systems while avoiding
-// holding a large archive in RAM unless nothing else fits.
+// order: the RAM-backed rootfs first, then a cache/SSD pool, then an array
+// share. The archive is a throwaway staging file - built here, downloaded by
+// the browser, then deleted - so RAM is the right home: it is always mounted
+// (works even with the array stopped) and fastest. We only spill to disk when
+// the flash is too large to stage in RAM with comfortable headroom. (Keeping
+// the *process* RAM-light is handled separately by streaming via the zip
+// binary rather than buffering the archive in memory.)
 $used = exec("df /boot|awk 'END{print $3}'") * 1.5;
 $zip = null;
-foreach ($pools as $pool) {
+// 1. RAM-backed rootfs (always available, fastest).
+$free = exec("df /|awk 'END{print $4}'");
+if ($free > $used) $zip = "/$backup";
+// 2. Too big for RAM: a cache/SSD pool, written straight to the pool mount to
+//    bypass the slower /mnt/user FUSE layer. Pools require the array started.
+if (!$zip) foreach ($pools as $pool) {
   if (!is_dir("/mnt/$pool")) continue;
   $free = exec("df ".escapeshellarg("/mnt/$pool")."|awk 'END{print $4}'");
   if ($free > $used) {$zip = "/mnt/$pool/$backup"; break;}
 }
-if (!$zip) {
-  $free = exec("df /|awk 'END{print $4}'");
-  if ($free > $used) $zip = "/$backup";
-}
-if (!$zip) {
-  foreach ($dir as $share) {
-    if (!is_dir("/mnt/user/$share")) continue;
-    $free = exec("df ".escapeshellarg("/mnt/user/$share")."|awk 'END{print $4}'");
-    if ($free > $used) {$zip = "/mnt/user/$share/$backup"; break;}
-  }
+// 3. Last resort: an array-backed user share.
+if (!$zip) foreach ($dir as $share) {
+  if (!is_dir("/mnt/user/$share")) continue;
+  $free = exec("df ".escapeshellarg("/mnt/user/$share")."|awk 'END{print $4}'");
+  if ($free > $used) {$zip = "/mnt/user/$share/$backup"; break;}
 }
 
 if (!$zip) {

--- a/emhttp/plugins/dynamix/scripts/flash_backup
+++ b/emhttp/plugins/dynamix/scripts/flash_backup
@@ -1,6 +1,6 @@
 #!/usr/bin/php -q
 <?PHP
-/* Copyright 2005-2023, Lime Technology
+/* Copyright 2005-2025, Lime Technology
  * Copyright 2012-2023, Bergware International.
  *
  * This program is free software; you can redistribute it and/or
@@ -12,38 +12,96 @@
  */
 ?>
 <?
+/* Create a backup zip of the boot device (USB flash).
+ *
+ * Usage: flash_backup [compression-level]
+ *   compression-level  0 (store, fastest) .. 9 (smallest, slowest), default 6
+ *
+ * Designed to run detached in the background (see Download.php cmd=backup).
+ * Progress is streamed to the 'flash_backup' nchan channel so the GUI can show
+ * live status and trigger the download when finished. The work runs under
+ * nice/ionice and uses the streaming `zip` binary, so it stays gentle on CPU,
+ * disk and RAM even on large flash drives.
+ */
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/Wrappers.php";
+require_once "$docroot/webGui/include/publish.php";
+
+$channel = 'flash_backup';
+
+// Stream a progress line to the GUI over nchan.
+function write(...$messages) {
+  global $channel;
+  foreach ($messages as $message) publish($channel, $message, 1, false);
+}
 
 $var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
 $dir = ['system','appdata','isos','domains'];
 $out = ['prev','previous'];
+
+// Clamp the requested compression level to a valid zip range (default 6).
+$level = isset($argv[1]) && is_numeric($argv[1]) ? (int)$argv[1] : 6;
+$level = max(0, min(9, $level));
 
 $server = isset($var['NAME']) ? str_replace(' ','_',strtolower($var['NAME'])) : 'tower';
 $mydate = date('Ymd-Hi');
 $osVersion = _var($var,'version','_unknown');
 $backup = "$server-v$osVersion-boot-backup-$mydate.zip";
 
+write(_('Preparing backup')."...");
+
+// Estimate required space (1.5x current flash usage) and pick a target.
+// Prefer real disk (array/pool shares) over the RAM-backed rootfs so a large
+// backup does not consume system memory; fall back to / only when no share fits.
 $used = exec("df /boot|awk 'END{print $3}'") * 1.5;
-$free = exec("df /|awk 'END{print $4}'");
-if ($free > $used) $zip = "/$backup"; else {
-  foreach ($dir as $share) {
-    if (!is_dir("/mnt/user/$share")) continue;
-    $free = exec("df /mnt/user/$share|awk 'END{print $4}'");
-    if ($free > $used) {$zip = "/mnt/user/$share/$backup"; break;}
-  }
+$zip = null;
+foreach ($dir as $share) {
+  if (!is_dir("/mnt/user/$share")) continue;
+  $free = exec("df /mnt/user/$share|awk 'END{print $4}'");
+  if ($free > $used) {$zip = "/mnt/user/$share/$backup"; break;}
 }
-if (isset($zip)) {
-  chdir("/boot");
-  foreach (glob("*",GLOB_NOSORT+GLOB_ONLYDIR) as $folder) {
-    if (in_array($folder,$out)) continue;
-    exec("zip -qr ".escapeshellarg($zip)." ".escapeshellarg($folder));
-  }
-  foreach (glob("*",GLOB_NOSORT) as $file) {
-    if (is_dir($file)) continue;
-    exec("zip -q ".escapeshellarg($zip)." ".escapeshellarg($file));
-  }
-  symlink($zip,"$docroot/$backup");
-  echo $backup;
+if (!$zip) {
+  $free = exec("df /|awk 'END{print $4}'");
+  if ($free > $used) $zip = "/$backup";
 }
+
+if (!$zip) {
+  write("_ERROR_"._('Insufficient free disk space available'));
+  write('_DONE_');
+  exit(1);
+}
+
+// Collect top-level entries to archive, skipping previous backups.
+chdir('/boot');
+$items = [];
+foreach (glob("*",GLOB_NOSORT) as $entry) {
+  if (in_array($entry,$out)) continue;
+  $items[] = $entry;
+}
+$total = count($items);
+
+// Run zip with low CPU/IO priority so the backup stays responsive under load.
+$prio = 'nice -n 19 ionice -c3';
+$ok = true;
+foreach ($items as $i => $entry) {
+  $pct = $total ? round(($i/$total)*100) : 0;
+  write(sprintf(_('Compressing %s')." (%d/%d - %d%%)", $entry, $i+1, $total, $pct));
+  $flag = is_dir($entry) ? '-r' : '';
+  exec("$prio zip -$level -q $flag ".escapeshellarg($zip)." ".escapeshellarg($entry)." 2>/dev/null", $o, $rc);
+  // zip rc 12 = "nothing to do"; treat any other non-zero result as a failure.
+  if ($rc !== 0 && $rc !== 12) $ok = false;
+}
+
+if (!$ok || !is_file($zip)) {
+  @unlink($zip);
+  write("_ERROR_"._('Backup failed'));
+  write('_DONE_');
+  exit(1);
+}
+
+// Expose the archive to the browser via a symlink in the webGui docroot.
+symlink($zip,"$docroot/$backup");
+write(_('Backup complete')."...");
+write("_FILE_$backup");
+write('_DONE_');
 ?>

--- a/emhttp/plugins/dynamix/scripts/flash_backup
+++ b/emhttp/plugins/dynamix/scripts/flash_backup
@@ -14,7 +14,8 @@
 <?
 /* Stream a zip backup of the boot device (USB flash) to stdout.
  *
- * Usage: flash_backup [compression-level] > backup.zip
+ * Usage: flash_backup [compression-level] > backup.zip   (stream the archive)
+ *        flash_backup size                                (print total bytes)
  *   compression-level  0 (store, fastest) .. 9 (smallest, slowest), default 6
  *
  * The archive is written straight to stdout so it can be streamed directly to a
@@ -23,8 +24,12 @@
  * no cleanup. zip runs under nice + best-effort-low ionice to stay gentle on
  * CPU and disk. The prior-release dirs (previous/prev) and desktop junk are
  * excluded so the archive stays small.
+ *
+ * The 'size' mode prints the total byte size of the same included set; the
+ * endpoint uses it as the denominator for a download progress bar.
  */
 
+$sizeOnly = isset($argv[1]) && $argv[1] === 'size';
 // Clamp the requested compression level to a valid zip range (default 6).
 $level = isset($argv[1]) && is_numeric($argv[1]) ? max(0, min(9, (int)$argv[1])) : 6;
 
@@ -41,10 +46,16 @@ foreach (glob('*', GLOB_NOSORT) as $entry) {
   $items[] = $entry;
 }
 if (!$items) exit(1);
+$args = implode(' ', array_map('escapeshellarg', $items));
+
+// 'size' mode: print the total apparent byte size of the included set and exit.
+if ($sizeOnly) {
+  echo (int)trim(exec("du -sbc $args 2>/dev/null | awk 'END{print $1}'"));
+  exit(0);
+}
 
 // Stream the archive to stdout. zip writes a valid streamable archive (data
 // descriptors) when its output is not seekable.
-$args = implode(' ', array_map('escapeshellarg', $items));
 passthru("nice -n 19 ionice -c2 -n7 zip -$level -qr - $args 2>/dev/null", $rc);
 exit($rc);
 ?>

--- a/emhttp/plugins/dynamix/scripts/flash_backup
+++ b/emhttp/plugins/dynamix/scripts/flash_backup
@@ -24,7 +24,10 @@
  * standard _DONE_/_ERROR_ sentinels; a _FILE_<name> message tells the GUI which
  * archive to download. The work runs under nice + best-effort-low ionice and
  * uses the streaming `zip` binary, so it stays gentle on CPU, disk and RAM
- * even on large flash drives.
+ * even on large flash drives. The prior-release dirs (previous/prev) and
+ * desktop junk are excluded so the archive stays small. The finished zip is a
+ * throwaway staged in RAM (then pool/array, finally the boot device's own pool)
+ * and is deleted right after the browser downloads it.
  */
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/Wrappers.php";
@@ -48,7 +51,10 @@ $var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
 $disks = (array)@parse_ini_file('/var/local/emhttp/disks.ini', true);
 $pools = pools_filter($disks);
 $dir = ['system','appdata','isos','domains'];
-$out = ['prev','previous'];
+// Top-level entries to exclude from the backup. 'previous'/'prev' hold the
+// entire prior OS release (often >1GB) and must never bloat the archive;
+// the rest is desktop junk created when the flash is mounted on a Mac/PC.
+$out = ['prev','previous','System Volume Information','.Trash-0','.Trashes','.Spotlight-V100','.fseventsd','.TemporaryItems'];
 
 // Clamp the requested compression level to a valid zip range (default 6).
 $level = isset($argv[1]) && is_numeric($argv[1]) ? (int)$argv[1] : 6;
@@ -58,6 +64,16 @@ $server = isset($var['NAME']) ? str_replace(' ','_',strtolower($var['NAME'])) : 
 $mydate = date('Ymd-Hi');
 $osVersion = _var($var,'version','_unknown');
 $backup = "$server-v$osVersion-boot-backup-$mydate.zip";
+
+// Safety net: reap any leftover staging archive from a previous run whose
+// browser-side cleanup never fired (e.g. the tab was closed mid-download), so a
+// stale copy can't linger - especially in RAM. The normal path still deletes
+// the archive right after the download via Download.php cmd=unlink.
+foreach (glob("$docroot/*-boot-backup-*.zip") as $stale) {
+  $target = @readlink($stale);
+  if ($target && is_file($target)) @unlink($target);
+  @unlink($stale);
+}
 
 write(_('Preparing backup')."...");
 
@@ -81,11 +97,22 @@ if (!$zip) foreach ($pools as $pool) {
   $free = exec("df ".escapeshellarg("/mnt/$pool")."|awk 'END{print $4}'");
   if ($free > $used) {$zip = "/mnt/$pool/$backup"; break;}
 }
-// 3. Last resort: an array-backed user share.
+// 3. An array-backed user share.
 if (!$zip) foreach ($dir as $share) {
   if (!is_dir("/mnt/user/$share")) continue;
   $free = exec("df ".escapeshellarg("/mnt/user/$share")."|awk 'END{print $4}'");
   if ($free > $used) {$zip = "/mnt/user/$share/$backup"; break;}
+}
+// 4. Last resort: the boot device's own pool. /boot is always mounted (even with
+//    the array stopped), so this guarantees a target when nothing else is
+//    available. Only used for a real pool filesystem - a FAT/USB flash is not a
+//    pool and could not hold a >4GB archive anyway.
+if (!$zip) {
+  $bootfs = exec("findmnt -no FSTYPE /boot");
+  if (in_array($bootfs, ['zfs','btrfs','xfs'])) {
+    $free = exec("df /boot|awk 'END{print $4}'");
+    if ($free > $used) $zip = "/boot/$backup";
+  }
 }
 
 if (!$zip) {
@@ -94,11 +121,13 @@ if (!$zip) {
   exit(1);
 }
 
-// Collect top-level entries to archive, skipping previous backups.
+// Collect top-level entries to archive, skipping the prior-release/junk dirs
+// above and any earlier flash-backup zip a user may have left on the flash.
 chdir('/boot');
 $items = [];
 foreach (glob("*",GLOB_NOSORT) as $entry) {
   if (in_array($entry,$out)) continue;
+  if (preg_match('/-boot-backup-.*\.zip$/',$entry)) continue;
   $items[] = $entry;
 }
 $total = count($items);

--- a/emhttp/plugins/dynamix/scripts/flash_backup
+++ b/emhttp/plugins/dynamix/scripts/flash_backup
@@ -12,150 +12,39 @@
  */
 ?>
 <?
-/* Create a backup zip of the boot device (USB flash).
+/* Stream a zip backup of the boot device (USB flash) to stdout.
  *
- * Usage: flash_backup [compression-level] [nchan]
+ * Usage: flash_backup [compression-level] > backup.zip
  *   compression-level  0 (store, fastest) .. 9 (smallest, slowest), default 6
- *   nchan              trailing marker added by StartCommand.php; ignored here
  *
- * Launched as a tracked background job via StartCommand.php (same mechanism as
- * plugin/docker operations), so it gets a PID, run de-duplication and abort for
- * free. Progress is streamed to the 'flash_backup' nchan channel using the
- * standard _DONE_/_ERROR_ sentinels; a _FILE_<name> message tells the GUI which
- * archive to download. The work runs under nice + best-effort-low ionice and
- * uses the streaming `zip` binary, so it stays gentle on CPU, disk and RAM
- * even on large flash drives. The prior-release dirs (previous/prev) and
- * desktop junk are excluded so the archive stays small. The finished zip is a
- * throwaway staged in RAM (then pool/array, finally the boot device's own pool)
- * and is deleted right after the browser downloads it.
+ * The archive is written straight to stdout so it can be streamed directly to a
+ * browser (see include/FlashBackup.php) without ever staging a file on disk or
+ * in RAM - this avoids any size limit, works with the array stopped, and needs
+ * no cleanup. zip runs under nice + best-effort-low ionice to stay gentle on
+ * CPU and disk. The prior-release dirs (previous/prev) and desktop junk are
+ * excluded so the archive stays small.
  */
-$docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
-require_once "$docroot/webGui/include/Wrappers.php";
-require_once "$docroot/webGui/include/publish.php";
-require_once "$docroot/webGui/include/Helpers.php"; // pools_filter()
-
-// This runs as a CLI background job (launched via StartCommand.php), where the
-// GUI translation layer is not loaded. Provide a no-op _() fallback like other
-// CLI scripts (e.g. monitor) so progress strings work; they stay in English.
-if (!function_exists('_')) { function _($text) { return $text; } }
-
-$channel = 'flash_backup';
-
-// Stream a progress line to the GUI over nchan.
-function write(...$messages) {
-  global $channel;
-  foreach ($messages as $message) publish($channel, $message, 1, false);
-}
-
-$var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
-$disks = (array)@parse_ini_file('/var/local/emhttp/disks.ini', true);
-$pools = pools_filter($disks);
-$dir = ['system','appdata','isos','domains'];
-// Top-level entries to exclude from the backup. 'previous'/'prev' hold the
-// entire prior OS release (often >1GB) and must never bloat the archive;
-// the rest is desktop junk created when the flash is mounted on a Mac/PC.
-$out = ['prev','previous','System Volume Information','.Trash-0','.Trashes','.Spotlight-V100','.fseventsd','.TemporaryItems'];
 
 // Clamp the requested compression level to a valid zip range (default 6).
-$level = isset($argv[1]) && is_numeric($argv[1]) ? (int)$argv[1] : 6;
-$level = max(0, min(9, $level));
+$level = isset($argv[1]) && is_numeric($argv[1]) ? max(0, min(9, (int)$argv[1])) : 6;
 
-$server = isset($var['NAME']) ? str_replace(' ','_',strtolower($var['NAME'])) : 'tower';
-$mydate = date('Ymd-Hi');
-$osVersion = _var($var,'version','_unknown');
-$backup = "$server-v$osVersion-boot-backup-$mydate.zip";
+// Top-level entries to exclude. 'previous'/'prev' hold the entire prior OS
+// release (often >1GB); the rest is desktop junk created when the flash is
+// mounted on a Mac/PC.
+$out = ['prev','previous','System Volume Information','.Trash-0','.Trashes','.Spotlight-V100','.fseventsd','.TemporaryItems'];
 
-// Safety net: reap any leftover staging archive from a previous run whose
-// browser-side cleanup never fired (e.g. the tab was closed mid-download), so a
-// stale copy can't linger - especially in RAM. The normal path still deletes
-// the archive right after the download via Download.php cmd=unlink.
-foreach (glob("$docroot/*-boot-backup-*.zip") as $stale) {
-  $target = @readlink($stale);
-  if ($target && is_file($target)) @unlink($target);
-  @unlink($stale);
-}
-
-write(_('Preparing backup')."...");
-
-// Estimate required space (1.5x current flash usage) and pick a target, in
-// order: the RAM-backed rootfs first, then a cache/SSD pool, then an array
-// share. The archive is a throwaway staging file - built here, downloaded by
-// the browser, then deleted - so RAM is the right home: it is always mounted
-// (works even with the array stopped) and fastest. We only spill to disk when
-// the flash is too large to stage in RAM with comfortable headroom. (Keeping
-// the *process* RAM-light is handled separately by streaming via the zip
-// binary rather than buffering the archive in memory.)
-$used = exec("df /boot|awk 'END{print $3}'") * 1.5;
-$zip = null;
-// 1. RAM-backed rootfs (always available, fastest).
-$free = exec("df /|awk 'END{print $4}'");
-if ($free > $used) $zip = "/$backup";
-// 2. Too big for RAM: a cache/SSD pool, written straight to the pool mount to
-//    bypass the slower /mnt/user FUSE layer. Pools require the array started.
-if (!$zip) foreach ($pools as $pool) {
-  if (!is_dir("/mnt/$pool")) continue;
-  $free = exec("df ".escapeshellarg("/mnt/$pool")."|awk 'END{print $4}'");
-  if ($free > $used) {$zip = "/mnt/$pool/$backup"; break;}
-}
-// 3. An array-backed user share.
-if (!$zip) foreach ($dir as $share) {
-  if (!is_dir("/mnt/user/$share")) continue;
-  $free = exec("df ".escapeshellarg("/mnt/user/$share")."|awk 'END{print $4}'");
-  if ($free > $used) {$zip = "/mnt/user/$share/$backup"; break;}
-}
-// 4. Last resort: the boot device's own pool. /boot is always mounted (even with
-//    the array stopped), so this guarantees a target when nothing else is
-//    available. Only used for a real pool filesystem - a FAT/USB flash is not a
-//    pool and could not hold a >4GB archive anyway.
-if (!$zip) {
-  $bootfs = exec("findmnt -no FSTYPE /boot");
-  if (in_array($bootfs, ['zfs','btrfs','xfs'])) {
-    $free = exec("df /boot|awk 'END{print $4}'");
-    if ($free > $used) $zip = "/boot/$backup";
-  }
-}
-
-if (!$zip) {
-  write(_('Insufficient free disk space available'));
-  write('_ERROR_');
-  exit(1);
-}
-
-// Collect top-level entries to archive, skipping the prior-release/junk dirs
-// above and any earlier flash-backup zip a user may have left on the flash.
 chdir('/boot');
 $items = [];
-foreach (glob("*",GLOB_NOSORT) as $entry) {
-  if (in_array($entry,$out)) continue;
-  if (preg_match('/-boot-backup-.*\.zip$/',$entry)) continue;
+foreach (glob('*', GLOB_NOSORT) as $entry) {
+  if (in_array($entry, $out)) continue;
+  if (preg_match('/-boot-backup-.*\.zip$/', $entry)) continue; // stray old backups
   $items[] = $entry;
 }
-$total = count($items);
+if (!$items) exit(1);
 
-// Run zip at low CPU/IO priority so the backup stays gentle without being
-// starved: best-effort IO at the lowest priority (not the idle class, which can
-// throttle throughput to a crawl on busy/ZFS systems).
-$prio = 'nice -n 19 ionice -c2 -n7';
-$ok = true;
-foreach ($items as $i => $entry) {
-  $pct = $total ? round(($i/$total)*100) : 0;
-  write(sprintf(_('Compressing %s')." (%d/%d - %d%%)", $entry, $i+1, $total, $pct));
-  $flag = is_dir($entry) ? '-r' : '';
-  exec("$prio zip -$level -q $flag ".escapeshellarg($zip)." ".escapeshellarg($entry)." 2>/dev/null", $o, $rc);
-  // zip rc 12 = "nothing to do"; treat any other non-zero result as a failure.
-  if ($rc !== 0 && $rc !== 12) $ok = false;
-}
-
-if (!$ok || !is_file($zip)) {
-  @unlink($zip);
-  write(_('Backup failed'));
-  write('_ERROR_');
-  exit(1);
-}
-
-// Expose the archive to the browser via a symlink in the webGui docroot.
-symlink($zip,"$docroot/$backup");
-write(_('Backup complete')."...");
-write("_FILE_$backup");
-write('_DONE_');
+// Stream the archive to stdout. zip writes a valid streamable archive (data
+// descriptors) when its output is not seekable.
+$args = implode(' ', array_map('escapeshellarg', $items));
+passthru("nice -n 19 ionice -c2 -n7 zip -$level -qr - $args 2>/dev/null", $rc);
+exit($rc);
 ?>

--- a/emhttp/plugins/dynamix/scripts/flash_backup
+++ b/emhttp/plugins/dynamix/scripts/flash_backup
@@ -22,13 +22,19 @@
  * plugin/docker operations), so it gets a PID, run de-duplication and abort for
  * free. Progress is streamed to the 'flash_backup' nchan channel using the
  * standard _DONE_/_ERROR_ sentinels; a _FILE_<name> message tells the GUI which
- * archive to download. The work runs under nice/ionice and uses the streaming
- * `zip` binary, so it stays gentle on CPU, disk and RAM even on large flash
- * drives.
+ * archive to download. The work runs under nice + best-effort-low ionice and
+ * uses the streaming `zip` binary, so it stays gentle on CPU, disk and RAM
+ * even on large flash drives.
  */
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/Wrappers.php";
 require_once "$docroot/webGui/include/publish.php";
+require_once "$docroot/webGui/include/Helpers.php"; // pools_filter()
+
+// This runs as a CLI background job (launched via StartCommand.php), where the
+// GUI translation layer is not loaded. Provide a no-op _() fallback like other
+// CLI scripts (e.g. monitor) so progress strings work; they stay in English.
+if (!function_exists('_')) { function _($text) { return $text; } }
 
 $channel = 'flash_backup';
 
@@ -39,6 +45,8 @@ function write(...$messages) {
 }
 
 $var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
+$disks = (array)@parse_ini_file('/var/local/emhttp/disks.ini', true);
+$pools = pools_filter($disks);
 $dir = ['system','appdata','isos','domains'];
 $out = ['prev','previous'];
 
@@ -53,19 +61,28 @@ $backup = "$server-v$osVersion-boot-backup-$mydate.zip";
 
 write(_('Preparing backup')."...");
 
-// Estimate required space (1.5x current flash usage) and pick a target.
-// Prefer real disk (array/pool shares) over the RAM-backed rootfs so a large
-// backup does not consume system memory; fall back to / only when no share fits.
+// Estimate required space (1.5x current flash usage) and pick a target, in
+// order: a cache/SSD pool first (fast, and writing straight to the pool mount
+// bypasses the slower /mnt/user FUSE layer), then the RAM-backed rootfs, then an
+// array-backed user share. This keeps it fast on typical systems while avoiding
+// holding a large archive in RAM unless nothing else fits.
 $used = exec("df /boot|awk 'END{print $3}'") * 1.5;
 $zip = null;
-foreach ($dir as $share) {
-  if (!is_dir("/mnt/user/$share")) continue;
-  $free = exec("df /mnt/user/$share|awk 'END{print $4}'");
-  if ($free > $used) {$zip = "/mnt/user/$share/$backup"; break;}
+foreach ($pools as $pool) {
+  if (!is_dir("/mnt/$pool")) continue;
+  $free = exec("df ".escapeshellarg("/mnt/$pool")."|awk 'END{print $4}'");
+  if ($free > $used) {$zip = "/mnt/$pool/$backup"; break;}
 }
 if (!$zip) {
   $free = exec("df /|awk 'END{print $4}'");
   if ($free > $used) $zip = "/$backup";
+}
+if (!$zip) {
+  foreach ($dir as $share) {
+    if (!is_dir("/mnt/user/$share")) continue;
+    $free = exec("df ".escapeshellarg("/mnt/user/$share")."|awk 'END{print $4}'");
+    if ($free > $used) {$zip = "/mnt/user/$share/$backup"; break;}
+  }
 }
 
 if (!$zip) {
@@ -83,8 +100,10 @@ foreach (glob("*",GLOB_NOSORT) as $entry) {
 }
 $total = count($items);
 
-// Run zip with low CPU/IO priority so the backup stays responsive under load.
-$prio = 'nice -n 19 ionice -c3';
+// Run zip at low CPU/IO priority so the backup stays gentle without being
+// starved: best-effort IO at the lowest priority (not the idle class, which can
+// throttle throughput to a crawl on busy/ZFS systems).
+$prio = 'nice -n 19 ionice -c2 -n7';
 $ok = true;
 foreach ($items as $i => $entry) {
   $pct = $total ? round(($i/$total)*100) : 0;

--- a/emhttp/plugins/dynamix/scripts/flash_backup_save
+++ b/emhttp/plugins/dynamix/scripts/flash_backup_save
@@ -14,8 +14,10 @@
 <?
 /* Save a zip backup of the boot device to a persistent location on the server.
  *
- * Usage: flash_backup_save [compression-level]
+ * Usage: flash_backup_save [compression-level] [run-token]
  *   compression-level  0 (store, fastest) .. 9 (smallest, slowest), default 6
+ *   run-token          opaque token echoed as a "<token>:" prefix on every
+ *                      published message, so the GUI can ignore stale ones
  *
  * This is the "save to server" counterpart of the streaming download
  * (include/FlashBackup.php). It is launched as a tracked background job via
@@ -36,7 +38,10 @@ require_once "$docroot/webGui/include/Helpers.php"; // pools_filter()
 if (!function_exists('_')) { function _($text) { return $text; } }
 
 $channel = 'flash_backup';
-function pub($message) { global $channel; publish($channel, $message, 1, false); }
+// Per-run token (see usage); prefixed onto every message so the GUI ignores
+// stale messages left in the channel by a previous run.
+$run = isset($argv[2]) ? preg_replace('/\D/', '', $argv[2]) : '';
+function pub($message) { global $channel, $run; publish($channel, "$run:$message", 1, false); }
 
 $var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
 $disks = (array)@parse_ini_file('/var/local/emhttp/disks.ini', true);

--- a/emhttp/plugins/dynamix/scripts/flash_backup_save
+++ b/emhttp/plugins/dynamix/scripts/flash_backup_save
@@ -20,13 +20,15 @@
  *                      published message, so the GUI can ignore stale ones
  *
  * This is the "save to server" counterpart of the streaming download
- * (include/FlashBackup.php). It is launched as a tracked background job via
- * StartCommand.php and writes the archive to a real disk target - a cache/SSD
- * pool, then an array share, then the boot device's own pool - and KEEPS it
- * (no RAM target: a saved backup must survive a reboot). Progress is published
- * as a percentage to the 'flash_backup' nchan channel; on completion it
- * publishes _SAVED_<path> then _DONE_, or _ERROR_<message> on failure. The
- * prior-release dirs (previous/prev) and desktop junk are excluded.
+ * (include/FlashBackup.php). Launched as a tracked background job via
+ * StartCommand.php, it runs to completion even if the browser navigates away.
+ * It pipes the single-pass streaming archive (scripts/flash_backup) into a file
+ * on a real disk target - a cache/SSD pool, then an array share, then the boot
+ * device's own pool - and KEEPS it (no RAM target: a saved backup must survive a
+ * reboot). Progress is published as a percentage to the 'flash_backup' nchan
+ * channel; on completion it raises an Unraid notification (with a click-to-
+ * download link), exposes the file for download, and publishes _SAVED_<path>
+ * then _DONE_ (or _ERROR_<message> on failure).
  */
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/Wrappers.php";
@@ -47,13 +49,13 @@ $var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
 $disks = (array)@parse_ini_file('/var/local/emhttp/disks.ini', true);
 $pools = pools_filter($disks);
 $dir = ['system','appdata','isos','domains'];
-$out = ['prev','previous','System Volume Information','.Trash-0','.Trashes','.Spotlight-V100','.fseventsd','.TemporaryItems'];
 
 $level = isset($argv[1]) && is_numeric($argv[1]) ? max(0, min(9, (int)$argv[1])) : 6;
 
 $server = isset($var['NAME']) ? str_replace(' ','_',strtolower($var['NAME'])) : 'tower';
 $osVersion = _var($var,'version','_unknown');
 $backup = "$server-v$osVersion-boot-backup-".date('Ymd-Hi').".zip";
+$script = "$docroot/webGui/scripts/flash_backup";
 
 // Required space (1.5x flash usage). Persistent disk target only, in order:
 // cache/SSD pool (written straight to the pool mount, bypassing the slower
@@ -82,33 +84,41 @@ if (!$zip) {
   exit(1);
 }
 
-// Collect top-level entries to archive, skipping prior-release/junk dirs and any
-// earlier flash-backup zip left on the flash.
-chdir('/boot');
-$items = [];
-foreach (glob('*',GLOB_NOSORT) as $entry) {
-  if (in_array($entry,$out)) continue;
-  if (preg_match('/-boot-backup-.*\.zip$/',$entry)) continue;
-  $items[] = $entry;
-}
-$total = count($items);
+// Total uncompressed size, used as the progress denominator.
+$total = (int)trim(shell_exec(escapeshellarg($script).' size 2>/dev/null'));
 
-// zip each entry into the archive at low CPU/IO priority, publishing a
-// percentage after each item completes.
-$prio = 'nice -n 19 ionice -c2 -n7';
-$ok = true;
-foreach ($items as $i => $entry) {
-  $flag = is_dir($entry) ? '-r' : '';
-  exec("$prio zip -$level -q $flag ".escapeshellarg($zip)." ".escapeshellarg($entry)." 2>/dev/null", $o, $rc);
-  if ($rc !== 0 && $rc !== 12) $ok = false; // rc 12 = "nothing to do"
-  pub((string)($total ? (int)round((($i+1)/$total)*100) : 100));
+// Pipe the single-pass streaming archive straight into the destination file -
+// one zip invocation is far faster than appending each item to a growing
+// archive - publishing a percentage as the bytes are written.
+$h = popen(escapeshellarg($script).' '.$level.' 2>/dev/null', 'r');
+$f = @fopen($zip, 'w');
+if (!$h || !$f) { if ($h) pclose($h); if ($f) fclose($f); @unlink($zip); pub('_ERROR_'._('Backup failed')); exit(1); }
+$sent = 0; $last = 0;
+while (!feof($h)) {
+  $buf = fread($h, 1 << 18);
+  if ($buf === '' || $buf === false) break;
+  fwrite($f, $buf);
+  $sent += strlen($buf);
+  $now = microtime(true);
+  if ($total > 0 && $now - $last > 0.4) { pub((string)min(99, intdiv($sent * 100, $total))); $last = $now; }
 }
+$rc = pclose($h);
+fclose($f);
 
-if (!$ok || !is_file($zip)) {
+if ($rc !== 0 || !is_file($zip) || filesize($zip) === 0) {
   @unlink($zip);
   pub('_ERROR_'._('Backup failed'));
   exit(1);
 }
+
+// Expose the saved file for download via a symlink in the webGui docroot, and
+// raise an Unraid notification (the tray bell) whose link downloads it.
+$name = basename($zip);
+@symlink($zip, "$docroot/$name");
+exec($docroot."/webGui/scripts/notify -e ".escapeshellarg(_('Flash backup'))
+  ." -s ".escapeshellarg(_('Boot device backup complete'))
+  ." -d ".escapeshellarg(sprintf(_('Saved to %s'), $zip))
+  ." -i normal -l ".escapeshellarg("/$name"));
 
 pub('_SAVED_'.$zip);
 pub('_DONE_');

--- a/emhttp/plugins/dynamix/scripts/flash_backup_save
+++ b/emhttp/plugins/dynamix/scripts/flash_backup_save
@@ -111,14 +111,15 @@ if ($rc !== 0 || !is_file($zip) || filesize($zip) === 0) {
   exit(1);
 }
 
-// Expose the saved file for download via a symlink in the webGui docroot, and
-// raise an Unraid notification (the tray bell) whose link downloads it.
+// Raise an Unraid notification (the tray bell). The download link points to the
+// authenticated, path-validated serve endpoint - NOT a symlink to the full-flash
+// backup in the web root (it would sit at a predictable, session-reachable path
+// for the whole uptime).
 $name = basename($zip);
-@symlink($zip, "$docroot/$name");
 exec($docroot."/webGui/scripts/notify -e ".escapeshellarg(_('Flash backup'))
   ." -s ".escapeshellarg(_('Boot device backup complete'))
   ." -d ".escapeshellarg(sprintf(_('Saved to %s'), $zip))
-  ." -i normal -l ".escapeshellarg("/$name"));
+  ." -i normal -l ".escapeshellarg("/webGui/include/FlashBackup.php?serve=$name"));
 
 pub('_SAVED_'.$zip);
 pub('_DONE_');

--- a/emhttp/plugins/dynamix/scripts/flash_backup_save
+++ b/emhttp/plugins/dynamix/scripts/flash_backup_save
@@ -14,21 +14,23 @@
 <?
 /* Save a zip backup of the boot device to a persistent location on the server.
  *
- * Usage: flash_backup_save [compression-level] [run-token]
+ * Usage: flash_backup_save [compression-level] [nchan]
  *   compression-level  0 (store, fastest) .. 9 (smallest, slowest), default 6
- *   run-token          opaque token echoed as a "<token>:" prefix on every
- *                      published message, so the GUI can ignore stale ones
+ *   nchan              trailing marker added by openPlugin()/the task queue; ignored
  *
  * This is the "save to server" counterpart of the streaming download
- * (include/FlashBackup.php). Launched as a tracked background job via
- * StartCommand.php, it runs to completion even if the browser navigates away.
- * It pipes the single-pass streaming archive (scripts/flash_backup) into a file
- * on a real disk target - a cache/SSD pool, then an array share, then the boot
- * device's own pool - and KEEPS it (no RAM target: a saved backup must survive a
- * reboot). Progress is published as a percentage to the 'flash_backup' nchan
- * channel; on completion it raises an Unraid notification (with a click-to-
- * download link), exposes the file for download, and publishes _SAVED_<path>
- * then _DONE_ (or _ERROR_<message> on failure).
+ * (include/FlashBackup.php). It is launched as a tracked background job via
+ * openPlugin() -> the task tray (TaskQueue) so it shows in the tray, opens the
+ * standard progress modal, and keeps running when the modal is closed. It pipes
+ * the single-pass streaming archive (scripts/flash_backup) into a file on a real
+ * disk target - cache/SSD pool, then array share, then the boot device's own
+ * pool - and KEEPS it (no RAM target: a saved backup must survive a reboot).
+ *
+ * Progress is published to the standard 'plugins' task channel as text lines (a
+ * trailing \r updates the current line in place); it ends with _DONE_ or _ERROR_
+ * and exits 0/non-zero so the task is marked done/error. On success it also
+ * raises an Unraid notification whose link downloads the saved file via the
+ * authenticated serve endpoint, and the Boot Device page lists saved backups.
  */
 $docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
 require_once "$docroot/webGui/include/Wrappers.php";
@@ -39,11 +41,11 @@ require_once "$docroot/webGui/include/Helpers.php"; // pools_filter()
 // no-op _() fallback like other CLI scripts. Strings stay in English.
 if (!function_exists('_')) { function _($text) { return $text; } }
 
-$channel = 'flash_backup';
-// Per-run token (see usage); prefixed onto every message so the GUI ignores
-// stale messages left in the channel by a previous run.
-$run = isset($argv[2]) ? preg_replace('/\D/', '', $argv[2]) : '';
-function pub($message) { global $channel, $run; publish($channel, "$run:$message", 1, false); }
+// Publish to the standard task channel ('plugins') so the task tray's modal
+// shows live progress. A trailing \r updates the current line; \n starts a new
+// one (see renderMessage). NCHAN_TASK also captures these to the task log.
+$channel = 'plugins';
+function pub($message) { global $channel; publish($channel, $message, 1, false); }
 
 $var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
 $disks = (array)@parse_ini_file('/var/local/emhttp/disks.ini', true);
@@ -56,6 +58,8 @@ $server = isset($var['NAME']) ? str_replace(' ','_',strtolower($var['NAME'])) : 
 $osVersion = _var($var,'version','_unknown');
 $backup = "$server-v$osVersion-boot-backup-".date('Ymd-Hi').".zip";
 $script = "$docroot/webGui/scripts/flash_backup";
+
+pub(_('Preparing backup')."...\n");
 
 // Required space (1.5x flash usage). Persistent disk target only, in order:
 // cache/SSD pool (written straight to the pool mount, bypassing the slower
@@ -80,7 +84,8 @@ if (!$zip) {
   }
 }
 if (!$zip) {
-  pub('_ERROR_'._('No destination with enough free space (is the array started?)'));
+  pub(_('No destination with enough free space (is the array started?)')."\n");
+  pub('_ERROR_');
   exit(1);
 }
 
@@ -88,11 +93,11 @@ if (!$zip) {
 $total = (int)trim(shell_exec(escapeshellarg($script).' size 2>/dev/null'));
 
 // Pipe the single-pass streaming archive straight into the destination file -
-// one zip invocation is far faster than appending each item to a growing
-// archive - publishing a percentage as the bytes are written.
+// one zip invocation is far faster than appending each item to a growing archive
+// - updating a single progress line in place (\r) as the bytes are written.
 $h = popen(escapeshellarg($script).' '.$level.' 2>/dev/null', 'r');
 $f = @fopen($zip, 'w');
-if (!$h || !$f) { if ($h) pclose($h); if ($f) fclose($f); @unlink($zip); pub('_ERROR_'._('Backup failed')); exit(1); }
+if (!$h || !$f) { if ($h) pclose($h); if ($f) fclose($f); @unlink($zip); pub(_('Backup failed')."\n"); pub('_ERROR_'); exit(1); }
 $sent = 0; $last = 0;
 while (!feof($h)) {
   $buf = fread($h, 1 << 18);
@@ -100,27 +105,31 @@ while (!feof($h)) {
   fwrite($f, $buf);
   $sent += strlen($buf);
   $now = microtime(true);
-  if ($total > 0 && $now - $last > 0.4) { pub((string)min(99, intdiv($sent * 100, $total))); $last = $now; }
+  if ($total > 0 && $now - $last > 0.4) {
+    pub(sprintf(_('Saving boot device backup to %s')." ... %d%%\r", $zip, min(99, intdiv($sent * 100, $total))));
+    $last = $now;
+  }
 }
 $rc = pclose($h);
 fclose($f);
 
 if ($rc !== 0 || !is_file($zip) || filesize($zip) === 0) {
   @unlink($zip);
-  pub('_ERROR_'._('Backup failed'));
+  pub(_('Backup failed')."\n");
+  pub('_ERROR_');
   exit(1);
 }
 
 // Raise an Unraid notification (the tray bell). The download link points to the
 // authenticated, path-validated serve endpoint - NOT a symlink to the full-flash
-// backup in the web root (it would sit at a predictable, session-reachable path
-// for the whole uptime).
+// backup in the web root.
 $name = basename($zip);
 exec($docroot."/webGui/scripts/notify -e ".escapeshellarg(_('Flash backup'))
   ." -s ".escapeshellarg(_('Boot device backup complete'))
   ." -d ".escapeshellarg(sprintf(_('Saved to %s'), $zip))
   ." -i normal -l ".escapeshellarg("/webGui/include/FlashBackup.php?serve=$name"));
 
-pub('_SAVED_'.$zip);
+pub(sprintf(_('Saved to %s'), $zip)."\n");
 pub('_DONE_');
+exit(0);
 ?>

--- a/emhttp/plugins/dynamix/scripts/flash_backup_save
+++ b/emhttp/plugins/dynamix/scripts/flash_backup_save
@@ -1,0 +1,110 @@
+#!/usr/bin/php -q
+<?PHP
+/* Copyright 2005-2025, Lime Technology
+ * Copyright 2012-2023, Bergware International.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ */
+?>
+<?
+/* Save a zip backup of the boot device to a persistent location on the server.
+ *
+ * Usage: flash_backup_save [compression-level]
+ *   compression-level  0 (store, fastest) .. 9 (smallest, slowest), default 6
+ *
+ * This is the "save to server" counterpart of the streaming download
+ * (include/FlashBackup.php). It is launched as a tracked background job via
+ * StartCommand.php and writes the archive to a real disk target - a cache/SSD
+ * pool, then an array share, then the boot device's own pool - and KEEPS it
+ * (no RAM target: a saved backup must survive a reboot). Progress is published
+ * as a percentage to the 'flash_backup' nchan channel; on completion it
+ * publishes _SAVED_<path> then _DONE_, or _ERROR_<message> on failure. The
+ * prior-release dirs (previous/prev) and desktop junk are excluded.
+ */
+$docroot ??= ($_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp');
+require_once "$docroot/webGui/include/Wrappers.php";
+require_once "$docroot/webGui/include/publish.php";
+require_once "$docroot/webGui/include/Helpers.php"; // pools_filter()
+
+// CLI background job: the GUI translation layer is not loaded, so provide a
+// no-op _() fallback like other CLI scripts. Strings stay in English.
+if (!function_exists('_')) { function _($text) { return $text; } }
+
+$channel = 'flash_backup';
+function pub($message) { global $channel; publish($channel, $message, 1, false); }
+
+$var = (array)@parse_ini_file('/var/local/emhttp/var.ini');
+$disks = (array)@parse_ini_file('/var/local/emhttp/disks.ini', true);
+$pools = pools_filter($disks);
+$dir = ['system','appdata','isos','domains'];
+$out = ['prev','previous','System Volume Information','.Trash-0','.Trashes','.Spotlight-V100','.fseventsd','.TemporaryItems'];
+
+$level = isset($argv[1]) && is_numeric($argv[1]) ? max(0, min(9, (int)$argv[1])) : 6;
+
+$server = isset($var['NAME']) ? str_replace(' ','_',strtolower($var['NAME'])) : 'tower';
+$osVersion = _var($var,'version','_unknown');
+$backup = "$server-v$osVersion-boot-backup-".date('Ymd-Hi').".zip";
+
+// Required space (1.5x flash usage). Persistent disk target only, in order:
+// cache/SSD pool (written straight to the pool mount, bypassing the slower
+// /mnt/user FUSE layer) -> array share -> the boot device's own pool.
+$used = exec("df /boot|awk 'END{print $3}'") * 1.5;
+$zip = null;
+foreach ($pools as $pool) {
+  if (!is_dir("/mnt/$pool")) continue;
+  $free = exec("df ".escapeshellarg("/mnt/$pool")."|awk 'END{print $4}'");
+  if ($free > $used) {$zip = "/mnt/$pool/$backup"; break;}
+}
+if (!$zip) foreach ($dir as $share) {
+  if (!is_dir("/mnt/user/$share")) continue;
+  $free = exec("df ".escapeshellarg("/mnt/user/$share")."|awk 'END{print $4}'");
+  if ($free > $used) {$zip = "/mnt/user/$share/$backup"; break;}
+}
+if (!$zip) {
+  $bootfs = exec("findmnt -no FSTYPE /boot");
+  if (in_array($bootfs, ['zfs','btrfs','xfs'])) {
+    $free = exec("df /boot|awk 'END{print $4}'");
+    if ($free > $used) $zip = "/boot/$backup";
+  }
+}
+if (!$zip) {
+  pub('_ERROR_'._('No destination with enough free space (is the array started?)'));
+  exit(1);
+}
+
+// Collect top-level entries to archive, skipping prior-release/junk dirs and any
+// earlier flash-backup zip left on the flash.
+chdir('/boot');
+$items = [];
+foreach (glob('*',GLOB_NOSORT) as $entry) {
+  if (in_array($entry,$out)) continue;
+  if (preg_match('/-boot-backup-.*\.zip$/',$entry)) continue;
+  $items[] = $entry;
+}
+$total = count($items);
+
+// zip each entry into the archive at low CPU/IO priority, publishing a
+// percentage after each item completes.
+$prio = 'nice -n 19 ionice -c2 -n7';
+$ok = true;
+foreach ($items as $i => $entry) {
+  $flag = is_dir($entry) ? '-r' : '';
+  exec("$prio zip -$level -q $flag ".escapeshellarg($zip)." ".escapeshellarg($entry)." 2>/dev/null", $o, $rc);
+  if ($rc !== 0 && $rc !== 12) $ok = false; // rc 12 = "nothing to do"
+  pub((string)($total ? (int)round((($i+1)/$total)*100) : 100));
+}
+
+if (!$ok || !is_file($zip)) {
+  @unlink($zip);
+  pub('_ERROR_'._('Backup failed'));
+  exit(1);
+}
+
+pub('_SAVED_'.$zip);
+pub('_DONE_');
+?>


### PR DESCRIPTION
## Problem

The manual **Boot device backup** ran the entire zip *synchronously inside the HTTP request* — froze the page for minutes, no compression choice, no progress.

## What it does now

A selectable **mode**, a **compression level**, and a live **progress bar**.

- **Download to your computer** — streams the archive straight to the browser as it is built (`include/FlashBackup.php`): nothing staged on the server, no size/FAT limit, works with the array stopped (`X-Accel-Buffering: no` so nginx streams, not spools).
- **Save to the server** — a tracked background job (`scripts/flash_backup_save` via `StartCommand.php`) writes the archive to a persistent disk target (cache/SSD pool → array share → boot pool) and keeps it. Runs to completion even if you navigate away, raises an Unraid notification (tray bell) on finish, and the page shows where it landed. Ideal when the link to the server is slow.

Both modes share one progress bar fed by the `flash_backup` nchan channel.

## Details

- **Compression**: None/Low/Normal/Maximum → zip `0/1/6/9`.
- **Progress without a Content-Length**: server publishes bytes/percent over nchan, tagged with a **per-run token** so a stale buffered message can't make a fresh run jump to 100%; one subscriber for the page lifetime (no per-click start/stop race).
- **Speed**: a single `zip -qr -` pass piped to its destination instead of per-item appends — save dropped from ~95 s to ~8 s on a test box.
- **Excludes** the prior OS release (`previous`/`prev`, often >1 GB) and desktop junk.
- **Download trigger** uses a hidden iframe, not `window.location` (a top-level navigation fires `beforeunload`, which makes `NchanSubscriber` stop itself and freezes the bar).
- **Saved backups** are listed on the Boot Device page (scanned from pool/array/boot), each with path, size, a Download link, and a File Manager link.
- **Theming**: brand tokens (`var(--orange-500)` on `var(--gray-300)`); list renders inside the definition-list value column.

## Security

No web-root symlink to the full-flash backup. Saved backups download only through an **authenticated, path-validated serve endpoint** (`FlashBackup.php?serve=<name>`): basename-stripped, name-pattern-gated, `realpath` must resolve onto `/mnt` or `/boot` — can't be coerced into an arbitrary file read. nginx already requires a session.

## Files

- `emhttp/plugins/dynamix/include/FlashBackup.php` (new) — streaming download + authenticated serve endpoint
- `emhttp/plugins/dynamix/scripts/flash_backup` — streams the zip to stdout (+ `size` mode)
- `emhttp/plugins/dynamix/scripts/flash_backup_save` (new) — background save-to-disk job + tray notification
- `emhttp/plugins/dynamix/BootInfo.page` — mode + compression selectors, progress bar, saved-backups list
- `emhttp/plugins/dynamix/include/Download.php` — drop the old synchronous `cmd=backup` branch

## Testing

Verified on a live 7.3.2 server (internal ZFS boot):
- **Download**: streams a valid archive, `zip -T` OK, progress published.
- **Save**: ~8 s for a valid 2.5 GB archive to the pool, kept, integrity OK, tray notification raised; serve endpoint validated (traversal/bad names rejected, real backup served).
- Progress bar confirmed updating in-browser.

Notes: `ionice` is a no-op on ZFS; a `_()`-undefined fatal (php-cli has no GUI translation layer) was found and fixed during development. Slow downloads on the test box trace to its network path (GL.iNet hop + Mac on Wi-Fi), not the code.

Linear: OS-473

🤖 Generated with [Claude Code](https://claude.com/claude-code)