### PR TITLE
fix: restore the orphan image row's Created date to the Uptime column

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -305,7 +305,7 @@ foreach ($images as $image) {
   $menu = sprintf("onclick=\"addDockerImageContext('%s','%s')\"", $id, implode(',',$image['Tags']));
   echo "<tr class='advanced'><td style='width:220px;padding:8px'>";
   echo "<span class='outer apps'><span id='$id' $menu class='hand'><img src='/webGui/images/disk.png' class='img'></span><span class='inner'>("._('orphan image').")<br><i class='fa fa-square stopped grey-text'></i><span class='state'>"._('stopped')."</span></span></span>";
-  echo "</td><td colspan='6'>"._('Image ID').": $id<br>";
+  echo "</td><td colspan='8'>"._('Image ID').": $id<br>";
   echo implode(', ',$image['Tags']);
   echo "</td><td>"._('Created')." ".htmlspecialchars(_($image['Created'],0))."</td></tr>";
 }


### PR DESCRIPTION
## Summary

Fixes #2694 — the orphan image row emits `1 + colspan='6' + 1 = 8` cells against a 10-column thead, so "Created ..." renders under **CPU & Memory load** instead of **Uptime**, and the Autostart/Uptime slots get no cell at all (which is why the row background stops at the Autostart boundary).

`colspan='6'` was correct until the thead grew. `b5f2e9da9` (2023-03-25, *"Fix table layout for orphan images"*) set it to 6 when the thead had **8** columns — `1+6+1 = 8` fit exactly and "Created" landed in Uptime. `8cabad6f0` (2024-08-08) split *Port Mappings* into *Container IP* / *Container Port* / *LAN IP:Port*, taking the thead to 10 without bumping the colspan.

## Changes

- **`include/DockerContainers.php`** (orphan image loop) — widen the Image ID cell from `colspan='6'` to `colspan='8'`, so the row spans a full `1 + 8 + 1 = 10` slots. "Created" returns to column 10 (Uptime) and the row background spans the table. This matches the pre-split shape, where the colspan also covered through Autostart — orphan images have no autostart control, so nothing is displaced.

## Testing (real hardware, per the README workflow)

Tested on Unraid 7.3.2 with two orphan images present, Docker tab in Advanced view.

The orphan image block (L303-311) is byte-identical between 7.3.2 and master at `369f0b2`, so the patched master file was copied to the live server directly. (The server's only other delta in this file is L100, from my in-flight #2693, which is unrelated to the orphan row.)

- `php -l` clean.
- Measured the orphan row against the live thead, before → after:

  | | before (`colspan='6'`) | after (`colspan='8'`) |
  |---|---|---|
  | row span total | 8 of 10 | **10 of 10** |
  | Created cell x-range | `1221→1395` | `1495→1692` |
  | CPU & Memory load header | `1221→1395` | `1221→1395` |
  | Uptime header | `1495→1692` | `1495→1692` |
  | Created aligns with | CPU & Memory load ✗ | **Uptime** ✓ |

  Before, the Created cell's x-range matched the CPU & Memory load header exactly; after, it matches the Uptime header exactly. (Absolute x-values are specific to this box's column widths — the load-bearing result is the exact alignment change and the 8 → 10 span. My test box runs my own folder plugin, which pins column widths on this table but does not touch orphan rows or cell/column assignment; the before/after pair above was measured on one page with identical widths, isolating the colspan as the only variable.)
- Row background now spans the full table width instead of terminating at the Autostart boundary.
- Both orphan rows on the box render correctly; container rows are unaffected (they already emit all 10 cells and this change does not touch them).
- Basic view unchanged — orphan rows are `tr.advanced` and remain hidden there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the orphan image table layout so the image ID cell spans the correct width and displays properly across the table row.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->