### PR TITLE
fix(file-manager): keep exclusive shares in /mnt/user space (OS-475)

### DIFF
--- a/emhttp/plugins/dynamix/Browse.page
+++ b/emhttp/plugins/dynamix/Browse.page
@@ -24,8 +24,23 @@ function dfm_array($array) {
 }
 
 function validdir($dir) {
-  $path = realpath($dir);
-  return in_array(explode('/', $path)[1] ?? '', ['mnt','boot']) ? $path : '';
+  $real = realpath($dir);
+  // Validate against the real (symlink-resolved) path: it must live under /mnt or /boot.
+  if ($real === false || !in_array(explode('/', $real)[1] ?? '', ['mnt','boot'])) return '';
+  // An exclusive share is exposed as a symlink /mnt/user/<share> -> /mnt/<pool|disk>/<share>,
+  // so realpath() would kick the File Manager out of user-share space and rewrite the whole
+  // view (and every folder link) to the raw /mnt/<disk> path. Keep the user-share path the
+  // caller asked for - FUSE is bypassed for exclusive shares, so it is the same data at native
+  // speed. Canonicalize lexically (no filesystem) so '..' can never escape /mnt/user.
+  $parts = [];
+  foreach (explode('/', $dir) as $p) {
+    if ($p === '' || $p === '.') continue;
+    if ($p === '..') { array_pop($parts); continue; }
+    $parts[] = $p;
+  }
+  $canon = '/'.implode('/', $parts);
+  if (preg_match('#^/mnt/(user0?|rootshare)(/|$)#', $canon) && is_dir($canon)) return $canon;
+  return $real;
 }
 
 $dir     = validdir(rawurldecode($dir));

