### PR TITLE
docs: fix minor spelling and grammar typos in comments

### DIFF
--- a/emhttp/languages/en_US/helptext.txt
+++ b/emhttp/languages/en_US/helptext.txt
@@ -2750,7 +2750,7 @@ Select your default keymap for the local console (not the web Terminal).
 
 **Disabled:** 'Disabled' will disable the blank and powersave timeout.
 
-**All other values:** Will set the blank timout to the selected value and disable the powersave timeout.
+**All other values:** Will set the blank timeout to the selected value and disable the powersave timeout.
 :end
 
 :console_bash_help:

--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -666,7 +666,7 @@ function addConfigPopup() {
   var title = "_(Add Configuration)_";
   var popup = $("#dialogAddConfig");
 
-  // Load popup the popup with the template info
+  // Load the popup with the template info
   popup.html($("#templatePopupConfig").html());
 
   // Add switchButton to checkboxes
@@ -724,7 +724,7 @@ function editConfigPopup(num,disabled) {
   var title = "_(Edit Configuration)_";
   var popup = $("#dialogAddConfig");
 
-  // Load popup the popup with the template info
+  // Load the popup with the template info
   popup.html($("#templatePopupConfig").html());
 
   // Load existing config info

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -696,7 +696,7 @@ class DockerUpdate{
 					//$this->debug("Updating $name from [$value] to [$rvalue]");
 					$changed = true;
 				}
-			// Compare atributes on Config if they are in the validAttributes list
+			// Compare attributes on Config if they are in the validAttributes list
 			} elseif ($name == 'Config') {
 				$type   = $this->xml_decode($remote_element['Type']);
 				$target = $this->xml_decode($remote_element['Target']);
@@ -706,7 +706,7 @@ class DockerUpdate{
 				} else {
 					$local_element = $template->xpath("//Config[@Type='$type'][@Target='$target']")[0];
 				}
-				// If the local template already have the pertinent Config element, loop through it's attributes and update those on validAttributes
+				// If the local template already has the pertinent Config element, loop through its attributes and update those on validAttributes
 				if (!empty($local_element)) {
 					foreach ($remote_element->attributes() as $key => $value) {
 						$rvalue  = $this->xml_decode($value);
@@ -731,7 +731,7 @@ class DockerUpdate{
 			}
 		}
 		if ($changed) {
-			// Format output and save to file if there were any commited changes
+			// Format output and save to file if there were any committed changes
 			//$this->debug("Saving template modifications to '$file");
 			$dom = new DOMDocument('1.0');
 			$dom->preserveWhiteSpace = false;

--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -471,7 +471,7 @@ function xmlToCommand($xml, $create_paths=false) {
     $TS_extra_params = !empty($xml['TailscaleParams']) ? '-e TAILSCALE_PARAMS=' . escapeshellarg($xml['TailscaleParams']) : '';
     $TS_state_dir = !empty($xml['TailscaleStateDir']) ? '-e TAILSCALE_STATE_DIR=' . escapeshellarg($xml['TailscaleStateDir']) : '';
     $TS_userspace_networking = !empty($xml['TailscaleUserspaceNetworking']) ? '-e TAILSCALE_USERSPACE_NETWORKING=' . escapeshellarg($xml['TailscaleUserspaceNetworking']) : '';
-    // Only add tun, cap and specific vairables to containers which are defined as Exit Nodes and Userspace Networking disabled
+    // Only add tun, cap and specific variables to containers which are defined as Exit Nodes and Userspace Networking disabled
     if (_var($xml,'TailscaleIsExitNode') == 'true') {
       $TS_tundev = preg_match('/--d(evice)?[= ](\'?\/dev\/net\/tun\'?)/', $xml['ExtraParams']) ? "" : "--device='/dev/net/tun'";
       $TS_cap = preg_match('/--cap\-add=NET_ADMIN/', $xml['ExtraParams']) ? "" : "--cap-add=NET_ADMIN";

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -474,7 +474,7 @@ function fillAvailableHeight(params = { // default params
     return acc + totalForElement;
   }, 0);
 
-  // subtract addtional spacing from the target height to provide spacing between the actions & the footer
+  // subtract additional spacing from the target height to provide spacing between the actions & the footer
   targetHeight -= params.manualSpacingOffset || 10;
 
   const finalHeight = Math.max(targetHeight, minHeight);
@@ -507,9 +507,9 @@ $(document).on('mouseenter', 'a.info', function() {
     const aInfoPosition = $(this).offset();
     const scrollTop = $(window).scrollTop();
     const scrollLeft = $(window).scrollLeft();
-    const addtionalOffset = 16;
-    const top = aInfoPosition.top - scrollTop + addtionalOffset;
-    const left = aInfoPosition.left - scrollLeft + addtionalOffset;
+    const additionalOffset = 16;
+    const top = aInfoPosition.top - scrollTop + additionalOffset;
+    const left = aInfoPosition.left - scrollLeft + additionalOffset;
     tooltip.css({ top, left });
   }
 });

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/HeadInlineJS.php
@@ -40,7 +40,7 @@ var csrf_token = "<?=_var($var,'csrf_token')?>";
 // form has unsaved changes indicator
 var formHasUnsavedChanges = false;
 
-// docker progess indicators
+// docker progress indicators
 var progress_dots = [], progress_span = [];
 function pauseEvents(id) {
   $.each(timers, function(i,timer){

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/MainContentTabbed.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/MainContentTabbed.php
@@ -124,7 +124,7 @@ if (cookieVal) {
     const idx = Array.from(tabs).findIndex(tab => tab.id === cookieVal);
     if (idx !== -1) activeIdx = idx;
 } else {
-    // If no cookie exists, clear both cookies to match the origial initab function behavior
+    // If no cookie exists, clear both cookies to match the original initTab function behavior
     $.removeCookie('one');
     $.removeCookie('tab');
 }

--- a/emhttp/plugins/dynamix/include/Encryption.php
+++ b/emhttp/plugins/dynamix/include/Encryption.php
@@ -43,7 +43,7 @@ function base64_decrypt($pw) {
     if ($t[$i]==$b[$j]) $s .= $a[$j];
   }
   $s = base64_decode($s);
-  // return decrypted or plain password (backward compability)
+  // return decrypted or plain password (backward compatibility)
   return substr($s,0,16)==substr(md5($key),0,16) ? substr($s,16) : $pw;
 }
 

--- a/emhttp/plugins/dynamix/include/Markdown.php
+++ b/emhttp/plugins/dynamix/include/Markdown.php
@@ -1000,7 +1000,7 @@ class Markdown implements MarkdownInterface {
 			);
 
 		foreach ($markers_relist as $marker_re => $other_marker_re) {
-			// Re-usable pattern to match any entirel ul or ol list:
+			// Re-usable pattern to match any entire ul or ol list:
 			$whole_list_re = '
 				(								# $1 = whole list
 				  (								# $2
@@ -1294,7 +1294,7 @@ class Markdown implements MarkdownInterface {
 	 */
 	protected function doItalicsAndBold($text) {
 		if ($this->in_emphasis_processing) {
-			return $text; // avoid reentrency
+			return $text; // avoid reentrancy
 		}
 		$this->in_emphasis_processing = true;
 
@@ -1305,7 +1305,7 @@ class Markdown implements MarkdownInterface {
 		$tree_char_em = false;
 
 		while (1) {
-			// Get prepared regular expression for seraching emphasis tokens
+			// Get prepared regular expression for searching emphasis tokens
 			// in current context.
 			$token_re = $this->em_strong_prepared_relist["$em$strong"];
 
@@ -1749,8 +1749,8 @@ class Markdown implements MarkdownInterface {
 				}xs';
 
 		while (1) {
-			// Each loop iteration seach for either the next tag, the next
-			// openning code span marker, or the next escaped character.
+			// Each loop iteration search for either the next tag, the next
+			// opening code span marker, or the next escaped character.
 			// Each token is then passed to handleSpanToken.
 			$parts = preg_split($span_re, $str, 2, PREG_SPLIT_DELIM_CAPTURE);
 

--- a/emhttp/plugins/dynamix/include/MarkdownExtra.php
+++ b/emhttp/plugins/dynamix/include/MarkdownExtra.php
@@ -411,7 +411,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 
 		if ($text === '') return array('', '');
 
-		// Regex to check for the presense of newlines around a block tag.
+		// Regex to check for the presence of newlines around a block tag.
 		$newline_before_re = '/(?:^\n?|\n\n)*$/';
 		$newline_after_re =
 			'{
@@ -663,7 +663,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 				)
 			}xs';
 
-		$original_text = $text;		// Save original text in case of faliure.
+		$original_text = $text;		// Save original text in case of failure.
 
 		$depth		= 0;	// Current depth inside the tag tree.
 		$block_text	= "";	// Temporary text holder for current text.
@@ -684,7 +684,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 			$parts = preg_split($tag_re, $text, 2, PREG_SPLIT_DELIM_CAPTURE);
 
 			if ($parts === false || count($parts) < 3) {
-				// End of $text reached with unbalenced tag(s).
+				// End of $text reached with unbalanced tag(s).
 				// In that case, we return original text unchanged and pass the
 				// first character as filtered to prevent an infinite loop in the
 				// parent function.
@@ -1233,7 +1233,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$underline	= preg_replace('/[|] *$/m', '', $underline);
 		$content	= preg_replace('/[|] *$/m', '', $content);
 
-		// Reading alignement from header underline.
+		// Reading alignment from header underline.
 		$separators	= preg_split('/ *[|] */', $underline);
 		foreach ($separators as $n => $s) {
 			if (preg_match('/^ *-+: *$/', $s))

--- a/emhttp/plugins/dynamix/include/OpenTerminal.php
+++ b/emhttp/plugins/dynamix/include/OpenTerminal.php
@@ -50,7 +50,7 @@ case 'ttyd':
   $sock = "/var/run/ttyd.sock";
   exec('pgrep --ns $$ -f '."'$sock'", $ttyd_pid, $retval);
   if ($retval == 0) {
-    // check if there are any child processes, ie, curently open tty windows
+    // check if there are any child processes, ie, currently open tty windows
     exec('pgrep --ns $$ -P '.$ttyd_pid[0], $output, $retval);
     // no child processes, restart ttyd to pick up possible font size change
     if ($retval != 0) exec("kill ".$ttyd_pid[0]);

--- a/emhttp/plugins/dynamix/include/SysDevs.php
+++ b/emhttp/plugins/dynamix/include/SysDevs.php
@@ -138,7 +138,7 @@ case 't1':
     if (is_file("/boot/config/vfio-pci.cfg")) {
       // accepts space-separated list of <Bus:Device.Function> or <Domain:Bus:Device.Function> followed by an optional "|" and <Vendor:Device>
       // example: BIND=03:00.0 0000:03:00.0 03:00.0|8086:1533 0000:03:00.0|8086:1533
-      // this front-end does not accept <Vendor:Device> by itself, altough the underlying vfio-pci script does
+      // this front-end does not accept <Vendor:Device> by itself, although the underlying vfio-pci script does
       $file = file_get_contents("/boot/config/vfio-pci.cfg");
       $file = trim(str_replace("BIND=", "", $file));
       $file_contents = explode(" ", $file);

--- a/etc/rc.d/rc.S
+++ b/etc/rc.d/rc.S
@@ -235,7 +235,7 @@ if [[ $ROOT == "" ]]; then
   bzcheck "$BRANCH" "bzroot"		# rootfs, sans /lib/modules, /lib/firmware, and /usr
   bzcheck "$BRANCH" "bzfirmware"	# /lib/firmware
   bzcheck "$BRANCH" "bzmodules"		# /usr
-  bzcheck "$BRANCH" "bzroot-gui"	# /etc/inittab overrride
+  bzcheck "$BRANCH" "bzroot-gui"	# /etc/inittab override
 
   # mount squashfs file systems
   if [[ -f /boot/config/fastusr ]]; then

--- a/etc/rc.d/rc.inet1
+++ b/etc/rc.d/rc.inet1
@@ -75,11 +75,11 @@
 
 # Adapted by Bergware for use in Unraid OS - January 2025
 # - added 'renew' command to restart interface without reconfiguring
-# - fixed dns assigment may be missing in some cases
+# - fixed dns assignment may be missing in some cases
 
 # Adapted by Bergware for use in Unraid OS - February 2025
 # - added metric value to interface IP assignment
-# - fixed DNS entries get removed when configuring interface other then eth0
+# - fixed DNS entries get removed when configuring interface other than eth0
 
 # Adapted by Bergware for use in Unraid OS - May 2025
 # - improved metric value to interface IP assignment

--- a/etc/rc.d/rc.libvirt
+++ b/etc/rc.d/rc.libvirt
@@ -103,7 +103,7 @@ stop_running_machines(){
   # graceful shutdown of suspended VMs
   i=0; UUID=($(vmlist all))
   while IFS='\n' read -r STATE; do
-    # check explicitely for suspended VMs
+    # check explicitly for suspended VMs
     if [[ $STATE == pmsuspended ]]; then
       log "Stopping suspended VM: ${NAMES[${UUID[$i]}]}"
       virsh destroy ${UUID[$i]} --graceful &>/dev/null

--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -637,7 +637,7 @@ build_ssl(){
 
   # handle TS cert if present
   if [[ -f "$TSCERTPATH" ]]; then
-    # confirm TS is intalled and running
+    # confirm TS is installed and running
     if [[ -x $TS ]] && $TS status &>/dev/null; then
       # extract common name from cert
       TSFQDN1=$(openssl x509 -noout -subject -nameopt multiline -in "$TSCERTPATH" | sed -n 's/ *commonName *= //p')

--- a/etc/rc.d/rc.setterm
+++ b/etc/rc.d/rc.setterm
@@ -7,7 +7,7 @@
 # LimeTech - modified for Unraid OS
 # Bergware - modified for Unraid OS, October 2023
 
-# Read Unraid config file and set timout or fall back to default
+# Read Unraid config file and set timeout or fall back to default
 SCREEN_BLANK=$(grep "screen_blank" /boot/config/plugins/dynamix/dynamix.cfg 2>/dev/null | cut -d'=' -f2 | sed 's/"//g')
 if [[ $SCREEN_BLANK =~ ^[0-9]+$ ]]; then
   setterm --blank $SCREEN_BLANK --powersave off

--- a/ungrub/mkbootable
+++ b/ungrub/mkbootable
@@ -5,7 +5,7 @@
 # mkbootable add <device> <size>
 
 # Remove a missing device
-# mkbootable remove missing|<devoce>
+# mkbootable remove missing|<device>
 
 # Resize the device boot partition
 # mkbootable resize <device> <size>
@@ -52,7 +52,7 @@ configure_grub() {
 #  1 = BIOS Boot Partition (1 MiB, starting at 1 MiB offset from start of device)
 #  2 = EFI System Partition (510 MiB, immediately following partition 1)
 #  3 = Unraid Boot Partition (boot_size-512 MiB, immediately following partition 2)
-#  4 = Data Partition (rest of disk, immediately following partiton 3) at offset boot_size from start of device
+#  4 = Data Partition (rest of disk, immediately following partition 3) at offset boot_size from start of device
 #
 # the storage from beginning of disk to start of th Data partition is collectively called
 # the "boot area" with size "boot_size"


### PR DESCRIPTION
### Description
This pull request fixes a series of minor spelling and grammatical typos in source code comments, shell scripts, and help text. Cleaning up these documentation typos helps keep the codebase polished and readable.              
  
 ### Checklist
 - [x] Typos are verified against the surrounding context.
 - [x] All modifications are limited only to comments or local scripts variables, with no changes to functional code or public APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling, grammar, and wording across help text, usage guidance, and interface comments.
  * Clarified descriptions for timeout settings, boot partitions, tab initialization, and device configuration.
  * Improved terminology and consistency in Docker, networking, virtualization, encryption, and Markdown documentation.
* **Bug Fixes**
  * Corrected a minor tab-cookie cleanup behavior to match existing initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->