### PR TITLE
fix: backport shared default docker icon fix to 7.3

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -898,7 +898,8 @@ class DockerClient {
 		// Attempt to remove container
 		$this->getDockerJSON("/containers/$id?force=1", 'DELETE', $code);
 		if (isset($info[$name])) {
-			if (isset($info[$name]['icon'])) {
+			// never unlink the shared default icon recorded for icon-less containers
+			if (isset($info[$name]['icon']) && $info[$name]['icon'] != '/plugins/dynamix.docker.manager/images/question.png') {
 				$iconRAM = $docroot.$info[$name]['icon'];
 				$iconUSB = str_replace($dockerManPaths['images-ram'], $dockerManPaths['images'], $iconRAM);
 				if ($cache>=1 && is_file($iconRAM)) unlink($iconRAM);

--- a/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -97,7 +97,7 @@ foreach ($containers as $ct) {
   $color = $status=='started' ? 'green-text' : ($status=='paused' ? 'orange-text' : 'red-text');
   $update = $updateStatus==1 && !empty($compose) ? 'blue-text' : '';
   $icon = $info['icon'] ?: '/plugins/dynamix.docker.manager/images/question.png';
-  $image = substr($icon,-4)=='.png' ? "<img src='$icon?".filemtime("$docroot{$info['icon']}")."' class='img' onerror=this.src='/plugins/dynamix.docker.manager/images/question.png';>" : (substr($icon,0,5)=='icon-' ? "<i class='$icon img'></i>" : "<i class='fa fa-$icon img'></i>");
+  $image = substr($icon,-4)=='.png' ? "<img src='$icon?".filemtime("$docroot{$info['icon']}")."' class='img' onerror=\"this.onerror=null;this.src='/plugins/dynamix.docker.manager/images/question.png';\">" : (substr($icon,0,5)=='icon-' ? "<i class='$icon img'></i>" : "<i class='fa fa-$icon img'></i>");
   $wait = var_split($autostart[array_search($name,$names)]??'',1);
   $networks = [];
   $network_ips = [];


### PR DESCRIPTION
## Summary
Backport of #2693 (@chodeus, fixes #2691) into the `7.3` release branch for the 7.3.3 patch release. Clean cherry-pick, no conflicts — `7.3` and `master` were identical at these two files.

Docker manager records the shared fallback icon `/plugins/dynamix.docker.manager/images/question.png` for icon-less containers, then `removeContainer()` unlinks it whenever such a container is removed or updated (e.g. via CA Docker Auto-Update). Once the file is gone, every icon-less container's `onerror` fallback re-requests it in a tight loop until the next reboot — this is what's generating the nginx log spam reported in the forums and increasingly on Discord.

## Changes
Identical to #2693:
- `DockerClient.php` (`removeContainer()`) — skip the icon unlink when the recorded icon is the shared default. Per-container cached icons (`<name>-icon.png`) are still cleaned up as before.
- `DockerContainers.php` — quote the `onerror` attribute and guard it with `this.onerror=null`, so a missing fallback costs one failed request per image instead of an endless 404 retry loop.

## Testing
- `php -l` clean on both changed files.
- Cherry-picked cleanly from master (`6f28eb6`) with no conflicts; diff is byte-identical to the original PR.
- Original PR #2693 already has an independent QA pass recorded (functional validation on 7.3.2 + plugin-based install/rollback validation) — see linked Linear ticket.

Related to OS-628