--- a/emhttp/plugins/dynamix/include/Browse.php
+++ b/emhttp/plugins/dynamix/include/Browse.php
@@ -24,8 +24,23 @@ function write(&$rows) {
 }
 
 function validdir($dir) {
-  $path = realpath($dir);
-  return in_array(explode('/', $path)[1] ?? '', ['mnt','boot']) ? $path : '';
+  $real = realpath($dir);
+  // Validate against the real (symlink-resolved) path: it must live under /mnt or /boot.
+  if ($real === false || !in_array(explode('/', $real)[1] ?? '', ['mnt','boot'])) return '';
+  // An exclusive share is exposed as a symlink /mnt/user/<share> -> /mnt/<pool|disk>/<share>,
+  // so realpath() would kick the File Manager out of user-share space and rewrite the whole
+  // listing (every row's path and LOCATION) to the raw /mnt/<disk> path. Keep the user-share
+  // path the caller asked for - FUSE is bypassed for exclusive shares, so it is the same data
+  // at native speed. Canonicalize lexically (no filesystem) so '..' can never escape /mnt/user.
+  $parts = [];
+  foreach (explode('/', $dir) as $p) {
+    if ($p === '' || $p === '.') continue;
+    if ($p === '..') { array_pop($parts); continue; }
+    $parts[] = $p;
+  }
+  $canon = '/'.implode('/', $parts);
+  if (preg_match('#^/mnt/(user0?|rootshare)(/|$)#', $canon) && is_dir($canon)) return $canon;
+  return $real;
 }
 
 function escapeQuote($data) {

--- a/emhttp/plugins/dynamix/include/DiskList.php
+++ b/emhttp/plugins/dynamix/include/DiskList.php
@@ -110,7 +110,7 @@ foreach ($disks as $name => $disk) {
     case 2: $luks = "<a class='info' onclick='return false'><i class='padlock fa fa-unlock-alt orange-text'></i><span>"._('Some or all files unencrypted')."</span></a>"; break;
    default: $luks = "<a class='info' onclick='return false'><i class='padlock fa fa-lock red-text'></i><span>"._('Unknown encryption state')."</span></a>"; break;
   } else $luks = "";
-  echo "<tr><td><a class='view' href=\"/$path/Browse?dir=/mnt/$name\"><i class=\"icon-u-tab\" title=\"",_('Browse')," /mnt/$name\"></i></a>";
+  echo "<tr><td><a class='view' href=\"/$path/Browse?dir=/mnt/$name\"><i class=\"fa fa-folder-open\" title=\"",_('Browse')," /mnt/$name\"></i></a>";
   echo "<a class='info nohand' onclick='return false'><i class='fa fa-$orb orb $color-orb'></i><span style='left:18px'>$help</span></a>$luks<a href=\"/$path/Disk?name=$name\" onclick=\"$.cookie('one','tab1')\">$name</a></td>";
   echo "<td>",htmlspecialchars(_var($disk,'comment')),"</td>";
   echo "<td>",disk_share_settings(_var($var,'shareSMBEnabled'), $sec[$name]),"</td>";

--- a/emhttp/plugins/dynamix/include/DiskList.php
+++ b/emhttp/plugins/dynamix/include/DiskList.php
@@ -110,7 +110,7 @@ foreach ($disks as $name => $disk) {
     case 2: $luks = "<a class='info' onclick='return false'><i class='padlock fa fa-unlock-alt orange-text'></i><span>"._('Some or all files unencrypted')."</span></a>"; break;
    default: $luks = "<a class='info' onclick='return false'><i class='padlock fa fa-lock red-text'></i><span>"._('Unknown encryption state')."</span></a>"; break;
   } else $luks = "";
-  echo "<tr><td><a class='view' href=\"/$path/Browse?dir=/mnt/$name\"><i class=\"fa fa-folder-open\" title=\"",_('Browse')," /mnt/$name\"></i></a>";
+  echo "<tr><td><a class='view' href=\"/$path/Browse?dir=/mnt/$name\"><i class=\"fa fa-folder-o\" title=\"",_('Browse')," /mnt/$name\"></i></a>";
   echo "<a class='info nohand' onclick='return false'><i class='fa fa-$orb orb $color-orb'></i><span style='left:18px'>$help</span></a>$luks<a href=\"/$path/Disk?name=$name\" onclick=\"$.cookie('one','tab1')\">$name</a></td>";
   echo "<td>",htmlspecialchars(_var($disk,'comment')),"</td>";
   echo "<td>",disk_share_settings(_var($var,'shareSMBEnabled'), $sec[$name]),"</td>";

--- a/emhttp/plugins/dynamix/include/DiskList.php
+++ b/emhttp/plugins/dynamix/include/DiskList.php
@@ -110,7 +110,7 @@ foreach ($disks as $name => $disk) {
     case 2: $luks = "<a class='info' onclick='return false'><i class='padlock fa fa-unlock-alt orange-text'></i><span>"._('Some or all files unencrypted')."</span></a>"; break;
    default: $luks = "<a class='info' onclick='return false'><i class='padlock fa fa-lock red-text'></i><span>"._('Unknown encryption state')."</span></a>"; break;
   } else $luks = "";
-  echo "<tr><td><a class='view' href=\"/$path/Browse?dir=/mnt/$name\"><i class=\"fa fa-folder-o\" title=\"",_('Browse')," /mnt/$name\"></i></a>";
+  echo "<tr><td><a class='view info' href=\"/$path/Browse?dir=/mnt/$name\"><i class=\"fa fa-folder-o\"></i><span>",_('Open in File Manager'),"</span></a>";
   echo "<a class='info nohand' onclick='return false'><i class='fa fa-$orb orb $color-orb'></i><span style='left:18px'>$help</span></a>$luks<a href=\"/$path/Disk?name=$name\" onclick=\"$.cookie('one','tab1')\">$name</a></td>";
   echo "<td>",htmlspecialchars(_var($disk,'comment')),"</td>";
   echo "<td>",disk_share_settings(_var($var,'shareSMBEnabled'), $sec[$name]),"</td>";

--- a/emhttp/plugins/dynamix/include/DiskList.php
+++ b/emhttp/plugins/dynamix/include/DiskList.php
@@ -110,7 +110,7 @@ foreach ($disks as $name => $disk) {
     case 2: $luks = "<a class='info' onclick='return false'><i class='padlock fa fa-unlock-alt orange-text'></i><span>"._('Some or all files unencrypted')."</span></a>"; break;
    default: $luks = "<a class='info' onclick='return false'><i class='padlock fa fa-lock red-text'></i><span>"._('Unknown encryption state')."</span></a>"; break;
   } else $luks = "";
-  echo "<tr><td><a class='view info' href=\"/$path/Browse?dir=/mnt/$name\"><i class=\"fa fa-folder-o\"></i><span>",_('Open in File Manager'),"</span></a>";
+  echo "<tr><td><a class='view info' href=\"/$path/Browse?dir=/mnt/",rawurlencode($name),"\"><i class=\"fa fa-folder-o\"></i><span>",_('Open in File Manager'),"</span></a>";
   echo "<a class='info nohand' onclick='return false'><i class='fa fa-$orb orb $color-orb'></i><span style='left:18px'>$help</span></a>$luks<a href=\"/$path/Disk?name=$name\" onclick=\"$.cookie('one','tab1')\">$name</a></td>";
   echo "<td>",htmlspecialchars(_var($disk,'comment')),"</td>";
   echo "<td>",disk_share_settings(_var($var,'shareSMBEnabled'), $sec[$name]),"</td>";

--- a/emhttp/plugins/dynamix/include/FileTree.php
+++ b/emhttp/plugins/dynamix/include/FileTree.php
@@ -31,6 +31,25 @@ function path($dir) {
   return mb_substr($dir,-1) == '/' ? $dir : $dir.'/';
 }
 
+function tree_dir($dir) {
+  $real = realpath($dir);
+  if ($real === false) return false;
+
+  // Exclusive shares are symlinks into their backing pool. Keep the requested
+  // user-share path so selecting a nested destination does not switch the
+  // File Manager target from /mnt/user to /mnt/<pool>.
+  $parts = [];
+  foreach (explode('/', $dir) as $part) {
+    if ($part === '' || $part === '.') continue;
+    if ($part === '..') { array_pop($parts); continue; }
+    $parts[] = $part;
+  }
+  $canonical = '/'.implode('/', $parts);
+  if (preg_match('#^/mnt/(user0?|rootshare)(/|$)#', $canonical) && is_dir($canonical)) return $canonical;
+
+  return $real;
+}
+
 function is_top($dir) {
   global $fileTreeRoot;
   return mb_strlen($dir) > mb_strlen($fileTreeRoot);
@@ -45,8 +64,9 @@ function my_dir($name) {
   return ($rootdir === $userdir && in_array($name, $UDincluded)) ? $topdir : $rootdir;
 }
 
-$fileTreeRoot = path(realpath($_POST['root']));
+$fileTreeRoot = tree_dir($_POST['root']);
 if (!$fileTreeRoot) exit("ERROR: Root filesystem directory not set in jqueryFileTree.php");
+$fileTreeRoot = path($fileTreeRoot);
 
 $docroot = '/usr/local/emhttp';
 require_once "$docroot/webGui/include/Secure.php";
@@ -56,7 +76,9 @@ require_once "$docroot/plugins/dynamix/include/PopularDestinations.php";
 
 $mntdir   = '/mnt/';
 $userdir  = '/mnt/user/';
-$rootdir  = path(realpath($_POST['dir']));
+$rootdir  = tree_dir($_POST['dir']);
+if (!$rootdir) exit("ERROR: Filesystem directory not set in jqueryFileTree.php");
+$rootdir  = path($rootdir);
 $topdir   = str_replace($userdir, $mntdir, $rootdir);
 $filters  = (array)$_POST['filter'];
 $match    = $_POST['match'];

--- a/emhttp/plugins/dynamix/include/ShareList.php
+++ b/emhttp/plugins/dynamix/include/ShareList.php
@@ -266,7 +266,7 @@ foreach ($shares as $name => $share) {
 		}
 	}
 
-	echo "<tr><td><a class='view' href=\"/$path/Browse?dir=/mnt/user/", htmlspecialchars($name), "\"><i class=\"icon-u-tab\" title=\"", _('Browse'), " /mnt/user/" . htmlspecialchars($name), "\"></i></a>";
+	echo "<tr><td><a class='view' href=\"/$path/Browse?dir=/mnt/user/", htmlspecialchars($name), "\"><i class=\"fa fa-folder-open\" title=\"", _('Browse'), " /mnt/user/" . htmlspecialchars($name), "\"></i></a>";
 	echo "<a class='info nohand' onclick='return false'><i class='fa fa-$orb orb $color-orb'></i><span style='left:18px'>$help</span></a>$luks<a href=\"/$path/Share?name=";
 	echo rawurlencode($name), "\" onclick=\"$.cookie('one','tab1')\">$name</a></td>";
         echo "<td>", htmlspecialchars(_var($share,'comment')), "</td>";

--- a/emhttp/plugins/dynamix/include/ShareList.php
+++ b/emhttp/plugins/dynamix/include/ShareList.php
@@ -266,7 +266,7 @@ foreach ($shares as $name => $share) {
 		}
 	}
 
