### PR TITLE
fix(vm-manager): guard qemu location lookup output

### DIFF
--- a/emhttp/plugins/dynamix.vm.manager/scripts/qemu.php
+++ b/emhttp/plugins/dynamix.vm.manager/scripts/qemu.php
@@ -15,7 +15,7 @@ function detect_user_share(&$arg) {
   $arg = preg_replace_callback('|(/mnt/user/[^,"]+\.[^,"\s]*)|', function($match) {
     if (is_file($match[0])) {
       // resolve the actual disk or cache backing device for this user share path
-      $realdisk = trim(shell_exec("getfattr --absolute-names --only-values -n system.LOCATION ".escapeshellarg($match[0])." 2>/dev/null"));
+      $realdisk = trim(shell_exec("getfattr --absolute-names --only-values -n system.LOCATION ".escapeshellarg($match[0])." 2>/dev/null") ?? '');
       if (!empty($realdisk)) {
         $replacement = str_replace('/mnt/user/', "/mnt/$realdisk/", $match[0]);
         if (is_file($replacement)) {


### PR DESCRIPTION
## Summary

VM launch path translation now treats missing `getfattr` output as an empty location so PHP 8.4 does not log deprecation noise while preserving the existing fallback behavior.

## Why This Exists

The VM manager `qemu.php` hook asks shfs for a `system.LOCATION` value before replacing `/mnt/user/...` paths with their backing disk or pool path. When that attribute lookup returns no output, `shell_exec()` can return `null`; passing that directly into `trim()` emits a PHP 8.4 deprecation warning during VM startup.

## Resolution

Coalesce the `shell_exec()` result to an empty string before trimming it. This keeps the existing `empty($realdisk)` fallback path intact when no location is available.

## Reviewer Considerations

* Confirm that preserving the original `/mnt/user/...` argument is still the right fallback when no `system.LOCATION` value is returned.
* The command and xattr name are unchanged; only the handling of no-output results changes.

## Behavior Changes

VM startup should no longer emit a PHP deprecation warning when the location lookup produces no output. Path translation behavior is otherwise unchanged.

## Implementation Summary

* Guard the `qemu.php` `shell_exec()` result with `?? ''` before `trim()`.

## Verification

* `git diff --check`
* Dev-container PHP syntax lint: `php -l emhttp/plugins/dynamix.vm.manager/scripts/qemu.php`
* Target PHP 8.4 expression check: `trim(null ?? "") === ""` returned `true`.

## Risk

Low; the change only normalizes a no-output command result to the empty string path the existing logic already treats as no replacement.

[OS-480](https://linear.app/lime-technology/issue/OS-480/vm-manager-logs-php-deprecation-when-qemu-location-lookup-returns-no)