### PR TITLE
feat(os-update): add generic 'os_update' pre-reboot event for plugins (OS-486)

### DIFF
--- a/emhttp/plugins/unRAIDServer/unRAIDServer.plg
+++ b/emhttp/plugins/unRAIDServer/unRAIDServer.plg
@@ -378,7 +378,9 @@ fi
 new_kernel=$(awk '/[Ll]inux kernel/{f=3} f>0{if(match($0,/[0-9]+(\.[0-9]+)+/)){print substr($0,RSTART,RLENGTH);exit}f--}' /boot/changes.txt 2>/dev/null | head -1)
 if [ -n "$new_kernel" ]; then new_kernel="${new_kernel}-Unraid"; fi
 if [ -x /usr/local/sbin/emhttp_event ]; then
-  /usr/local/sbin/emhttp_event os_update "&version;" "$new_kernel"
+  # Bound the whole dispatch so a wedged hook cannot stall the update forever;
+  # a hook that needs longer should background itself and notify (see emhttp_event).
+  timeout 300 /usr/local/sbin/emhttp_event os_update "&version;" "$new_kernel"
 fi
 # ensure writes to USB flash boot device have completed
 sync -f /boot

--- a/emhttp/plugins/unRAIDServer/unRAIDServer.plg
+++ b/emhttp/plugins/unRAIDServer/unRAIDServer.plg
@@ -366,13 +366,15 @@ rm -f /boot/config/plugins/dynamix.plg
 if [[ -x /usr/local/emhttp/plugins/unraid.patch/scripts/patch.php ]]; then
   /usr/local/emhttp/plugins/unraid.patch/scripts/patch.php check &version;
 fi
-# Fire the 'os_update' event so kernel-dependent plugins (out-of-tree driver
-# plugins, etc.) can stage a build matching the INCOMING kernel before reboot.
-# The new release files - including changes.txt - are already on the flash here,
-# so the incoming kernel release can be read from it. Hooks run synchronously,
-# so the reboot prompt below only appears once they have finished. This is the
-# generic, self-registering replacement for hardcoded third-party helpers: a
-# plugin just installs an executable at its event/os_update path.
+# Fire the generic 'os_update' event: a pre-reboot hook for an OS update that
+# any plugin can register for (config migration, backups, compatibility checks
+# and - for out-of-tree driver plugins - staging a build matching the INCOMING
+# kernel so a reboot never lands on a kernel without its driver). The new release
+# files - including changes.txt - are already on the flash here; pass the
+# incoming Unraid version and kernel release as context (consumers ignore what
+# they do not need). Hooks run synchronously, so the reboot prompt below only
+# appears once they have finished. Self-registering: a plugin just installs an
+# executable at its event/os_update path - no hardcoded list.
 new_kernel=$(awk '/[Ll]inux kernel/{f=3} f>0{if(match($0,/[0-9]+(\.[0-9]+)+/)){print substr($0,RSTART,RLENGTH);exit}f--}' /boot/changes.txt 2>/dev/null | head -1)
 if [ -n "$new_kernel" ]; then new_kernel="${new_kernel}-Unraid"; fi
 if [ -x /usr/local/sbin/emhttp_event ]; then

--- a/emhttp/plugins/unRAIDServer/unRAIDServer.plg
+++ b/emhttp/plugins/unRAIDServer/unRAIDServer.plg
@@ -366,6 +366,18 @@ rm -f /boot/config/plugins/dynamix.plg
 if [[ -x /usr/local/emhttp/plugins/unraid.patch/scripts/patch.php ]]; then
   /usr/local/emhttp/plugins/unraid.patch/scripts/patch.php check &version;
 fi
+# Fire the 'os_update' event so kernel-dependent plugins (out-of-tree driver
+# plugins, etc.) can stage a build matching the INCOMING kernel before reboot.
+# The new release files - including changes.txt - are already on the flash here,
+# so the incoming kernel release can be read from it. Hooks run synchronously,
+# so the reboot prompt below only appears once they have finished. This is the
+# generic, self-registering replacement for hardcoded third-party helpers: a
+# plugin just installs an executable at its event/os_update path.
+new_kernel=$(awk '/[Ll]inux kernel/{f=3} f>0{if(match($0,/[0-9]+(\.[0-9]+)+/)){print substr($0,RSTART,RLENGTH);exit}f--}' /boot/changes.txt 2>/dev/null | head -1)
+if [ -n "$new_kernel" ]; then new_kernel="${new_kernel}-Unraid"; fi
+if [ -x /usr/local/sbin/emhttp_event ]; then
+  /usr/local/sbin/emhttp_event os_update "&version;" "$new_kernel"
+fi
 # ensure writes to USB flash boot device have completed
 sync -f /boot
 if [ -z "${plg_update_helper}" ]; then

--- a/sbin/emhttp_event
+++ b/sbin/emhttp_event
@@ -79,6 +79,16 @@
 #   Note that if array is not Started, emhttpd will not spin down any disk, but emhttpd will
 #   still poll SMART data (for spun-up devices) and generate this event.
 