-	echo "<tr><td><a class='view' href=\"/$path/Browse?dir=/mnt/user/", htmlspecialchars($name), "\"><i class=\"fa fa-folder-open\" title=\"", _('Browse'), " /mnt/user/" . htmlspecialchars($name), "\"></i></a>";
+	echo "<tr><td><a class='view' href=\"/$path/Browse?dir=/mnt/user/", htmlspecialchars($name), "\"><i class=\"fa fa-folder-o\" title=\"", _('Browse'), " /mnt/user/" . htmlspecialchars($name), "\"></i></a>";
 	echo "<a class='info nohand' onclick='return false'><i class='fa fa-$orb orb $color-orb'></i><span style='left:18px'>$help</span></a>$luks<a href=\"/$path/Share?name=";
 	echo rawurlencode($name), "\" onclick=\"$.cookie('one','tab1')\">$name</a></td>";
         echo "<td>", htmlspecialchars(_var($share,'comment')), "</td>";

--- a/emhttp/plugins/dynamix/include/ShareList.php
+++ b/emhttp/plugins/dynamix/include/ShareList.php
@@ -266,7 +266,7 @@ foreach ($shares as $name => $share) {
 		}
 	}
 
-	echo "<tr><td><a class='view' href=\"/$path/Browse?dir=/mnt/user/", htmlspecialchars($name), "\"><i class=\"fa fa-folder-o\" title=\"", _('Browse'), " /mnt/user/" . htmlspecialchars($name), "\"></i></a>";
+	echo "<tr><td><a class='view info' href=\"/$path/Browse?dir=/mnt/user/", htmlspecialchars($name), "\"><i class=\"fa fa-folder-o\"></i><span>", _('Open in File Manager'), "</span></a>";
 	echo "<a class='info nohand' onclick='return false'><i class='fa fa-$orb orb $color-orb'></i><span style='left:18px'>$help</span></a>$luks<a href=\"/$path/Share?name=";
 	echo rawurlencode($name), "\" onclick=\"$.cookie('one','tab1')\">$name</a></td>";
         echo "<td>", htmlspecialchars(_var($share,'comment')), "</td>";

