### PR TITLE
fix(plugin-manager): shell-escape hook arguments in pre/post_hooks

### DIFF
--- a/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
@@ -221,7 +221,7 @@ function pre_hooks() {
   $hooks = "/usr/local/emhttp/plugins/dynamix.plugin.manager/pre-hooks";
   foreach (glob("$hooks/*") as $hook) if (is_executable($hook)) {
     write("Executing hook script: ".basename($hook)."\n");
-    run("$hook plugin $method $plugin");
+    run(escapeshellarg($hook)." plugin ".escapeshellarg($method)." ".escapeshellarg($plugin));
   }
 }
 
@@ -235,7 +235,7 @@ function post_hooks($error='') {
   $hooks = "/usr/local/emhttp/plugins/dynamix.plugin.manager/post-hooks";
   foreach (glob("$hooks/*") as $hook) if (is_executable($hook)) {
     write("Executing hook script: ".basename($hook)."\n");
-    run("$hook plugin $method $plugin $error");
+    run(escapeshellarg($hook)." plugin ".escapeshellarg($method)." ".escapeshellarg($plugin)." ".escapeshellarg($error));
   }
 }
 


### PR DESCRIPTION
Fixes OS-610.

## Summary

`pre_hooks()` and `post_hooks()` build the hook command by concatenating unquoted values into a string that `run()` executes via `sh -c` (`popen`):

```php
run("$hook plugin $method $plugin $error");
```

A normal Plugin Manager error contains an apostrophe — `XML file doesn't exist or xml parse error` — so the shell treats it as the start of a quoted string and aborts:

```
sh: -c: line 1: unexpected EOF while looking for matching `'`
```

The hook never executes.

## Impact

This doesn't cause the original plugin failure, but it prevents Plugin Manager from completing its failure-handling contract — exactly when those hooks matter most:

- The pending marker created by `pre_plugin_checks` is never removed (`/tmp/plugins/pluginPending/<name>`), so the UI can be left showing a stuck "pending" state.
- Post-hook cleanup and notification behavior is skipped.
- A misleading secondary error obscures the actual failure.
- An error containing spaces is split into multiple arguments, so hooks don't receive the documented complete error value even when the command stays syntactically valid.

## Fix

Keep the existing `run()` implementation and escape each interpolated argument at the call site with `escapeshellarg()`, in both `pre_hooks()` and `post_hooks()`. Surgical, and preserves the existing execution model. `post_hooks()` keeps passing `$error` (escaped) so `post_plugin_checks`' `if ($error) break;` success/failure signal is retained.

## Verification

Using the reproduction from OS-610 (a deliberately malformed `.plg`):

**Before**
```
plugin: XML file doesn't exist or xml parse error
Executing hook script: post_plugin_checks
sh: -c: line 1: unexpected EOF while looking for matching `'`
exit_status=1
pending marker remains
```

**After**
```
plugin: XML file doesn't exist or xml parse error
Executing hook script: post_plugin_checks
exit_status=1
pending marker cleared
```

The original XML failure and nonzero status are unchanged — `post_plugin_checks` now executes, clears the pending marker, and emits no secondary shell error. Separately confirmed the hook receives the full error as a single argument (`$argv[4]` = `XML file doesn't exist or xml parse error`). `php -l` clean.

## Security context

This is not claiming a demonstrated privilege escalation — the inputs here come from a plugin operation that is already privileged. But Plugin Manager runs these commands with elevated authority, so passing values through `sh -c` without argument escaping is undesirable; escaping is worthwhile defense-in-depth alongside the failure-handling fix.

## Notes

Independent of the dangling-symlink fix in #2696 (that error string is what surfaced this bug). The two touch different functions and can merge in either order.