### PR TITLE
fix(plugin-manager): treat a dangling plugin symlink as not installed

### DIFF
--- a/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
@@ -518,6 +518,21 @@ function move($src_file, $tar_dir) {
   return rename($src_file, $tar_dir."/".basename($src_file));
 }
 
+// Resolve the installed plugin file that a tracking symlink points at, or FALSE
+// if the plugin is not installed. A dangling symlink - one whose target .plg has
+// been removed or renamed on the flash out-of-band - is treated as not installed
+// and the stale link is cleaned up, so a subsequent install/update/check starts
+// from a clean state instead of failing to parse the missing target.
+function installed_plugin($symlink) {
+  $target = @readlink($symlink);
+  if ($target === false) return false;
+  if (!is_file($target)) {
+    @unlink($symlink);
+    return false;
+  }
+  return $target;
+}
+
 $notify        = '/usr/local/emhttp/webGui/scripts/notify';
 $boot          = '/boot/config/plugins';
 $nextboot      = '/boot/config/plugins-nextboot';
@@ -701,7 +716,7 @@ if ($method == 'install') {
   }
   $symlink = "$plugins/$plugin";
   // check for re-install
-  $installed_plugin_file = @readlink($symlink);
+  $installed_plugin_file = installed_plugin($symlink);
   if ($installed_plugin_file !== false) {
     if ($plugin_file == $installed_plugin_file) {
       write("plugin: not re-installing same plugin\n");
@@ -797,7 +812,7 @@ if ($method == 'check') {
   $plugin = $argv[2];
   $symlink = "$plugins/$plugin";
   write("plugin: checking: $plugin ...\n");
-  $installed_plugin_file = @readlink($symlink);
+  $installed_plugin_file = installed_plugin($symlink);
   if ($installed_plugin_file === false) {
     write("plugin: not installed\n");
     // run hook scripts for post processing
@@ -850,7 +865,7 @@ if ($method == 'update') {
   }
   $action = $download_only ? 'downloading' : 'updating';
   write("plugin: $action: $plugin\n");
-  $installed_plugin_file = @readlink($symlink);
+  $installed_plugin_file = installed_plugin($symlink);
   if ($installed_plugin_file === false) {
     write("plugin: $plugin not installed\n");
     // run hook scripts for post processing

--- a/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
@@ -594,7 +594,7 @@ if ($method == 'checkall') {
     // skip OS related plugins
     if (in_array(basename($link,'.plg'),$builtin)) continue;
     // only consider symlinks
-    $installed_plugin_file = @readlink($link);
+    $installed_plugin_file = installed_plugin($link);
     if ($installed_plugin_file === false) continue;
     if (plugin('pluginURL', $installed_plugin_file, $error) === false) continue;
     $plugin = basename($installed_plugin_file);
@@ -617,7 +617,7 @@ if ($method == 'updateall') {
     // skip OS related plugins
     if (in_array(basename($link,'.plg'),$builtin)) continue;
     // only consider symlinks
-    $installed_plugin_file = @readlink($link);
+    $installed_plugin_file = installed_plugin($link);
     if ($installed_plugin_file === false) continue;
     if (plugin('pluginURL', $installed_plugin_file, $error) === false) continue;
     $version = plugin('version', $installed_plugin_file, $error);
@@ -643,7 +643,7 @@ if ($method == 'checkos') {
   }
   foreach ($builtin as $link) {
     // only consider symlinks
-    $installed_plugin_file = @readlink("$plugins/$link.plg");
+    $installed_plugin_file = installed_plugin("$plugins/$link.plg");
     if ($installed_plugin_file === false) continue;
     if (plugin("pluginURL", $installed_plugin_file, $error) === false) continue;
     $plugin = basename($installed_plugin_file);


### PR DESCRIPTION
## Summary

Plugin Manager now treats dangling plugin tracking symlinks as not installed across both direct and bulk operations, removing the stale registration so the plugin can be checked or installed normally again.

## Why This Exists

The manager tracks installed plugins with `/var/log/plugins/<name>.plg` symlinks pointing to `/boot/config/plugins/<name>.plg`. `readlink()` returns a path even when the target was removed or renamed out-of-band, so stale registrations were treated as installed and later failed with a misleading XML parse error. The Plugins page uses the bulk handlers, which also left these stale links behind.

## Resolution

Add one `installed_plugin()` helper that resolves a tracking link, verifies its target is a regular file, and deletes a dangling link before reporting the plugin as not installed. Use the same helper in `install`, `check`, `update`, `checkall`, `updateall`, and `checkos` so direct CLI calls and WebGUI-triggered bulk actions share one installed-state contract.

## Reviewer Considerations

- Confirm healthy tracking symlinks retain the existing install, check, and update behavior; the helper returns their target unchanged.
- Dangling links and links to non-files are cleaned, while an existing malformed XML target is preserved for the existing parse-error handling.
- `remove` remains unchanged because it already unlinks the tracking entry before acting and self-heals this state.

## Behavior Changes

- Direct `install`, `check`, and `update` treat a dangling tracking link as not installed and remove it.
- Bulk `checkall`, `updateall`, and built-in `checkos` now perform the same cleanup, covering the Plugins page Check For Updates path.
- Healthy plugin operations are unchanged.

## Implementation Summary

- Add `installed_plugin()` as the canonical tracking-link resolver.
- Replace direct `readlink()` checks in the three direct handlers and three bulk handlers.

## Verification

- Live QA confirmed direct dangling-link cleanup, fresh reinstall recovery, healthy install/check/update/remove behavior, directory-target cleanup, and malformed-target preservation.
- Live QA isolated the remaining failure to `checkall`, `updateall`, and `checkos`; those exact call sites now use the already-validated helper.
- `php -l emhttp/plugins/dynamix.plugin.manager/scripts/plugin` — passed.
- `git diff --check` — passed.
- GitHub `build-plugin` for commit `8a9d594` — passed.

## Risk

Low; the follow-up changes only the resolver used by three bulk loops and reuses the helper already validated on the direct paths. Live bulk-path re-verification is still required before QA sign-off.
