### PR TITLE
fix: backport 7.2.8-rc.0.2 WebGUI fixes (php 8.4 snapshots, dmidecode, qemu guard, docker VLAN gateway)

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerSettings.page
@@ -115,6 +115,17 @@ function base_net($route) {
   return substr(explode('/',$route)[0],0,-2);
 }
 
+// Derive the IPv4 gateway rc.docker would use when none is configured:
+// the subnet's first usable host (e.g. 192.168.10.0/24 -> 192.168.10.1).
+// Calls the same scripts/derive_gateway helper rc.docker uses, so the logic
+// is not duplicated. Returns '' if not derivable.
+function derive_gw($route) {
+  global $docroot;
+  $route = trim((string)$route);
+  if ($route === '') return '';
+  return exec($docroot."/plugins/dynamix.docker.manager/scripts/derive_gateway ".escapeshellarg($route));
+}
+
 $bgcolor = $themeHelper->isLightTheme() ? '#f2f2f2' : '#1c1c1c'; // $themeHelper set in DefaultPageLayout.php
 
 //Check if docker.cfg does exist
@@ -315,6 +326,7 @@ _(Preserve user defined networks)_:
 $net = normalize($network);
 $docker_auto = "DOCKER_AUTO_$net";
 $docker_dhcp = "DOCKER_DHCP_$net";
+$docker_gw   = "DOCKER_GATEWAY_$net";
 ?>
 <input type="hidden" name="<?=$docker_auto?>" value="<?=_var($dockercfg,$docker_auto)?>">
 
@@ -369,8 +381,9 @@ _(IPv4 custom network on interface)_ <?=$network?> (_(optional)_):
       <span class="<?=$ip4class?>">
         <strong><?=_('Subnet')?>:</strong> <?=str_replace(' ', '<br><b>'._('Subnet').': </b>', $route)?>
       </span>
-      <span class="<?=$gw4class?>">
-        <strong><?=_('Gateway')?>:</strong> <?=$gateway[$network] ?: '---'?>
+      <span class="<?=$gw4class?> flex flex-row items-center gap-2">
+        <strong><?=_('Gateway')?>:</strong>
+        <input type="text" id="<?=$docker_dhcp?>_gw" name="<?=$docker_gw?>" class="ip4" value="<?=htmlspecialchars(_var($dockercfg,$docker_gw))?>" placeholder="<?=htmlspecialchars($gateway[$network] ?: derive_gw($route))?>" title="_(IPv4 address A.B.C.D)_"<?=$autoDisabled?>>
       </span>
       <span class="flex flex-row items-center gap-2">
         <span class="flex flex-row items-center gap-2">
@@ -464,6 +477,7 @@ _(IPv4 custom network on interface)_ <?=$network?> (_(optional)_):
 $net = normalize($network);
 $docker_auto  = "DOCKER_AUTO_$net";
 $docker_dhcp6 = "DOCKER_DHCP6_$net";
+$docker_gw6   = "DOCKER_GATEWAY6_$net";
 ?>
 <?if ($network != 'wlan0' || lan_port('wlan0',true) == 1):?>
 
@@ -485,7 +499,10 @@ _(IPv6 custom network on interface)_ <?=$network?> (_(optional)_):
     </label>
     <span id="<?=$docker_dhcp6?>_line" class="<?=$auto6Disabled?>">
       <span class="ip6">**_(Subnet)_:** <?=str_replace(' ', '<br><b>'._('Subnet').': </b>', $route)?></span>
-      <span class="gw6">**_(Gateway)_:** <?=$gateway6[$network] ?: '---'?></span>
+      <span class="gw6 flex flex-row items-center gap-2">
+        <strong><?=_('Gateway')?>:</strong>
+        <input type="text" id="<?=$docker_dhcp6?>_gw" name="<?=$docker_gw6?>" class="gw6" value="<?=htmlspecialchars(_var($dockercfg,$docker_gw6))?>" placeholder="<?=htmlspecialchars($gateway6[$network] ?: '')?>" title="_(IPv6 address nnnn:xxxx::yyyy)_"<?=$auto6Disabled?>>
+      </span>
     </span>
   </span>
 
