### PR TITLE
feat(docker): attach containers to multiple custom networks (OS-503)

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -224,6 +224,7 @@ if (isset($_POST['contName'])) {
   }
   if ($startContainer) $cmd = str_replace('/docker create ', '/docker run -d ', $cmd);
   execCommand($cmd);
+  connectExtraNetworks($Name, $_POST['contExtraNetworks'] ?? '', $_POST['contNetwork'] ?? '', true);
   if ($startContainer) addRoute($Name); // add route for remote WireGuard access
 
   dockerUIBlockerScript(false);
@@ -302,6 +303,7 @@ if (isset($_GET['updateContainer'])){
       exec("/usr/local/emhttp/plugins/dynamix.docker.manager/scripts/docker rm '" . escapeshellarg($Name) . "'");
     }
     execCommand($cmd, $echo);
+    connectExtraNetworks($Name, getXmlVal($xml, "ExtraNetworks"), $Network, $echo);
     if ($startContainer) addRoute($Name); // add route for remote WireGuard access
     $DockerClient->flushCaches();
     $newImageID = $DockerClient->getImageID($Repository);
@@ -1181,6 +1183,16 @@ _(Network Type)_:
   ?>
   <?=mk_option(1,$network,_('Custom')." : $name")?>
   <?endforeach;?></select>
+
+_(Additional Networks)_:
+: <select name="contExtraNetworks[]" multiple size="4">
+  <?php $extraNets = isset($xml['ExtraNetworks']) ? preg_split('/[\s,]+/', trim($xml['ExtraNetworks']), -1, PREG_SPLIT_NO_EMPTY) : []; ?>
+  <?foreach ($custom as $network):?>
+  <?php if (in_array($network, ['host','none','bridge','container'])) continue; ?>
+  <option value="<?=htmlspecialchars($network)?>"<?=in_array($network,$extraNets)?' selected':''?>><?=htmlspecialchars($network)?></option>
+  <?endforeach;?></select>
+
+> _(Attach the container to more custom networks in addition to the primary Network Type above. Applied with `docker network connect` after creation. Hold Ctrl/Cmd to select several.)_
 
 <div markdown="1" class="myIP noshow">
 _(Fixed IP address)_ (_(optional)_):

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -955,6 +955,8 @@ $(function() {
     load_contOverview();
     $("#catSelect").dropdownchecklist("destroy");
     $("#catSelect").dropdownchecklist({emptyText:"_(Select categories)_...", maxDropHeight:200, width:300, explicitClose:"..._(close)_"});
+    $("#contExtraNetworks").dropdownchecklist("destroy");
+    $("#contExtraNetworks").dropdownchecklist({emptyText:"_(None)_", maxDropHeight:200, width:300, explicitClose:"..._(close)_"});
   });
 });
 </script>
@@ -1185,14 +1187,14 @@ _(Network Type)_:
   <?endforeach;?></select>
 
 _(Additional Networks)_:
-: <select name="contExtraNetworks[]" multiple size="4">
+: <select id="contExtraNetworks" name="contExtraNetworks[]" multiple="multiple" style="display:none">
   <?php $extraNets = isset($xml['ExtraNetworks']) ? preg_split('/[\s,]+/', trim($xml['ExtraNetworks']), -1, PREG_SPLIT_NO_EMPTY) : []; ?>
   <?foreach ($custom as $network):?>
   <?php if (in_array($network, ['host','none','bridge','container'])) continue; ?>
   <option value="<?=htmlspecialchars($network)?>"<?=in_array($network,$extraNets)?' selected':''?>><?=htmlspecialchars($network)?></option>
   <?endforeach;?></select>
 
-> _(Attach the container to more custom networks in addition to the primary Network Type above. Applied with `docker network connect` after creation. Hold Ctrl/Cmd to select several.)_
+> _(Attach the container to more custom networks in addition to the primary Network Type above. Applied with `docker network connect` after creation. Use the checkbox dropdown to select one or more additional networks.)_
 
 <div markdown="1" class="myIP noshow">
 _(Fixed IP address)_ (_(optional)_):