--- a/emhttp/plugins/dynamix/include/ShareList.php
+++ b/emhttp/plugins/dynamix/include/ShareList.php
@@ -266,7 +266,7 @@ foreach ($shares as $name => $share) {
 		}
 	}
 
-	echo "<tr><td><a class='view info' href=\"/$path/Browse?dir=/mnt/user/", htmlspecialchars($name), "\"><i class=\"fa fa-folder-o\"></i><span>", _('Open in File Manager'), "</span></a>";
+	echo "<tr><td><a class='view info' href=\"/$path/Browse?dir=/mnt/user/", rawurlencode($name), "\"><i class=\"fa fa-folder-o\"></i><span>", _('Open in File Manager'), "</span></a>";
 	echo "<a class='info nohand' onclick='return false'><i class='fa fa-$orb orb $color-orb'></i><span style='left:18px'>$help</span></a>$luks<a href=\"/$path/Share?name=";
 	echo rawurlencode($name), "\" onclick=\"$.cookie('one','tab1')\">$name</a></td>";
         echo "<td>", htmlspecialchars(_var($share,'comment')), "</td>";

--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -344,14 +344,17 @@ function pool_status_html(string $poolName, array $poolstatusData, array $disks)
   $displayText = $hasErrors ? _('ONLINE') : _($status_text);
   $deviceUrl = "/Main/Device?name=".urlencode($poolName)."#poolsummary";
 
+  // The pool-status class + trailing chevron mark this as a "view pool details"
+  // link rather than a stray blue label (the device name beside it is also a link).
+  $chevron = "<i class='fa fa-angle-right pool-status-go'></i>";
   if (!$isOnline) {
-    return " <a href='$deviceUrl' title='"._('View pool details')."'>("._($status_text).")</a><span title='"._('Check pool status')."'><i class='fa fa-warning fa-fw orange-text'></i></span>";
+    return " <a class='pool-status' href='$deviceUrl' title='"._('View pool details')."'>("._($status_text).") $chevron</a><span title='"._('Check pool status')."'><i class='fa fa-warning fa-fw orange-text'></i></span>";
   }
   if ($hasErrors) {
-    return " <a href='$deviceUrl' title='"._('View pool details')."'>($displayText)</a><span title='"._('Check pool status')."'><i class='fa fa-warning fa-fw orange-text'></i></span>";
+    return " <a class='pool-status' href='$deviceUrl' title='"._('View pool details')."'>($displayText) $chevron</a><span title='"._('Check pool status')."'><i class='fa fa-warning fa-fw orange-text'></i></span>";
   }
 
-  return " <a href='$deviceUrl' title='"._('View pool details')."'>($displayText)</a>";
+  return " <a class='pool-status' href='$deviceUrl' title='"._('View pool details')."'>($displayText) $chevron</a>";
 }
 
 function pool_function_row(string $label, ?array $poolDisk, ?array $firstMember, array $metrics, string $poolName='', array $poolstatusData=[], bool $showSummary=false, array $fsOverride=[], bool $showPoolStatusInTitle=true, string $statusPoolName='', string $summaryDisplayName='', bool $summaryShowView=true, string $summaryRowId=''): string

--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -344,17 +344,18 @@ function pool_status_html(string $poolName, array $poolstatusData, array $disks)
   $displayText = $hasErrors ? _('ONLINE') : _($status_text);
   $deviceUrl = "/Main/Device?name=".urlencode($poolName)."#poolsummary";
 
-  // The pool-status class + trailing chevron mark this as a "view pool details"
-  // link rather than a stray blue label (the device name beside it is also a link).
-  $chevron = "<i class='fa fa-angle-right pool-status-go'></i>";
+  // Health stays plain status text; the only clickable bit is a small info icon
+  // (with the standard a.info tooltip) that jumps to the pool details section.
+  $details = "<a class='info pool-info' href='$deviceUrl'><i class='fa fa-info-circle'></i><span>"._('View pool details')."</span></a>";
+  $warn = "<a class='info' onclick='return false'><i class='fa fa-warning fa-fw orange-text'></i><span>"._('Check pool status')."</span></a>";
   if (!$isOnline) {
-    return " <a class='pool-status' href='$deviceUrl' title='"._('View pool details')."'>("._($status_text).") $chevron</a><span title='"._('Check pool status')."'><i class='fa fa-warning fa-fw orange-text'></i></span>";
+    return " <span class='pool-state'>("._($status_text).")</span> $warn$details";
   }
   if ($hasErrors) {
-    return " <a class='pool-status' href='$deviceUrl' title='"._('View pool details')."'>($displayText) $chevron</a><span title='"._('Check pool status')."'><i class='fa fa-warning fa-fw orange-text'></i></span>";
+    return " <span class='pool-state'>($displayText)</span> $warn$details";
   }
 
