### PR TITLE
fix: don't delete the shared default docker icon when removing an icon-less container

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -898,7 +898,8 @@ class DockerClient {
 		// Attempt to remove container
 		$this->getDockerJSON("/containers/$id?force=1", 'DELETE', $code);
 		if (isset($info[$name])) {
-			if (isset($info[$name]['icon'])) {
+			// never unlink the shared default icon recorded for icon-less containers
+			if (isset($info[$name]['icon']) && $info[$name]['icon'] != '/plugins/dynamix.docker.manager/images/question.png') {
 				$iconRAM = $docroot.$info[$name]['icon'];
 				$iconUSB = str_replace($dockerManPaths['images-ram'], $dockerManPaths['images'], $iconRAM);
 				if ($cache>=1 && is_file($iconRAM)) unlink($iconRAM);

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -97,7 +97,7 @@ foreach ($containers as $ct) {
   $color = $status=='started' ? 'green-text' : ($status=='paused' ? 'orange-text' : 'red-text');
   $update = $updateStatus==1 && !empty($compose) ? 'blue-text' : '';
   $icon = $info['icon'] ?: '/plugins/dynamix.docker.manager/images/question.png';
-  $image = substr($icon,-4)=='.png' ? "<img src='$icon?".filemtime("$docroot{$info['icon']}")."' class='img' onerror=this.src='/plugins/dynamix.docker.manager/images/question.png';>" : (substr($icon,0,5)=='icon-' ? "<i class='$icon img'></i>" : "<i class='fa fa-$icon img'></i>");
+  $image = substr($icon,-4)=='.png' ? "<img src='$icon?".filemtime("$docroot{$info['icon']}")."' class='img' onerror=\"this.onerror=null;this.src='/plugins/dynamix.docker.manager/images/question.png';\">" : (substr($icon,0,5)=='icon-' ? "<i class='$icon img'></i>" : "<i class='fa fa-$icon img'></i>");
   $wait = var_split($autostart[array_search($name,$names)]??'',1);
   $networks = [];
   $network_ips = [];


### PR DESCRIPTION
## Summary
Fixes #2691 — the docker manager deletes its own shared fallback icon (`question.png`) whenever an icon-less container is removed or updated with cache flags, and once the file is missing, every icon-less container's `onerror` fallback re-requests it in a tight loop until the next reboot.

## Changes
- **`include/DockerClient.php` (`removeContainer()`)** — skip the icon unlink when the recorded icon is the shared default. Containers with no template icon get `/plugins/dynamix.docker.manager/images/question.png` recorded as their icon (L346), so the existing unlink deleted the shared static file from the docroot for the whole system. Per-container cached icons (`<name>-icon.png`) are still cleaned up exactly as before.
- **`include/DockerContainers.php`** — quote the `onerror` attribute and guard it with `this.onerror=null`, so a missing fallback costs one failed request per image instead of an endless 404 retry loop (measured ~150 req/s against nginx with 15 affected images on one open Docker page).

## Testing (real hardware, per the README workflow)
Tested on Unraid 7.3.2 — both files are byte-identical between 7.3.2 and master at `369f0b2`, so the patched master files were copied to the live server directly.

- `php -l` clean on both files.
- Functional test of `removeContainer()` via injected webui-info registry entries:
  - entry recording the shared default icon, removed with `cache=2` → `question.png` survives, registry entry cleaned up ✓
  - entry recording a per-container `/state/...-icon.png` (file created for the test), removed with `cache=1` → cached icon still unlinked, registry entry cleaned up ✓ (registry returned to its original entry count)
- Browser test with `question.png` temporarily removed: stock-rendered container images now fail once and stop — previously an endless 404 retry loop. The Docker page renders normally in both states. (The only remaining repeat-requester on my test box traced to a third-party plugin carrying its own copy of the unguarded `onerror` pattern.)
- The original deletion was observed in the wild via CA Docker Auto-Update updating an icon-less container — full trace in #2691.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cleanup from accidentally removing the shared default container icon.
  * Improved fallback handling when a container icon image fails to load, avoiding repeated error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->