### PR TITLE
feat(pr-plugin): restart patched nchan publishers on install/remove

### DIFF
--- a/.github/scripts/generate-pr-plugin.sh
+++ b/.github/scripts/generate-pr-plugin.sh
@@ -256,6 +256,22 @@ if [ -f "$PAYLOAD/modes.txt" ]; then
     echo "✅ File modes restored"
 fi
 
+# ---- Restart patched nchan publishers --------------------------------------
+# nchan publishers (scripts under .../nchan/) are long-running loops. The running
+# process keeps executing the OLD script after we patch it on disk - and a browser
+# reload won't fix it, because DefaultPageLayout only (re)launches a publisher that
+# is NOT already running. So a patched publisher would keep streaming stale output
+# until every tab closes and monitor_nchan idle-reaps it. Kill the ones this PR
+# touched; DefaultPageLayout respawns them with the new code on the next page load.
+# Safe: monitor_nchan kills these routinely, and subscribers stay connected and
+# resume from the respawned publisher (matches the ResetTZ.php reload pattern).
+if [ -s "$PAYLOAD/text_files.txt" ]; then
+    grep -aoE '/nchan/[^/]+$' "$PAYLOAD/text_files.txt" 2>/dev/null | sed 's#^/##' | sort -u | while IFS= read -r rel; do
+        [ -n "$rel" ] || continue
+        if pkill -f "$rel" 2>/dev/null; then echo "Restarted nchan publisher: $rel"; fi
+    done
+fi
+
 echo ""
 echo "✅ Installation complete for PR #PR_PLACEHOLDER"
 echo "⚠️  This is a TEST plugin — remove it before applying production updates"
@@ -349,6 +365,13 @@ if [ -f "$PLUGIN_DIR/text_files.txt" ]; then
             echo "⚠️  Warning: could not re-apply $(basename "$other")'s changes; reinstall it or reboot to restore them"
             logger -t webgui-pr "re-apply of $(basename "$other") patch failed during $(basename "$PLUGIN_DIR") rollback"
         fi
+    done
+    # Restart any nchan publishers this PR patched so the live process drops the
+    # patched code and respawns from the restored original on the next page load
+    # (long-running publishers don't pick up the on-disk change until killed).
+    grep -aoE '/nchan/[^/]+$' "$PLUGIN_DIR/text_files.txt" 2>/dev/null | sed 's#^/##' | sort -u | while IFS= read -r rel; do
+        [ -n "$rel" ] || continue
+        if pkill -f "$rel" 2>/dev/null; then echo "Restarted nchan publisher: $rel"; fi
     done
     echo "✅ Text changes restored"
 fi


### PR DESCRIPTION
## Summary

PR test plugins patch files in place, but **nchan publishers** (the long-running loops under `.../nchan/`, e.g. `device_list`) keep executing the **old** script after the patch lands. A browser reload doesn't fix it: `DefaultPageLayout` only (re)launches a publisher that isn't already running ([DefaultPageLayout.php:83-86](emhttp/plugins/dynamix/include/DefaultPageLayout.php)), so a patched publisher streams stale output until every tab closes and `monitor_nchan` idle-reaps it. Net effect: nchan-script changes look like they didn't apply.

This adds a **scoped publisher restart** to the generated plugin's install and remove scripts ([.github/scripts/generate-pr-plugin.sh](.github/scripts/generate-pr-plugin.sh)):

- **Install:** after the patch is applied, kill the publishers this PR actually touched (derived from the payload's `text_files.txt`). `DefaultPageLayout` respawns them with the new code on the next page navigation.
- **Remove:** after originals are restored, kill the same publishers so the live process drops the patched code and respawns from the restored original.

Matched on `.../nchan/<script>` so it works whether the publisher was launched via the `webGui` symlink or the `plugins/dynamix` path.

## Why this, and not a forced reader/nginx restart

This is the safe, targeted alternative. Killing pollers is exactly what `monitor_nchan` does routinely; subscribers keep their `/sub` connection and resume from the respawned publisher (same approach as [ResetTZ.php:23-26](emhttp/plugins/dynamix/include/ResetTZ.php)). Forcing nginx/subscriber drops would instead tear down every live connection for every session on the box, can truncate in-flight nchan-backed streams (flash-backup download, file-manager job progress), and *still* wouldn't reload page templates/JS — a bad trade.

**Known limit (unchanged):** patched `.page` templates and client JS still require a normal browser reload — the server can't force already-loaded tabs to reload. This change removes the separate case where even a reload silently no-ops because a stale publisher is still alive.

## Testing

- `bash -n` clean on the generator.
- Generated a sample plugin and `bash -n`'d every embedded INLINE block (install/update/remove) — all pass.
- Verified the `text_files.txt` extraction selects only `nchan/*` scripts (ignores `.php`/`.page`/`.css`) and that the `pkill -f` pattern matches both the `webGui/nchan/...` and `plugins/dynamix/nchan/...` launch forms.
- Not yet exercised through a real CI build + on-server install (draft until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)