### PR TITLE
fix(shares): allow setting Emptying disk(s) while array is Started

### DIFF
--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -1553,6 +1553,13 @@ Uncheck all disks in order to not exclude any disks
 disks which represent a subset of the Included/Excluded disks defined here.
 :end
 
+:shares_emptying_disks_help:
+This setting designates array disk(s) that are being *emptied* of User Share data,
+typically as a prelude to removing the disk(s) from the array.
+
+Unlike the other Global Share Settings, this setting may be changed while the array is **Started**.
+:end
+
 :shares_exclusive_shares_help:
 If set to Yes, share directories under /mnt/user are actually symlinks to the share directory on a storage volume
 provided the following conditions are met:

--- a/emhttp/plugins/dynamix/ShareSettings.page
+++ b/emhttp/plugins/dynamix/ShareSettings.page
@@ -18,6 +18,9 @@ Tag="share-alt"
 ?>
 <?
 $disabled = _var($var,'fsState')!='Stopped' ? 'disabled' : '';
+/* The "Emptying disk(s)" setting is accepted by emhttpd while the array is Started,
+   so it is not gated on array state - only on user shares being enabled. */
+$emptyingDisabled = _var($var,'shareUser')=='-' ? 'disabled' : '';
 $disks    = array_filter($disks,'my_disks');
 $width    = [166,300];
 
@@ -101,10 +104,13 @@ function presetShare(form,shares) {
   var onOff = disabled ? 'disable':'enable';
   form.shareUserInclude.disabled = disabled;
   form.shareUserExclude.disabled = disabled;
-  form.shareUserEmptying.disabled = disabled;
   $('#s1').dropdownchecklist(onOff);
   $('#s2').dropdownchecklist(onOff);
-  $('#s3').dropdownchecklist(onOff);
+  /* Emptying disk(s) can be changed while the array is Started - emhttpd accepts it.
+     Only disable it when user shares are turned off. */
+  var emptyingDisabled = shares==null ? <?=$emptyingDisabled ? 'true':'false'?> : shares=='-';
+  form.shareUserEmptying.disabled = emptyingDisabled;
+  $('#s3').dropdownchecklist(emptyingDisabled ? 'disable':'enable');
 }
 </script>
 <form markdown="1" name="share_settings" method="POST" action="/update.htm" target="progressFrame" onsubmit="return prepareShare(this)">
@@ -189,5 +195,5 @@ _(Number of fuse File Descriptors)_:
     <input type="submit" name="changeShare" value="_(Apply)_" disabled>
     <input type="button" value="_(Done)_" onclick="done()">
   </span>
-<?if ($disabled):?>*_(Array must be **Stopped** to change)_*<?endif;?>
+<?if ($disabled):?>*_(Array must be **Stopped** to change these settings, except **Emptying disk(s)**)_*<?endif;?>
 </form>