@@ -2031,6 +2033,8 @@ $(function() {
   $('.switch-on-off').switchButton({labels_placement:'right',on_label:"_(On)_",off_label:"_(Off)_"});
   // Add dropdownchecklist to Select Categories
   $("#catSelect").dropdownchecklist({emptyText:"_(Select categories)_...", maxDropHeight:200, width:300, explicitClose:"..._(close)_"});
+  // Add dropdownchecklist to Additional Networks
+  $("#contExtraNetworks").dropdownchecklist({emptyText:"_(None)_", maxDropHeight:200, width:300, explicitClose:"..._(close)_"});
   <?if ($authoringMode){
     echo "$('.advancedview').prop('checked','true'); $('.advancedview').change();";
     echo "$('.advancedview').siblings('.switch-button-background').click();";

--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -134,6 +134,11 @@ function postToXML($post, $setOwnership=false) {
   } else {
     $xml->Network                  = xml_encode($post['contNetwork']);
   }
+  // Additional networks the container is attached to after creation (docker
+  // network connect). Stored comma-separated; the primary <Network> is excluded.
+  $extraNetworks = $post['contExtraNetworks'] ?? '';
+  if (is_array($extraNetworks)) $extraNetworks = implode(',', $extraNetworks);
+  $xml->ExtraNetworks              = xml_encode(trim($extraNetworks));
   $xml->MyIP                       = xml_encode($post['contMyIP']);
   $extraNetwork                    = hasNetworkParam($post['contExtraParams'] ?? '');
   $myMAC                           = $extraNetwork ? '' : normalizeMacAddress(trim($post['contMyMAC'] ?? '') ?: extractMacAddressParam($post['contExtraParams'] ?? ''));
@@ -211,6 +216,7 @@ function xmlToVar($xml) {
   $out['Repository']                   = xml_decode($xml->Repository);
   $out['Registry']                     = xml_decode($xml->Registry);
   $out['Network']                      = xml_decode($xml->Network);
+  $out['ExtraNetworks']                = xml_decode($xml->ExtraNetworks ?? '');
   $out['MyIP']                         = xml_decode($xml->MyIP ?? '');
   $extraParams                         = xml_decode($xml->ExtraParams ?? '');
   $extraNetwork                        = hasNetworkParam($extraParams);
@@ -566,6 +572,32 @@ function xmlToCommand($xml, $create_paths=false) {
          $cmdName, $TS_entrypoint, $cmdNetwork, $cmdMyIP, $cmdCPUset, $pid_limit, $cmdPrivileged, implode(' -e ', $Variables), $TS_hostname, $TS_exitnode, $TS_exitnode_ip, $TS_lan_access, $TS_routes, $TS_accept_routes, $TS_ssh, $TS_userspace_networking, $TS_serve_funnel, $TS_serve_port, $TS_serve_target, $TS_serve_local_path, $TS_serve_protocol, $TS_serve_protocol_port, $TS_serve_path, $TS_daemon_params, $TS_extra_params, $TS_state_dir, $TS_troubleshooting, $TS_postargs, implode(' -l ', $Labels), $TS_web_ui, $TS_hostname_label, implode(' -p ', $Ports), implode(' -v ', $Volumes), $TS_hook, $TS_cap, $TS_tundev, implode(' --device=', $Devices), $xml['ExtraParams'], escapeshellarg($xml['Repository']), $xml['PostArgs']);
   return [preg_replace('/\s\s+/', ' ', $cmd), $xml['Name'], $xml['Repository']];
 }
+
+// Attach a container to additional custom networks after it has been created.
+// `docker create/run` only accepts one --network, so extra networks (stored in
+// the template's <ExtraNetworks>, comma/space separated) are wired up here with
+// `docker network connect`. Idempotent and safe on both created and running
+// containers; the primary network is skipped so it is never double-connected.
+function connectExtraNetworks($name, $extra, $primary='', $echo=false) {
+  global $docroot;
+  if (is_array($extra)) $extra = implode(',', $extra);
+  if (!is_string($extra) || !strlen(trim($extra)) || !strlen(trim($name))) return;
+  $script = $docroot.'/plugins/dynamix.docker.manager/scripts/docker';
+  $done = [];
+  foreach (preg_split('/[\s,]+/', trim($extra)) as $net) {
+    $net = trim($net);
+    if (!strlen($net)) continue;
+    $key = strtolower($net);
+    if ($key == strtolower(trim($primary)) || isset($done[$key])) continue;
+    $done[$key] = true;
+    exec($script.' network connect '.escapeshellarg($net).' '.escapeshellarg($name).' 2>&1', $o, $rc);
+    if ($echo) {
+      $msg = $rc===0 ? _('Connected network') : _('Could not connect network');
+      echo "<script>addLog('<b>".addslashes(htmlspecialchars($msg.": $net"))."</b>');</script>\n"; @flush();
+    }
+  }
+}
+
 function stopContainer($name, $t=false, $echo=true) {
   global $DockerClient;
   $waitID = mt_rand();


### PR DESCRIPTION
## Problem
DockerMan templates can only express a single `<Network>`. A container that needs two custom networks (e.g. a reverse-proxy network *and* a service network) has to be `docker network connect`ed by hand, and that extra attachment is **lost on any UI recreate/update** — the container silently drops back to one network. This bites reverse-proxy sidecars, management tools, and anything bridging two isolated stacks.

## Approach
`docker create/run` only accepts one `--network`, so extra networks are attached with `docker network connect` *after* the container is created. A new optional `<ExtraNetworks>` template field (comma/space separated) drives it.

- **`Helpers.php`**
  - `postToXML` persists `<ExtraNetworks>` from the form
  - `xmlToVar` parses it
  - new `connectExtraNetworks()` — idempotent, skips the primary network, runs on created *and* running containers
- **`CreateDocker.php`**
  - create path: connects extras from the form POST after `execCommand`
  - update/recreate path: connects extras from the template (`getXmlVal`) after `execCommand`
  - editor UI: an **"Additional Networks"** multi-select of available custom networks

Backward compatible: absent/empty field = today's single-network behaviour.

## Testing (against live Docker on 7.x)
- `connectExtraNetworks` moved a real container `vanilla-net` → `appnet vanilla-net`; second call idempotent + correctly skipped the primary.
- `xmlToVar` path-parse → `ExtraNetworks=[appnet, proxynet]`; `postToXML`↔`xmlToVar` round-trips; update-path `getXmlVal` reads it.
- End-to-end payoff: a multi-homed container became reachable **by name** from a reverse proxy on the shared network (no host-IP workaround).
- `php -l` clean on both files.

## Follow-ups / review notes
- Editor UI wants a manual browser click-through (create → pick two networks → apply).
- Managed/orphan + "update ready" detection keys on image/template, not full network set, so multi-homing shouldn't cause false "not up to date" — worth a reviewer sanity check.

Targeting **7.4.0**.

## Linear

- OS-503