@@ -591,7 +608,7 @@ $docker_dhcp = "DOCKER_DHCP_$net";
 _(IPv4 custom network on interface)_ <?=$network?>:
 : <span class="flex flex-row flex-wrap items-center gap-4">
     <span class="<?=$gw4class?>">**_(Subnet)_:** <?=str_replace(' ', '<br><b>'._('Subnet').': </b>', $route)?></span>
-    <span class="<?=$gw4class?>">**_(Gateway)_:** <?=$gateway[$network] ?: '---'?></span>
+    <span class="<?=$gw4class?>">**_(Gateway)_:** <?=$gateway[$network] ?: (_var($dockercfg,"DOCKER_GATEWAY_$net") ?: (derive_gw($route) ?: '---'))?></span>
     <span>**_(DHCP pool)_:** <?=_var($dockercfg,$docker_dhcp) ?: "_(not set)_"?><?if (isset($dockercfg[$docker_dhcp])):?>&nbsp;&nbsp;(<?=pow(2,32-my_explode('/',$dockercfg[$docker_dhcp])[1])?> _(hosts)_)<?endif;?></span>
   </span>
 
@@ -784,7 +801,9 @@ function prepareDocker(form) {
     $(mask).prop('disabled',true);
   });
   $(form).find('input[name^="DOCKER_GATEWAY_"]').each(function(){
-    var edit = '#'+$(this).attr('name').replace('GATEWAY','CUSTOM')+'_edit';
+    var custom = '#'+$(this).attr('name').replace('GATEWAY','CUSTOM')+'_edit';
+    var auto = '#'+$(this).attr('name').replace('GATEWAY','DHCP')+'_edit';
+    var edit = $(custom).length ? custom : auto;
     if (!$(edit).prop('checked')) $(this).val('').prop('disabled',false);
   });
   $(form).find('input[name^="DOCKER_RANGE_"]').each(function(){
@@ -809,7 +828,9 @@ function prepareDocker(form) {
     $(mask6).prop('disabled',true);
   });
   $(form).find('input[name^="DOCKER_GATEWAY6_"]').each(function(){
-    var edit6 = '#'+$(this).attr('name').replace('GATEWAY','CUSTOM')+'_edit';
+    var custom6 = '#'+$(this).attr('name').replace('GATEWAY','CUSTOM')+'_edit';
+    var auto6 = '#'+$(this).attr('name').replace('GATEWAY','DHCP')+'_edit';
+    var edit6 = $(custom6).length ? custom6 : auto6;
     if (!$(edit6).prop('checked')) $(this).val('').prop('disabled',false);
   });
   $(form).find('input[name^="DOCKER_RANGE6_"]').each(function(){
@@ -842,6 +863,7 @@ function changeEdit(id, ip) {
     auto.val(auto.val().replace(ip,''));
     if (auto.val() == '') auto.val('no');
   }
+  $(id1+'gw').prop('disabled',!checked);
   changeDHCP(id, ip, $('#'+id.replace('edit','dhcp')).prop('checked'));
 }
 

--- a/emhttp/plugins/dynamix.docker.manager/scripts/derive_gateway
+++ b/emhttp/plugins/dynamix.docker.manager/scripts/derive_gateway
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Derive the IPv4 gateway for a subnet: the first usable host address
+# (e.g. 192.168.10.0/24 -> 192.168.10.1). Prints nothing if not derivable.
+#
+# Restores the pre-Docker-28 behavior where macvlan/ipvlan networks created
+# without an explicit gateway implicitly used the subnet's first address.
+# Shared by etc/rc.d/rc.docker and the Docker Settings page so the logic
+# lives in one place.
+#
+# Usage: derive_gateway "<subnet-cidr>"   (a space-separated list is accepted;
+#        only the first subnet is used)
+CIDR=${1%% *}
+IP=${CIDR%/*}; MASK=${CIDR#*/}
+[[ $IP == *.*.*.* && $MASK =~ ^[0-9]+$ ]] || exit 0
+(( MASK >= 1 && MASK <= 30 )) || exit 0
+IFS=. read -r A B C D <<< "$IP"
+IPNUM=$(( (A<<24) + (B<<16) + (C<<8) + D ))
+MASKNUM=$(( (0xFFFFFFFF << (32-MASK)) & 0xFFFFFFFF ))
+NET=$(( IPNUM & MASKNUM ))
+HOST=$(( NET + 1 ))
+printf '%d.%d.%d.%d\n' $(( (HOST>>24)&255 )) $(( (HOST>>16)&255 )) $(( (HOST>>8)&255 )) $(( HOST&255 ))

--- a/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/emhttp/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -1871,7 +1871,11 @@ class Array2XML {
 		$noxml = "";
 		$snaps_json = file_get_contents($dbpath."/snapshots.db");
 		$snaps = json_decode($snaps_json,true);
-		$snapshot_res=$lv->domain_snapshot_lookup_by_name($vm,$name);
+		$snapshot_xml = @file_get_contents("/etc/libvirt/qemu/snapshot/{$vm}/{$name}.xml");
+		if (empty($snapshot_xml)) {
+			$snapshot_xml = trim(shell_exec("virsh snapshot-dumpxml ".escapeshellarg($vm)." ".escapeshellarg($name)." 2>/dev/null"));
+		}
+		$snapshot_res = !empty($snapshot_xml);
 		if (!$snapshot_res) {
 			 # Manual Snap no XML
 		if ($state == "shutoff" && ($method == "ZFS" || $method == "BTRFS")) {
@@ -1888,7 +1892,7 @@ class Array2XML {
 			$noxml = "noxml";
 		}
 		} else {
-		$snapshot_xml=$lv->domain_snapshot_get_xml($snapshot_res);
+
 		$a = simplexml_load_string($snapshot_xml);
 		$a = json_encode($a);
 		$b = json_decode($a, TRUE);
@@ -2097,7 +2101,9 @@ class Array2XML {
 		if ($logging) qemu_log($vm,"Success write snap db");
 		$ret = write_snapshots_database("$vm","$name",$state,$snapshotdescinput,$method);
 		#remove meta data
-		if ($ret != "noxml") $ret = $lv->domain_snapshot_delete($vm, "$name" ,2);
+		if ($ret != "noxml") {
+			exec("virsh snapshot-delete ".escapeshellarg($vm)." ".escapeshellarg($name)." --metadata 2>&1", $snapDelOut, $snapDelRtn);
+		}
 		}
 		return $arrResponse;
 

--- a/emhttp/plugins/dynamix.vm.manager/scripts/qemu.php
+++ b/emhttp/plugins/dynamix.vm.manager/scripts/qemu.php
@@ -15,7 +15,7 @@ function detect_user_share(&$arg) {
   $arg = preg_replace_callback('|(/mnt/user/[^,"]+\.[^,"\s]*)|', function($match) {
     if (is_file($match[0])) {
       // resolve the actual disk or cache backing device for this user share path
-      $realdisk = trim(shell_exec("getfattr --absolute-names --only-values -n system.LOCATION ".escapeshellarg($match[0])." 2>/dev/null"));
+      $realdisk = trim(shell_exec("getfattr --absolute-names --only-values -n system.LOCATION ".escapeshellarg($match[0])." 2>/dev/null") ?? '');
       if (!empty($realdisk)) {
         $replacement = str_replace('/mnt/user/', "/mnt/$realdisk/", $match[0]);
         if (is_file($replacement)) {

--- a/emhttp/plugins/dynamix/DashStats.page
+++ b/emhttp/plugins/dynamix/DashStats.page
@@ -151,34 +151,45 @@ $total = exec("awk '/^MemTotal/{print $2*1024}' /proc/meminfo");
 unset($ports); exec("ls --indicator-style=none /sys/class/net|grep -Po '^(bond|eth|wlan)\d+$'",$ports);
 $ports[] = 'lo';
 
-$sizes = ['MB','GB','TB'];
+$memory_units = [
+  // dmidecode reports memory capacities using binary math; treat both SI and IEC labels as base-1024.
+  // This keeps parsing consistent across dmidecode versions that may print GB/TB or GiB/TiB.
+  'kb' => 1/1024, 'kib' => 1/1024,
+  'mb' => 1,      'mib' => 1,
+  'gb' => 1024,   'gib' => 1024,
+  'tb' => 1048576,'tib' => 1048576,
+  'pb' => 1073741824, 'pib' => 1073741824
+];
+$parse_memory_to_mib = function($value) use ($memory_units) {
+  if (!preg_match('/([0-9.]+)\s*([A-Za-z]+)/',$value ?? '',$match)) return 0;
+  $size = (float)$match[1];
+  $unit = strtolower($match[2]);
+  return isset($memory_units[$unit]) ? (int)round($size*$memory_units[$unit]) : 0;
+};
 $memory_type = $ecc = '';
 $memory_installed = $memory_maximum = 0;
 $memory_devices = dmidecode('Memory Device','17');
 foreach ($memory_devices as $device) {
-  if (!is_numeric($device['Size'][0])) continue;
-  [$size, $unit] = my_explode(' ',$device['Size']??'');
-  $base = array_search($unit,$sizes);
-  if ($base!==false) $memory_installed += $size*pow(1024,$base);
+  $memory_installed += $parse_memory_to_mib($device['Size'] ?? '');
   if (!$memory_type && isset($device['Type']) && $device['Type']!='Unknown') $memory_type = $device['Type'];
 }
 $memory_array = dmidecode('Physical Memory Array','16');
 foreach ($memory_array as $device) {
-  [$size, $unit] = my_explode(' ',$device['Maximum Capacity']??'');
-  $base = array_search($unit,$sizes);
-  if ($base>=1) $memory_maximum += $size*pow(1024,$base);
+  $memory_maximum += $parse_memory_to_mib($device['Maximum Capacity'] ?? '');
   if (!$ecc && isset($device['Error Correction Type']) && $device['Error Correction Type']!='None') $ecc = "{$device['Error Correction Type']} ";
 }
 if ($memory_installed >= 1048576) {
   $memory_installed = round($memory_installed/1048576);
   $memory_maximum = round($memory_maximum/1048576);
-  $unit = 'TiB';
+  $memory_unit = 'TiB';
 } else { 
 if ($memory_installed >= 1024) {
   $memory_installed = round($memory_installed/1024);
   $memory_maximum = round($memory_maximum/1024);
-  $unit = 'GiB';}
-else $unit = 'MiB'; }
+  $memory_unit = 'GiB';}
+else $memory_unit = 'MiB'; }
+
+$unit = $memory_unit;
 
 // get system resources size
 exec("df --output=size /boot /var/log /var/lib/docker 2>/dev/null|awk '(NR>1){print $1*1024}'",$df);
@@ -433,7 +444,7 @@ switch ($themeHelper->getThemeName()) { // $themeHelper set in DefaultPageLayout
                                         <span class='flex flex-row flex-wrap items-center gap-4'>
                                             <span class="head_info">
                                                 <span>
-                                                    <i class='ups fa fa-line-chart'></i>_(Memory)_: <?="$memory_installed $unit $memory_type $ecc"?>
+                                                    <i class='ups fa fa-line-chart'></i>_(Memory)_: <?="$memory_installed $memory_unit $memory_type $ecc"?>
                                                 </span>
                                             </span>
                                             <span class="switch">
@@ -464,7 +475,7 @@ switch ($themeHelper->getThemeName()) { // $themeHelper set in DefaultPageLayout
                                 <div class="tile-system-memory-labels">
                                     <div>
                                         <i class='ups fa fa-compress'></i>_(Usable size)_: <?=$ramsize?><br>
-                                        <i class='ups fa fa-expand'></i>_(Maximum size)_: <?="$memory_maximum $unit"?><?=$low?'*':''?>
+                                        <i class='ups fa fa-expand'></i>_(Maximum size)_: <?="$memory_maximum $memory_unit"?><?=$low?'*':''?>
                                     </div>
                                     <div>
                                         <legend>_(Legend)_</legend>

--- a/emhttp/plugins/dynamix/scripts/system_information
+++ b/emhttp/plugins/dynamix/scripts/system_information
@@ -83,38 +83,57 @@ if (!empty($iommu_groups)) {
   $iommu .= '</a>';
 }
 
+$normalize_binary_unit = function($value) {
+  return preg_replace_callback('/\b([KMGTPE]?)(?:i)?B\b/i',function($match) {
+    $prefix = strtoupper($match[1] ?? '');
+    return $prefix ? "{$prefix}iB" : 'B';
+  },$value ?? '');
+};
+
 $cache_installed = [];
 $cache_devices = dmidecode('Cache Information',7);
-foreach ($cache_devices as $device) $cache_installed[] = $device['Socket Designation'].": ".str_replace(['kB','B'],['KB','iB'],$device['Installed Size']);
+foreach ($cache_devices as $device) {
+  $cache_installed[] = $device['Socket Designation'].": ".$normalize_binary_unit($device['Installed Size'] ?? '');
+}
 
 /*
  Memory Device (16) will get us each ram chip. By matching on MB it'll filter out Flash/Bios chips
- Sum up all the Memory Devices to get the amount of system memory installed. Convert MB to GB
+ Sum up all the Memory Devices to get the amount of system memory installed. Convert MiB to GiB
  Physical Memory Array (16) usually one of these for a desktop-class motherboard but higher-end xeon motherboards
- might have two or more of these.  The trick is to filter out any Flash/Bios types by matching on GB
+ might have two or more of these.  The trick is to filter out any Flash/Bios types by matching on GiB
  Sum up all the Physical Memory Arrays to get the motherboard's total memory capacity
  Extract error correction type, if none, do not include additional information in the output
  If maximum < installed then roundup maximum to the next power of 2 size of installed. E.g. 6 -> 8 or 12 -> 16
 */
-$sizes = ['MB','GB','TB'];
+$memory_units = [
+  // dmidecode reports memory capacities using binary math; treat both SI and IEC labels as base-1024.
+  // This keeps parsing consistent across dmidecode versions that may print GB/TB or GiB/TiB.
+  'kb' => 1/1024, 'kib' => 1/1024,
+  'mb' => 1,      'mib' => 1,
+  'gb' => 1024,   'gib' => 1024,
+  'tb' => 1048576,'tib' => 1048576,
+  'pb' => 1073741824, 'pib' => 1073741824
+];
+$parse_memory_to_mib = function($value) use ($memory_units) {
+  if (!preg_match('/([0-9.]+)\s*([A-Za-z]+)/',$value ?? '',$match)) return 0;
+  $size = (float)$match[1];
+  $unit = strtolower($match[2]);
+  return isset($memory_units[$unit]) ? (int)round($size*$memory_units[$unit]) : 0;
+};
 $memory_type = $ecc = '';
 $memory_installed = $memory_maximum = 0;
 $memory_devices = dmidecode('Memory Device',17);
 $modules = 0;
 foreach ($memory_devices as $device) {
   if (empty($device['Type']) || $device['Type']=='Unknown') continue;
-  [$size, $unit] = my_explode(' ',$device['Size']);
-  $base = array_search($unit,$sizes);
-  if ($base!==false) $memory_installed += $size*pow(1024,$base);
+  $memory_installed += $parse_memory_to_mib($device['Size'] ?? '');
   if (!$memory_type) $memory_type = $device['Type'];
   $modules++;
 }
 $memory = $modules > 1 ? "<span class='link blue-text' onclick=\"$('tr.ram').toggle()\">"._('Memory').":</span>" : _('Memory').':';
 $memory_array = dmidecode('Physical Memory Array',16);
 foreach ($memory_array as $device) {
-  [$size, $unit] = my_explode(' ',$device['Maximum Capacity']);
-  $base = array_search($unit,$sizes);
-  if ($base>=1) $memory_maximum += $size*pow(1024,$base);
+  $memory_maximum += $parse_memory_to_mib($device['Maximum Capacity'] ?? '');
   if (!$ecc && isset($device['Error Correction Type']) && $device['Error Correction Type']!='None') $ecc = $device['Error Correction Type']." ";
 }
 if ($memory_installed >= 1048576) {
@@ -152,7 +171,7 @@ span.link{text-decoration:underline;cursor:pointer}
 <?
 foreach ($memory_devices as $device) {
   if (empty($device['Type']) || $device['Type']=='Unknown') continue;
-  $size = preg_replace('/( .)B$/','$1iB',_var($device,'Size',0));
+  $size = $normalize_binary_unit(_var($device,'Size',0));
   echo "<tr class='ram'><td></td><td>",$device['Locator'],": ",_var($device,'Manufacturer')," ",_var($device,'Part Number'),", $size ",_var($device,'Type')," @ ",_var($device,'Configured Memory Speed'),"</td></tr>";
 }
 

--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -499,6 +499,8 @@ docker_network_start(){
         SUBNET=$(ip -4 route show dev $NETWORK | sort | awk -v ORS=" " '$1 !~ /^default/ {print $1}' | sed 's/ $//')
         GATEWAY=$(ip -4 route show to default dev $NETWORK | awk '{print $3;exit}')
         [[ -n $GATEWAY ]] || GATEWAY=$(configured_gateway "$NETWORK" GATEWAY)
+        [[ -n $GATEWAY ]] || { DEVICE=${NETWORK/./_}; DEVICE=${DEVICE^^}; DGW=DOCKER_GATEWAY_$DEVICE; GATEWAY=${!DGW}; }
+        [[ -n $GATEWAY ]] || GATEWAY=$(/usr/local/emhttp/plugins/dynamix.docker.manager/scripts/derive_gateway "$SUBNET")
         SERVER=${IPV4%/*}
         DHCP=${NETWORK/./_}
         DHCP=DOCKER_DHCP_${DHCP^^}
@@ -511,6 +513,7 @@ docker_network_start(){
         SUBNET6=$(ip -6 route show dev $NETWORK | sort | awk -v ORS=" " '$1 !~ /^(default|fe80)/ {print $1}' | sed 's/ $//')
         GATEWAY6=$(ip -6 route show to default dev $NETWORK | awk '{print $3;exit}')
         [[ -n $GATEWAY6 ]] || GATEWAY6=$(configured_gateway "$NETWORK" GATEWAY6)
+        [[ -n $GATEWAY6 ]] || { DEVICE=${NETWORK/./_}; DEVICE=${DEVICE^^}; DGW=DOCKER_GATEWAY6_$DEVICE; GATEWAY6=${!DGW}; }
       fi
     else
       # add user defined networks


### PR DESCRIPTION
Backports the WebGUI fixes required for the **7.2.8-rc.0.2** rebase, which retains the PHP 8.4 and dmidecode 3.7 upgrades. Targets the `7.2` branch.

## Commits

| Fix | Source |
|-----|--------|
| `fix(VM_Manager): fix gpf issues with snapshots and php 8.4` | #2537 (merged) |
| `fix: parse dmidecode memory capacity labels consistently across versions` | #2562 (merged) |
| `fix(vm-manager): guard qemu location lookup output` | #2682 (**open** against master) |
| `fix(docker): fall back to docker.cfg gateway for auto VLAN networks (OS-468)` | #2675 (merged) |

## Why

Because 7.2.8 retains the PHP 8.4 and dmidecode 3.7 upgrades (to match 7.3.2), these WebGUI fixes must come along:
- **PHP 8.4 / VM snapshots** — avoids GPF in VM Manager snapshot handling under PHP 8.4.
- **dmidecode memory capacity parsing** — dmidecode 3.7 changed capacity label formatting; this parses it consistently across versions.
- **qemu location guard** — guards the qemu location lookup output (defensive, one-line).
- **docker.cfg VLAN gateway fallback (OS-468)** — restores pre-Docker-28 implicit gateway behavior for auto VLAN networks.

## Verification
- Each commit is a faithful reproduction of its source (content-identical diffs; only base-tree offsets differ).
- `php -l` passes on all changed PHP/`.page` files.
- No merge conflicts; branch is current with the `7.2` tip.

## Note
The qemu guard fix (#2682) is not yet merged to master. It is a trivial one-line guard and was explicitly requested for this backport, but this means 7.2 receives it slightly ahead of master. Can be dropped if you'd prefer to wait for #2682 to merge.
