### PR TITLE
update.php fixes (OS-490)

### DIFF
--- a/emhttp/update.php
+++ b/emhttp/update.php
@@ -114,7 +114,7 @@ if (isset($_POST['#command'])) {
   if (strpos($command, $docroot) !== 0)
     $command = "$docroot/$command";
   $command = realpath($command);
-  if ($command === false)
+  if ($command === false || strpos($command, rtrim(realpath($docroot), '/') . '/') !== 0)
     syslog(LOG_INFO, "Invalid #command: {$_POST['#command']}");
   else {
     $command = escapeshellcmd($command);


### PR DESCRIPTION
Restrict `update.php` `#file` writes to the expected configuration roots (`/boot/config`, `/etc/wireguard`) so a write cannot land outside config storage via an absolute path or `..`.

- Resolve the target with `realpath()` (collapsing `..`/symlinks) and range-check it with a shared `in_safe_path()` helper.
- Promote `in_safe_path()` into `Wrappers.php` so `update.php` and `FileUpload.php` share one implementation (drops the duplicate copy in `FileUpload.php`).
- Add a regression test that drives the real `update.php` and asserts out-of-root targets are refused while legitimate `/boot/config` writes still succeed.

Relative `#file` paths are unaffected (still placed under `/boot/config/plugins/`).

## Linear

- OS-490