-  return " <a class='pool-status' href='$deviceUrl' title='"._('View pool details')."'>($displayText) $chevron</a>";
+  return " <span class='pool-state'>($displayText)</span> $details";
 }
 
 function pool_function_row(string $label, ?array $poolDisk, ?array $firstMember, array $metrics, string $poolName='', array $poolstatusData=[], bool $showSummary=false, array $fsOverride=[], bool $showPoolStatusInTitle=true, string $statusPoolName='', string $summaryDisplayName='', bool $summaryShowView=true, string $summaryRowId=''): string
@@ -506,11 +507,11 @@ function device_info(&$disk,$online,$poolName='',$poolstatusData=[], $options=[]
   if (!$online || _var($disk,'fsStatus')!='Mounted' || (in_array(_var($disk,'type'),['Parity','Cache']) && (!in_array(_var($disk,'name'),$pools) || isSubpool(_var($disk,'name'))))) {
     $view = "<a class='view'></a>";
   } else {
-    $view = "<a class='view' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"fa fa-folder-o\" title=\""._('Browse')." $dir\"></i></a>";
+    $view = "<a class='view info' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"fa fa-folder-o\"></i><span>"._('Open in File Manager')."</span></a>";
   }
   if (!$showView) $view = $showViewPlaceholder ? "<a class='view'></a>" : "";
   if ($showView && _var($options,'forceView',false) && _var($disk,'fsStatus')=='Mounted' && $dir !== '') {
-    $view = "<a class='view' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"fa fa-folder-o\" title=\""._('Browse')." $dir\"></i></a>";
+    $view = "<a class='view info' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"fa fa-folder-o\"></i><span>"._('Open in File Manager')."</span></a>";
   }
   if ($indent) $view = "<span style='padding-left:{$indent}px'></span>".$view;
   $realName = _var($disk,'name');
@@ -1395,7 +1396,7 @@ while (true) {
         $bootBrowseUrl = $bootDir !== '' ? "/Main/Browse?dir=".htmlspecialchars($bootDir) : $bootDeviceUrl;
         $bootIcon = $bootBrowseUrl === $bootDeviceUrl
           ? "<a class='view'></a>"
-          : "<a class='view' href=\"$bootBrowseUrl\"><i class=\"fa fa-folder-o\" title=\""._('Browse')." $bootDir\"></i></a>";
+          : "<a class='view info' href=\"$bootBrowseUrl\"><i class=\"fa fa-folder-o\"></i><span>"._('Open in File Manager')."</span></a>";
         $bootLink = "<a href=\"$bootDeviceUrl\">"._($bootLabel,3)."</a>";
         $poolLabel = ucfirst($pool);
         $poolDeviceUrl = "/Main/Device?name=".urlencode($pool);
@@ -1403,7 +1404,7 @@ while (true) {
         $poolBrowseUrl = $poolDir !== '' ? "/Main/Browse?dir=".htmlspecialchars($poolDir) : $poolDeviceUrl;
         $poolIcon = $poolBrowseUrl === $poolDeviceUrl
           ? "<a class='view'></a>"
-          : "<a class='view' href=\"$poolBrowseUrl\"><i class=\"fa fa-folder-o\" title=\""._('Browse')." $poolDir\"></i></a>";
+          : "<a class='view info' href=\"$poolBrowseUrl\"><i class=\"fa fa-folder-o\"></i><span>"._('Open in File Manager')."</span></a>";
         $poolLink = "<a href=\"$poolDeviceUrl\">"._($poolLabel,3)."</a>";
         $flashWarn = flash_smb_warning_html(_var($bootDisk,'name',''));
         $bootSummaryName = $bootIcon.$bootLink.$flashWarn;

--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -503,11 +503,11 @@ function device_info(&$disk,$online,$poolName='',$poolstatusData=[], $options=[]
   if (!$online || _var($disk,'fsStatus')!='Mounted' || (in_array(_var($disk,'type'),['Parity','Cache']) && (!in_array(_var($disk,'name'),$pools) || isSubpool(_var($disk,'name'))))) {
     $view = "<a class='view'></a>";
   } else {
-    $view = "<a class='view' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"icon-u-tab\" title=\""._('Browse')." $dir\"></i></a>";
+    $view = "<a class='view' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"fa fa-folder-open\" title=\""._('Browse')." $dir\"></i></a>";
   }
   if (!$showView) $view = $showViewPlaceholder ? "<a class='view'></a>" : "";
   if ($showView && _var($options,'forceView',false) && _var($disk,'fsStatus')=='Mounted' && $dir !== '') {
-    $view = "<a class='view' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"icon-u-tab\" title=\""._('Browse')." $dir\"></i></a>";
+    $view = "<a class='view' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"fa fa-folder-open\" title=\""._('Browse')." $dir\"></i></a>";
   }
   if ($indent) $view = "<span style='padding-left:{$indent}px'></span>".$view;
   $realName = _var($disk,'name');
@@ -1392,7 +1392,7 @@ while (true) {
         $bootBrowseUrl = $bootDir !== '' ? "/Main/Browse?dir=".htmlspecialchars($bootDir) : $bootDeviceUrl;
         $bootIcon = $bootBrowseUrl === $bootDeviceUrl
           ? "<a class='view'></a>"
-          : "<a class='view' href=\"$bootBrowseUrl\"><i class=\"icon-u-tab\" title=\""._('Browse')." $bootDir\"></i></a>";
+          : "<a class='view' href=\"$bootBrowseUrl\"><i class=\"fa fa-folder-open\" title=\""._('Browse')." $bootDir\"></i></a>";
         $bootLink = "<a href=\"$bootDeviceUrl\">"._($bootLabel,3)."</a>";
         $poolLabel = ucfirst($pool);
         $poolDeviceUrl = "/Main/Device?name=".urlencode($pool);
@@ -1400,7 +1400,7 @@ while (true) {
         $poolBrowseUrl = $poolDir !== '' ? "/Main/Browse?dir=".htmlspecialchars($poolDir) : $poolDeviceUrl;
         $poolIcon = $poolBrowseUrl === $poolDeviceUrl
           ? "<a class='view'></a>"
-          : "<a class='view' href=\"$poolBrowseUrl\"><i class=\"icon-u-tab\" title=\""._('Browse')." $poolDir\"></i></a>";
+          : "<a class='view' href=\"$poolBrowseUrl\"><i class=\"fa fa-folder-open\" title=\""._('Browse')." $poolDir\"></i></a>";
         $poolLink = "<a href=\"$poolDeviceUrl\">"._($poolLabel,3)."</a>";
         $flashWarn = flash_smb_warning_html(_var($bootDisk,'name',''));
         $bootSummaryName = $bootIcon.$bootLink.$flashWarn;

--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -503,11 +503,11 @@ function device_info(&$disk,$online,$poolName='',$poolstatusData=[], $options=[]
   if (!$online || _var($disk,'fsStatus')!='Mounted' || (in_array(_var($disk,'type'),['Parity','Cache']) && (!in_array(_var($disk,'name'),$pools) || isSubpool(_var($disk,'name'))))) {
     $view = "<a class='view'></a>";
   } else {
-    $view = "<a class='view' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"fa fa-folder-open\" title=\""._('Browse')." $dir\"></i></a>";
+    $view = "<a class='view' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"fa fa-folder-o\" title=\""._('Browse')." $dir\"></i></a>";
   }
   if (!$showView) $view = $showViewPlaceholder ? "<a class='view'></a>" : "";
   if ($showView && _var($options,'forceView',false) && _var($disk,'fsStatus')=='Mounted' && $dir !== '') {
-    $view = "<a class='view' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"fa fa-folder-open\" title=\""._('Browse')." $dir\"></i></a>";
+    $view = "<a class='view' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"fa fa-folder-o\" title=\""._('Browse')." $dir\"></i></a>";
   }
   if ($indent) $view = "<span style='padding-left:{$indent}px'></span>".$view;
   $realName = _var($disk,'name');
@@ -1392,7 +1392,7 @@ while (true) {
         $bootBrowseUrl = $bootDir !== '' ? "/Main/Browse?dir=".htmlspecialchars($bootDir) : $bootDeviceUrl;
         $bootIcon = $bootBrowseUrl === $bootDeviceUrl
           ? "<a class='view'></a>"
-          : "<a class='view' href=\"$bootBrowseUrl\"><i class=\"fa fa-folder-open\" title=\""._('Browse')." $bootDir\"></i></a>";
+          : "<a class='view' href=\"$bootBrowseUrl\"><i class=\"fa fa-folder-o\" title=\""._('Browse')." $bootDir\"></i></a>";
         $bootLink = "<a href=\"$bootDeviceUrl\">"._($bootLabel,3)."</a>";
         $poolLabel = ucfirst($pool);
         $poolDeviceUrl = "/Main/Device?name=".urlencode($pool);
@@ -1400,7 +1400,7 @@ while (true) {
         $poolBrowseUrl = $poolDir !== '' ? "/Main/Browse?dir=".htmlspecialchars($poolDir) : $poolDeviceUrl;
         $poolIcon = $poolBrowseUrl === $poolDeviceUrl
           ? "<a class='view'></a>"
-          : "<a class='view' href=\"$poolBrowseUrl\"><i class=\"fa fa-folder-open\" title=\""._('Browse')." $poolDir\"></i></a>";
+          : "<a class='view' href=\"$poolBrowseUrl\"><i class=\"fa fa-folder-o\" title=\""._('Browse')." $poolDir\"></i></a>";
         $poolLink = "<a href=\"$poolDeviceUrl\">"._($poolLabel,3)."</a>";
         $flashWarn = flash_smb_warning_html(_var($bootDisk,'name',''));
         $bootSummaryName = $bootIcon.$bootLink.$flashWarn;

--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -507,11 +507,11 @@ function device_info(&$disk,$online,$poolName='',$poolstatusData=[], $options=[]
   if (!$online || _var($disk,'fsStatus')!='Mounted' || (in_array(_var($disk,'type'),['Parity','Cache']) && (!in_array(_var($disk,'name'),$pools) || isSubpool(_var($disk,'name'))))) {
     $view = "<a class='view'></a>";
   } else {
-    $view = "<a class='view info' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"fa fa-folder-o\"></i><span>"._('Open in File Manager')."</span></a>";
+    $view = "<a class='view info' href=\"/Main/Browse?dir=".rawurlencode($dir)."\"><i class=\"fa fa-folder-o\"></i><span>"._('Open in File Manager')."</span></a>";
   }
   if (!$showView) $view = $showViewPlaceholder ? "<a class='view'></a>" : "";
   if ($showView && _var($options,'forceView',false) && _var($disk,'fsStatus')=='Mounted' && $dir !== '') {
-    $view = "<a class='view info' href=\"/Main/Browse?dir=".htmlspecialchars($dir)."\"><i class=\"fa fa-folder-o\"></i><span>"._('Open in File Manager')."</span></a>";
+    $view = "<a class='view info' href=\"/Main/Browse?dir=".rawurlencode($dir)."\"><i class=\"fa fa-folder-o\"></i><span>"._('Open in File Manager')."</span></a>";
   }
   if ($indent) $view = "<span style='padding-left:{$indent}px'></span>".$view;
   $realName = _var($disk,'name');
@@ -1393,7 +1393,7 @@ while (true) {
         $bootLabel = _($bootPoolMode === 'dedicated' ? 'Internal Boot(Dedicated)' : 'Internal Boot');
         $bootDeviceUrl = "/Main/Boot?name=".urlencode($bootPoolName);
         $bootDir = _var($bootDisk,'fsMountpoint','/boot');
-        $bootBrowseUrl = $bootDir !== '' ? "/Main/Browse?dir=".htmlspecialchars($bootDir) : $bootDeviceUrl;
+        $bootBrowseUrl = $bootDir !== '' ? "/Main/Browse?dir=".rawurlencode($bootDir) : $bootDeviceUrl;
         $bootIcon = $bootBrowseUrl === $bootDeviceUrl
           ? "<a class='view'></a>"
           : "<a class='view info' href=\"$bootBrowseUrl\"><i class=\"fa fa-folder-o\"></i><span>"._('Open in File Manager')."</span></a>";
@@ -1401,7 +1401,7 @@ while (true) {
         $poolLabel = ucfirst($pool);
         $poolDeviceUrl = "/Main/Device?name=".urlencode($pool);
         $poolDir = _var($poolDisk,'fsMountpoint','');
-        $poolBrowseUrl = $poolDir !== '' ? "/Main/Browse?dir=".htmlspecialchars($poolDir) : $poolDeviceUrl;
+        $poolBrowseUrl = $poolDir !== '' ? "/Main/Browse?dir=".rawurlencode($poolDir) : $poolDeviceUrl;
         $poolIcon = $poolBrowseUrl === $poolDeviceUrl
           ? "<a class='view'></a>"
           : "<a class='view info' href=\"$poolBrowseUrl\"><i class=\"fa fa-folder-o\"></i><span>"._('Open in File Manager')."</span></a>";

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -131,6 +131,16 @@ a.static {
 a.view {
     display: inline-block;
     width: 20px;
+    /* Gap so the browse icon doesn't visually merge with the device/share link beside it */
+    margin-right: 8px;
+}
+/* Mute the browse icon so it reads as a separate action, not part of the blue link
+   next to it; brighten to the link color on hover to signal it is clickable. */
+a.view i {
+    color: var(--alt-text-color);
+}
+a.view:hover i {
+    color: var(--blue-800);
 }
 i.spacing {
     margin-left: -6px;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -146,6 +146,21 @@ a.view:hover i {
 a.view:hover i.fa-folder-o:before {
     content: "\f115"; /* fa-folder-open-o */
 }
+/* Pool health indicator: a "view pool details" link, not a generic blue label.
+   Muted so it reads as secondary status text; a small chevron marks it navigable,
+   and it brightens + underlines on hover. */
+a.pool-status {
+    color: var(--alt-text-color);
+}
+a.pool-status:hover {
+    color: var(--blue-800);
+    text-decoration: underline;
+}
+i.pool-status-go {
+    font-size: 0.85em;
+    margin-left: 3px;
+    opacity: 0.7;
+}
 i.spacing {
     margin-left: -6px;
 }

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -142,6 +142,10 @@ a.view i {
 a.view:hover i {
     color: var(--blue-800);
 }
+/* Closed folder at rest, opening on hover, to signal "click to browse here" */
+a.view:hover i.fa-folder-o:before {
+    content: "\f115"; /* fa-folder-open-o */
+}
 i.spacing {
     margin-left: -6px;
 }

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -146,20 +146,18 @@ a.view:hover i {
 a.view:hover i.fa-folder-o:before {
     content: "\f115"; /* fa-folder-open-o */
 }
-/* Pool health indicator: a "view pool details" link, not a generic blue label.
-   Muted so it reads as secondary status text; a small chevron marks it navigable,
-   and it brightens + underlines on hover. */
-a.pool-status {
+/* Pool health is plain status text, not a link. The separate info icon beside it
+   is the only clickable bit; it's muted and brightens on hover, with the standard
+   a.info tooltip explaining where it goes. */
+span.pool-state {
     color: var(--alt-text-color);
 }
-a.pool-status:hover {
-    color: var(--blue-800);
-    text-decoration: underline;
+a.pool-info {
+    color: var(--alt-text-color);
+    margin-left: 4px;
 }
-i.pool-status-go {
-    font-size: 0.85em;
-    margin-left: 3px;
-    opacity: 0.7;
+a.pool-info:hover {
+    color: var(--blue-800);
 }
 i.spacing {
     margin-left: -6px;


### PR DESCRIPTION
## Summary

Exclusive shares now stay in `/mnt/user` throughout both File Manager browsing and copy/move destination selection, preventing nested destinations from being rewritten to raw backing-storage paths and rejected as invalid targets.

## Why This Exists

Opening an exclusive share originally ran the requested path through `realpath()`, which follows the exclusive-share symlink from `/mnt/user/<share>` to `/mnt/<pool|disk>/<share>`. The first fix preserved the path in the main File Manager listing, but QA found the destination picker had an independent `realpath()` boundary in `FileTree.php`. Selecting a folder below an exclusive share therefore still changed the target path and caused an `Invalid target` error.

## Resolution

Preserve a lexically canonicalized `/mnt/user`, `/mnt/user0`, or `/mnt/rootshare` path after confirming the requested directory exists with `realpath()`. The same rule now applies in the main browser and the destination tree. Disk, pool, boot, and Unassigned Devices paths retain their existing resolved behavior.

The PR also improves the File Manager launcher affordance with a labeled folder icon, URL-encodes browse destinations containing reserved characters, and clarifies pool-status navigation.

## Reviewer Considerations

- `emhttp/webGui` is a hard-linked mirror of `plugins/dynamix`; the tracked files under `plugins/dynamix` cover both runtime paths.
- Review `include/FileTree.php` together with the existing `validdir()` changes: both boundaries must preserve the requested user-share namespace to avoid reintroducing mixed `/mnt/user` and `/mnt/<disk>` paths.
- The picker still requires `realpath()` and `is_dir()` success before preserving a user-share path, so nonexistent destinations are not accepted.
- Browse-link paths use `rawurlencode()` because they are query parameter values; HTML escaping does not protect reserved URL characters such as `&` and `#`.

## Behavior Changes

- Browsing an exclusive share stays under `/mnt/user/<share>`.
- Selecting the root or any nested folder of an exclusive share as a copy/move destination keeps `/mnt/user/<share>/...` in the target field.
- Raw disk/pool browsing remains under `/mnt/<disk|pool>/...`.
- Share, disk, boot, pool, and generic device browse links support names containing reserved URL characters.
- File Manager launch links use a closed folder icon that opens on hover and includes an `Open in File Manager` tooltip.
- Pool health remains plain status text with a dedicated details affordance.

## Implementation Summary

- Preserve validated user-share paths in `Browse.page` and `include/Browse.php`.
- Preserve validated user-share paths in the File Tree connector used by destination pickers.
- URL-encode File Manager browse query parameters across share, disk, boot, pool, and generic device links.
- Update browse-link and pool-status affordances across disk, share, and device views.

## Verification

- `php -l` on `FileTree.php`, `ShareList.php`, `DiskList.php`, and `nchan/device_list` — pass.
- `git diff --check` — pass.
- PHP 8.5 container fixture with `/mnt/user/share -> /mnt/cache/share`:
  - nested exclusive-share folder stays `/mnt/user/share/folder` — pass;
  - raw disk folder remains `/mnt/disk1/data` — pass;
  - missing folder remains invalid — pass;
  - fixture confirms unpatched `realpath()` resolves the nested user path to `/mnt/cache/share/folder` — pass.
- Special-character query round-trip for `My & Share#1` — pass.
- PR plugin and GitHub checks are rebuilt on each push.

## Risk

Low. The path-preservation change is confined to File Tree presentation for existing user-share directories; filesystem existence is still established from the symlink-resolved path, and non-user-share paths retain the prior behavior. Browse-link encoding uses the standard query-value encoding already used elsewhere in these views.

## Linear

- OS-475


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer “Open in File Manager” links with folder icons across disk, share, device, and pool views.
  * Enhanced pool status display with separate controls for checking status vs viewing pool details.
* **Bug Fixes**
  * Improved directory path validation and navigation for symlinked “exclusive shares,” strengthening allowlist behavior around `/mnt` and `/boot`.
* **Style**
  * Updated link markup and visual styling (muted icons/text by default, brighter hover states) for a cleaner UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->