### PR TITLE
fix(csrf): return 403 on CSRF rejection instead of silent empty 200

### DIFF
--- a/emhttp/plugins/dynamix/include/local_prepend.php
+++ b/emhttp/plugins/dynamix/include/local_prepend.php
@@ -16,7 +16,14 @@
 
 function csrf_terminate($reason) {
   exec('logger -t webGUI -- '.escapeshellarg("error: {$_SERVER['REQUEST_URI']} - {$reason} csrf_token"));
-  exit;
+  // Reject with an explicit 403 instead of a silent empty 200 so callers can
+  // tell a CSRF failure apart from a genuine empty result (e.g. a fetch-based
+  // status read must not render as "service down" when it was simply blocked).
+  if (!headers_sent()) {
+    http_response_code(403);
+    header('Content-Type: application/json');
+  }
+  exit(json_encode(['error' => "{$reason} csrf_token"]));
 }
 
 putenv('PATH=.:/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin');


### PR DESCRIPTION
## Problem

When `local_prepend.php` rejects a POST for a missing/invalid CSRF token, it logs the error and `exit`s with **no status code** — so the client receives an empty **HTTP 200**. A fetch/XHR caller can't distinguish that from a genuine empty result.

Concretely: Settings → Management Access → **Unraid API Status** issues a fetch POST to `unraid-api.php`. When that POST is blocked by the CSRF gate, the empty 200 is read as "the service returned nothing" and the panel renders **Not Running** — even though the API is up and the request was simply blocked. (Full first-paint reproduction and the client-side fix are in unraid/api#2039.)

## Change

`csrf_terminate()` now returns an explicit **403** with a small JSON body (`{"error":"<reason> csrf_token"}`) instead of a silent empty 200.

**Validation logic is unchanged** — the gate still rejects the same requests and still logs the same `wrong csrf_token` line. Only the response *shape* of an already-rejected request changes, so a blocked read is observable and can't masquerade as a real (empty) response. A legitimate request carrying a valid token never reaches this path.

`headers_sent()` is guarded so this is a no-op if output already began.

## Testing

- `php -l` clean.
- This is defense-in-depth; it does not by itself remove the red log line — the correct token from the caller does (unraid/api#2039). The two PRs are independent.

## Note / possible follow-up

The token is read as `$_POST['csrf_token'] ?? $_SERVER['HTTP_X_CSRF_TOKEN']`. `??` only falls through on `null`, not on an empty string, so a caller that sends a blank `csrf_token=` body field overrides a valid `x-csrf-token` header. If we want the header to win in that case, `($_POST['csrf_token'] ?? '') ?: ($_SERVER['HTTP_X_CSRF_TOKEN'] ?? null)` would do it without weakening validation. Left out of this PR to keep the change minimal — happy to add if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSRF validation failures now return a clear JSON error response with HTTP status 403.
  * Clients can reliably distinguish CSRF errors from legitimate empty responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->