### PR TITLE
fix(docker): orphan image row spans all 10 columns (Created under Uptime)

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -305,7 +305,7 @@ foreach ($images as $image) {
   $menu = sprintf("onclick=\"addDockerImageContext('%s','%s')\"", $id, implode(',',$image['Tags']));
   echo "<tr class='advanced'><td style='width:220px;padding:8px'>";
   echo "<span class='outer apps'><span id='$id' $menu class='hand'><img src='/webGui/images/disk.png' class='img'></span><span class='inner'>("._('orphan image').")<br><i class='fa fa-square stopped grey-text'></i><span class='state'>"._('stopped')."</span></span></span>";
-  echo "</td><td colspan='6'>"._('Image ID').": $id<br>";
+  echo "</td><td colspan='8'>"._('Image ID').": $id<br>";
   echo implode(', ',$image['Tags']);
   echo "</td><td>"._('Created')." ".htmlspecialchars(_($image['Created'],0))."</td></tr>";
 }


### PR DESCRIPTION
Fixes #2694.

The Docker containers table has 10 columns, but the orphan image row emits only 8 cells: a 220px name cell, a `colspan='6'` details cell, and the Created cell. It is therefore 2 columns short, so "Created" renders under "CPU & Memory load" instead of "Uptime", and the row background stops at the Autostart boundary instead of spanning the table.

Widening the details cell from `colspan='6'` to `colspan='8'` makes the row span cols 1-10, placing "Created" in the Uptime column and letting the row background span the full width. No other rows are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the layout of orphan Docker image entries so Image ID information spans the appropriate table columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->