+# os_update
+#   Occurs during an Unraid OS update, after the new release files (including
+#   /boot/changes.txt) have been written to the flash but BEFORE the user reboots.
+#   Fired by the unRAIDServer plugin, not by emhttpd. Lets kernel-dependent
+#   plugins (e.g. out-of-tree driver plugins) stage a build matching the INCOMING
+#   kernel before reboot, so a reboot never lands on a kernel without a driver.
+#   Extra arguments: $2 = incoming Unraid version, $3 = incoming kernel release
+#   (uname -r form, e.g. 6.18.33-Unraid; empty if it could not be determined).
+#   Hooks run synchronously - keep them quick and use network timeouts.
+
 # Invoke all 'any_event' scripts that might exist
 for Dir in /usr/local/emhttp/plugins/* ; do
   if [ -d $Dir/event/any_event ]; then

--- a/sbin/emhttp_event
+++ b/sbin/emhttp_event
@@ -90,7 +90,10 @@
 #   Extra arguments, passed as context (ignore if not needed): $2 = incoming
 #   Unraid version, $3 = incoming kernel release (uname -r form, e.g.
 #   6.18.33-Unraid; empty if it could not be determined).
-#   Hooks run synchronously - keep them quick and use network timeouts.
+#   Hooks run synchronously and the whole dispatch is bounded by a timeout, so
+#   keep them quick and use network timeouts. A hook that genuinely needs long
+#   or async work should fork itself, return promptly, and surface its own result
+#   via notify - rather than blocking the OS update.
 
 # Invoke all 'any_event' scripts that might exist
 for Dir in /usr/local/emhttp/plugins/* ; do

--- a/sbin/emhttp_event
+++ b/sbin/emhttp_event
@@ -82,11 +82,14 @@
 # os_update
 #   Occurs during an Unraid OS update, after the new release files (including
 #   /boot/changes.txt) have been written to the flash but BEFORE the user reboots.
-#   Fired by the unRAIDServer plugin, not by emhttpd. Lets kernel-dependent
-#   plugins (e.g. out-of-tree driver plugins) stage a build matching the INCOMING
-#   kernel before reboot, so a reboot never lands on a kernel without a driver.
-#   Extra arguments: $2 = incoming Unraid version, $3 = incoming kernel release
-#   (uname -r form, e.g. 6.18.33-Unraid; empty if it could not be determined).
+#   Fired by the unRAIDServer plugin, not by emhttpd. A general pre-reboot hook
+#   for an OS update: any plugin can run work that must happen before rebooting
+#   into the new release - e.g. migrate/convert config, back something up, warn
+#   about an incompatibility, or (for out-of-tree driver plugins) stage a build
+#   matching the incoming kernel so the reboot never lands on a kernel without it.
+#   Extra arguments, passed as context (ignore if not needed): $2 = incoming
+#   Unraid version, $3 = incoming kernel release (uname -r form, e.g.
+#   6.18.33-Unraid; empty if it could not be determined).
 #   Hooks run synchronously - keep them quick and use network timeouts.
 
 # Invoke all 'any_event' scripts that might exist


### PR DESCRIPTION
## Why

When Unraid updates the OS, the new release ships a new kernel but the box keeps running the old one until reboot. Out-of-tree driver plugins (WiFi, GPU, NIC, …) build per-kernel modules, so a reboot can land on a kernel with **no matching driver** — fatal for, e.g., a headless server whose only link is a USB WiFi adapter.

Today the only mitigation is hardwired in `unRAIDServer.plg`: it greps for a running `inotifywait -q /boot/changes.txt …` process and, if found, force-downloads + runs **ich777's `plugin_update_helper`**, which carries a **hardcoded list** of ~22 supported plugins and is not extensible.

## What

Add a generic, self-registering **`os_update`** event, dispatched through the existing `emhttp_event` mechanism:

- `unRAIDServer.plg` fires `os_update` after the new release files (incl. `changes.txt`) are on the flash but **before** the reboot prompt, passing the incoming Unraid version (`$2`) and kernel release (`$3`, `uname -r` form parsed from `changes.txt`).
- `sbin/emhttp_event` documents the new event.

Any plugin can then drop an executable at `…/event/os_update` to stage a kernel-matched build. Hooks run **synchronously**, so "PLEASE REBOOT" only appears once they finish — no separate "wait for a notification" gate.

## Notes

- **Additive + backward compatible:** the existing ich777 `inotifywait` detection and messaging are untouched.
- **Not auto-update:** the event fires only during a user-initiated OS update. The webgui change downloads nothing itself — it runs only already-installed plugin hooks (which already run as root at boot). Strictly more conservative than the current `wget … | at now` of ich777's helper.
- Reference consumer: the `unraid-rtl8821au` driver plugin migrates to `event/os_update` (separate repo).

## Test

- `xmllint` clean on `unRAIDServer.plg`; `bash -n` clean on the resolved install block and `emhttp_event`.
- End-to-end sim: kernel parsed from a realistic `changes.txt` → `emhttp_event os_update` → sample `event/os_update` hook receives `(os_update, <version>, 6.19.2-Unraid)`; plugins without the hook are skipped.

Resolves OS-486.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OS updates now trigger an additional pre-reboot `os_update` event so supporting components can prepare before the system restarts.
  * The event includes the detected incoming Linux kernel identifier when available, built into an Unraid-specific version string.

* **Bug Fixes**
  * Update hooks now safely handle situations where the kernel identifier can’t be determined and won’t run if the event helper isn’t present.
  * The hook runs synchronously but is protected by a timeout to prevent hangs from blocking the update flow.

* **Documentation**
  * Added clear in-file documentation for the `os_update` event timing and arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->