### PR TITLE
fix(mover): use a widely supported arrow for the Mover direction label

### DIFF
--- a/emhttp/plugins/dynamix/ShareEdit.page
+++ b/emhttp/plugins/dynamix/ShareEdit.page
@@ -750,8 +750,8 @@ function updateScreen(cache, slow) {
 			}
 
 			if ((secondaryValue !== "0") && (secondaryValue !== primaryValue)) {
-				$('#moverDirection1 option:eq(0)').text($('#primary option:eq(' + z(0) + ')').text() + ' ⮕ ' + $('#secondary option:eq(' + z(1) + ')').text());
-				$('#moverDirection1 option:eq(1)').text($('#secondary option:eq(' + z(1) + ')').text() + ' ⮕ ' + $('#primary option:eq(' + z(0) + ')').text());
+				$('#moverDirection1 option:eq(0)').text($('#primary option:eq(' + z(0) + ')').text() + ' → ' + $('#secondary option:eq(' + z(1) + ')').text());
+				$('#moverDirection1 option:eq(1)').text($('#secondary option:eq(' + z(1) + ')').text() + ' → ' + $('#primary option:eq(' + z(0) + ')').text());
 				$('#moverDirection1').val('0').show();
 				$('#moverDirection2').hide();
 				$('#moverAction1').html("<i class='fa fa-info i'></i>" + moverAction1Text);
@@ -795,8 +795,8 @@ function updateScreen(cache, slow) {
 			$('#primary option:eq(' + z(0) + ')').prop('selected', true);
 			$('#secondary option:eq(' + z(1) + ')').prop('selected', true);
 			$('#secondary option:eq(1)').prop('disabled', poolsOnly);
-			$('#moverDirection1 option:eq(0)').text($('#primary option:eq(' + z(0) + ')').text() + ' ⮕ ' + $('#secondary option:eq(' + z(1) + ')').text());
-			$('#moverDirection1 option:eq(1)').text($('#secondary option:eq(' + z(1) + ')').text() + ' ⮕ ' + $('#primary option:eq(' + z(0) + ')').text());
+			$('#moverDirection1 option:eq(0)').text($('#primary option:eq(' + z(0) + ')').text() + ' → ' + $('#secondary option:eq(' + z(1) + ')').text());
+			$('#moverDirection1 option:eq(1)').text($('#secondary option:eq(' + z(1) + ')').text() + ' → ' + $('#primary option:eq(' + z(0) + ')').text());
 
 			for (let i = 0; i < secondaryDropdown.options.length; i++) {
 				if (secondaryDropdown.options[i].value === primaryValue || (i === 1 && poolsOnly) || secondaryDropdown.options[i].id === 'cachePoolOption2') {
@@ -813,8 +813,8 @@ function updateScreen(cache, slow) {
 			}
 
 			if ((secondaryValue !== "0") && (secondaryValue !== primaryValue)) {
-				$('#moverDirection1 option:eq(0)').text($('#primary option:eq(' + z(0) + ')').text() + ' ⮕ ' + $('#secondary option:eq(' + z(1) + ')').text());
-				$('#moverDirection1 option:eq(1)').text($('#secondary option:eq(' + z(1) + ')').text() + ' ⮕ ' + $('#primary option:eq(' + z(0) + ')').text());
+				$('#moverDirection1 option:eq(0)').text($('#primary option:eq(' + z(0) + ')').text() + ' → ' + $('#secondary option:eq(' + z(1) + ')').text());
+				$('#moverDirection1 option:eq(1)').text($('#secondary option:eq(' + z(1) + ')').text() + ' → ' + $('#primary option:eq(' + z(0) + ')').text());
 				$('#moverDirection1').val('0').show();
 				$('#moverDirection2').hide();
 				$('#moverAction1').html("<i class='fa fa-info i'></i>" + moverAction2Text);


### PR DESCRIPTION
Fixes #2545.

The Mover direction options in Share Settings use `⮕` (U+2B95), which is missing from many system fonts and renders as a tofu box. Replacing it with `→` (U+2192), which is universally available, keeps the same meaning and renders everywhere.

The label is set via jQuery `.text()`, so a literal character is used rather than an HTML entity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the “Mover action” direction indicator to use a simpler arrow symbol for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->