### PR TITLE
fix(docker): do not delete the shared fallback icon when removing an icon-less container

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -900,9 +900,14 @@ class DockerClient {
 		if (isset($info[$name])) {
 			if (isset($info[$name]['icon'])) {
 				$iconRAM = $docroot.$info[$name]['icon'];
-				$iconUSB = str_replace($dockerManPaths['images-ram'], $dockerManPaths['images'], $iconRAM);
-				if ($cache>=1 && is_file($iconRAM)) unlink($iconRAM);
-				if ($cache==2 && $code===true && is_file($iconUSB)) unlink($iconUSB);
+				// Only remove per-container cached icons (they live under images-ram).
+				// Icon-less containers record the shared fallback (e.g. question.png) as
+				// their icon; unlinking that would delete it system-wide until reboot.
+				if (strpos($iconRAM, $dockerManPaths['images-ram']) === 0) {
+					$iconUSB = str_replace($dockerManPaths['images-ram'], $dockerManPaths['images'], $iconRAM);
+					if ($cache>=1 && is_file($iconRAM)) unlink($iconRAM);
+					if ($cache==2 && $code===true && is_file($iconUSB)) unlink($iconUSB);
+				}
 			}
 			unset($info[$name]);
 			DockerUtil::saveJSON($dockerManPaths['webui-info'], $info);


### PR DESCRIPTION
Fixes #2691.

`removeContainer()` unlinks `$docroot.$info[$name]['icon']`. For a container whose template has no icon, that recorded path is the shared fallback `/plugins/dynamix.docker.manager/images/question.png` (set when the icon is empty), so removing or updating such a container deletes `question.png` for the whole system until the next reboot re-extracts bzroot.

Per-container cached icons live under `images-ram` (`$dockerManPaths['images-ram']`); the shared fallback does not. This guards the cleanup so it only unlinks icons inside the `images-ram` cache and never the shared static file. Containers with a real icon are cleaned up exactly as before.