### PR TITLE
fix(ci): preserve file modes in PR test plugins

### DIFF
--- a/.github/scripts/generate-pr-plugin.sh
+++ b/.github/scripts/generate-pr-plugin.sh
@@ -114,10 +114,18 @@ if [ -f "$PLUGIN_DIR/text_files.txt" ]; then
             echo "⚠️  Warning: could not re-apply $(basename "$other")'s changes; reinstall it or reboot to restore them"
             logger -t webgui-pr "re-apply of $(basename "$other") patch failed during $(basename "$PLUGIN_DIR") rollback"
         fi
+        # Re-applying the patch recreates any new files at 0644; restore modes.
+        if [ -f "$other/modes.txt" ]; then
+            while read -r mode sys; do
+                [ -n "$mode" ] && [ -n "$sys" ] || continue
+                [ -e "/$sys" ] && chmod "$mode" "/$sys"
+            done < "$other/modes.txt"
+        fi
     done
 fi
 rm -f "$PATCH_APPLIED"
 rm -rf "$PLUGIN_DIR/orig"
+rm -f "$PLUGIN_DIR/modes.txt"
 : > "$PLUGIN_DIR/text_files.txt"
 
 # Restore any previously installed binary files
@@ -233,6 +241,19 @@ if [ -s "$PAYLOAD/binary_files.txt" ]; then
         cp -f "$SRC" "$SYS"
         echo "Installed binary: $SYS"
     done < "$PAYLOAD/binary_files.txt"
+fi
+
+# ---- Restore file modes ----------------------------------------------------
+# Unified diffs carry no permission bits, so patched/new text files land 0644
+# and lose any exec bit. Re-apply the modes recorded at build time. Persist
+# modes.txt so rolling back another PR plugin can restore them too.
+if [ -f "$PAYLOAD/modes.txt" ]; then
+    cp -f "$PAYLOAD/modes.txt" "$PLUGIN_DIR/modes.txt"
+    while read -r mode sys; do
+        [ -n "$mode" ] && [ -n "$sys" ] || continue
+        [ -e "/$sys" ] && chmod "$mode" "/$sys"
+    done < "$PAYLOAD/modes.txt"
+    echo "✅ File modes restored"
 fi
 
 echo ""

--- a/.github/workflows/pr-plugin-build.yml
+++ b/.github/workflows/pr-plugin-build.yml
@@ -154,6 +154,20 @@ jobs:
             cp -a old/. build/orig/ 2>/dev/null || true
           fi
 
+          # Record the intended mode of every changed file. Unified diffs carry
+          # no permission bits, so `patch` creates new files with the umask
+          # (0644) and drops the exec bit. The installer re-applies these modes
+          # after patching/installing.
+          : > build/modes.txt
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            [ -f "$file" ] || continue
+            sys=$(map_path "$file")
+            [ -n "$sys" ] || continue
+            printf '%s %s\n' "$(stat -c '%a' "$file")" "$sys" >> build/modes.txt
+          done < changed_files.txt
+          echo "modes.txt:"; cat build/modes.txt
+
           find build -type f | sed 's|^build/||' > file_list.txt
           echo "Payload contents:"; cat file_list.txt
 


### PR DESCRIPTION
## Problem

PR test plugins (OS-469) ship changed **text** files as a `diff -ruN` unified patch, applied on install with `patch -p1 -d /`. Two facts combine to drop permissions:

1. A unified diff carries **no mode metadata** (`diff -ruN` doesn't emit `new file mode 100755` the way `git diff` does).
2. `patch` creates new files with the process umask → **0644**.

So any **new executable script** delivered via the patch lands non-executable. Concretely, [#2675](https://github.com/unraid/webgui/pull/2675) adds `scripts/derive_gateway`, called from `rc.docker`; under the PR plugin it deployed as 0644 and failed to execute. (Binary files don't hit this — they're shipped whole and installed with `cp`, preserving mode.)

## Fix

Record a mode manifest at build time and re-apply it at install:

- **Build** (`pr-plugin-build.yml`): write `build/modes.txt` with `<octal> <system-path>` for every changed file (from the checkout's real modes).
- **Install** (`generate-pr-plugin.sh`): after the patch and binaries are applied, `chmod` each path from `modes.txt`. Persist `modes.txt` per plugin.
- **Rollback**: when removing one plugin re-applies the *other* still-installed plugins' patches (which would recreate their new files at 0644), restore those plugins' modes from their persisted `modes.txt` too.

~35 lines, no change to the patch/stacking machinery. Generalizes to any mode (e.g. a `750` helper), not just the exec bit.

## Test

Build→install simulated end-to-end against a temp root: a new `755` file is `0644` immediately after `patch` (reproduces the bug) and `0755` after the restore step; a modified `0644` file stays `0644`; the script executes and patched content is correct. `bash -n` passes on the generator.

This unblocks relying on shipped executable helpers in PR test plugins (e.g. #2675) without per-script `bash <file>` workarounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)