--- a/emhttp/plugins/dynamix/ShareSettings.page
+++ b/emhttp/plugins/dynamix/ShareSettings.page
@@ -64,18 +64,6 @@ async function prepareShare(form) {
   item.value = exclude;
   item.selected = true;
 
-  var emptying = '';
-  for (var i=0,item; item=form.shareUserEmptying.options[i]; i++) {
-    if (item.selected) {
-      if (emptying.length) emptying += ',';
-      emptying += item.value;
-      item.selected = false;
-    }
-  }
-  item = form.shareUserEmptying.options[0];
-  item.value = emptying;
-  item.selected = true;
-
   /* Validate file count input against fileMax */
   try {
     const fileCountInput = form.querySelector('#file_count');
@@ -99,6 +87,22 @@ async function prepareShare(form) {
   return true;
 }
 
+/* Collapse the Emptying disk(s) multi-select into a single value before submit. */
+function prepareEmptying(form) {
+  var emptying = '';
+  for (var i=0,item; item=form.shareUserEmptying.options[i]; i++) {
+    if (item.selected) {
+      if (emptying.length) emptying += ',';
+      emptying += item.value;
+      item.selected = false;
+    }
+  }
+  item = form.shareUserEmptying.options[0];
+  item.value = emptying;
+  item.selected = true;
+  return true;
+}
+
 function presetShare(form,shares) {
   var disabled = shares==null ? <?=$disabled ? 'true':'false'?> : shares=='-';
   var onOff = disabled ? 'disable':'enable';
@@ -106,10 +110,10 @@ function presetShare(form,shares) {
   form.shareUserExclude.disabled = disabled;
   $('#s1').dropdownchecklist(onOff);
   $('#s2').dropdownchecklist(onOff);
-  /* Emptying disk(s) can be changed while the array is Started - emhttpd accepts it.
-     Only disable it when user shares are turned off. */
+  /* Emptying disk(s) lives in its own form so it can be changed while the array is
+     Started - emhttpd accepts it. Only disable it when user shares are turned off. */
   var emptyingDisabled = shares==null ? <?=$emptyingDisabled ? 'true':'false'?> : shares=='-';
-  form.shareUserEmptying.disabled = emptyingDisabled;
+  document.share_emptying.shareUserEmptying.disabled = emptyingDisabled;
   $('#s3').dropdownchecklist(emptyingDisabled ? 'disable':'enable');
 }
 </script>
@@ -150,15 +154,6 @@ _(Excluded disk(s))_:
 
 :shares_excluded_disks_help:
 
-_(Emptying disk(s))_:
-: <select id="s3" name="shareUserEmptying" multiple="multiple" style="display:none">
-  <?foreach ($disks as $disk):?>
-  <?=mk_option_luks(_var($disk,'name'),_var($var,'shareUserEmptying'),strstr(_var($disk,'fsType'),':',true))?>
-  <?endforeach;?>
-  </select>
-
-:shares_emptying_disks_help:
-
 _(Permit exclusive shares)_:
 : <select name="shareUserExclusive" <?=$disabled?>>
   <?=mk_option($var['shareUserExclusive'], "no", _('No'))?>
@@ -195,5 +190,23 @@ _(Number of fuse File Descriptors)_:
     <input type="submit" name="changeShare" value="_(Apply)_" disabled>
     <input type="button" value="_(Done)_" onclick="done()">
   </span>
-<?if ($disabled):?>*_(Array must be **Stopped** to change these settings, except **Emptying disk(s)**)_*<?endif;?>
+<?if ($disabled):?>*_(Array must be **Stopped** to change)_*<?endif;?>
+</form>
+
+<form markdown="1" name="share_emptying" method="POST" action="/update.htm" target="progressFrame" onsubmit="return prepareEmptying(this)">
+
+_(Emptying disk(s))_:
+: <select id="s3" name="shareUserEmptying" multiple="multiple" style="display:none">
+  <?foreach ($disks as $disk):?>
+  <?=mk_option_luks(_var($disk,'name'),_var($var,'shareUserEmptying'),strstr(_var($disk,'fsType'),':',true))?>
+  <?endforeach;?>
+  </select>
+
+:shares_emptying_disks_help:
+
+&nbsp;
+: <span class="inline-block">
+    <input type="submit" name="changeShare" value="_(Apply)_" disabled>
+    <input type="button" value="_(Done)_" onclick="done()">
+  </span>
 </form>


### PR DESCRIPTION
## Summary

The **Global Share Settings** page locked every control whenever the array was not `Stopped`, including **Emptying disk(s)** (`shareUserEmptying`) — even though `emhttpd` accepts the emptying command at runtime and does not require the array to be stopped.

This **splits "Emptying disk(s)" into its own form** at the bottom of the page (mirroring the two-form pattern already used in `NFS.page`), so it can be changed independently while the array is Started. The main settings form remains fully locked while the array is not Stopped.

## Why a separate form (vs. one form)

The page is a single markdown definition-list form and "Emptying disk(s)" sat in the middle of the stop-required settings. A dedicated form:

- posts **only** `shareUserEmptying` to `/update.htm` — no reliance on "disabled fields aren't submitted"
- has its own Apply button and explicit, self-documenting submit semantics
- stays editable while the array is Started, gated only on user shares being enabled

## Changes

- **`emhttp/plugins/dynamix/ShareSettings.page`**
  - New `share_emptying` form at the bottom with the "Emptying disk(s)" control + its own Apply (posts to `/update.htm` with `changeShare`, identical backend path to the existing form).
  - `prepareEmptying()` collapses the multi-select for submit; emptying collapse removed from `prepareShare()`.
  - `presetShare()` gates the emptying control only on user shares being enabled (not array state).
  - Main form footer note reverted to the original "Array must be **Stopped** to change".
- **`emhttp/languages/en_US/helptext.txt`**
  - Added the previously missing `:shares_emptying_disks_help:` entry.

## Testing

- Array **Started**: main settings locked; "Emptying disk(s)" editable; selecting a disk enables its Apply; applying writes only `shareUserEmptying`.
- Array **Stopped**: all settings editable, unchanged behavior.
- User shares = **No**: "Emptying disk(s)" disabled (nothing to empty).

## Linear

Resolves OS-495 — https://linear.app/lime-technology/issue/OS-495