### PR TITLE
fix: guard the dashboard's docker icon onerror fallback

### DIFF
--- a/emhttp/plugins/dynamix/include/DashboardApps.php
+++ b/emhttp/plugins/dynamix/include/DashboardApps.php
@@ -94,7 +94,7 @@ if ($_POST['docker']) {
     $color = $status=='started' ? 'green-text' : ($status=='paused' ? 'orange-text' : 'red-text');
     $update = $updateStatus==1 ? 'blue-text' : '';
     $icon = $info['icon'] ?: '/plugins/dynamix.docker.manager/images/question.png';
-    $image = substr($icon,-4)=='.png' ? "<img src='$icon?".filemtime("$docroot{$info['icon']}")."' class='img' onerror=this.src='/plugins/dynamix.docker.manager/images/question.png';>" : (substr($icon,0,5)=='icon-' ? "<i class='$icon img'></i>" : "<i class='fa fa-$icon img'></i>");
+    $image = substr($icon,-4)=='.png' ? "<img src='$icon?".filemtime("$docroot{$info['icon']}")."' class='img' onerror=\"this.onerror=null;this.src='/plugins/dynamix.docker.manager/images/question.png';\">" : (substr($icon,0,5)=='icon-' ? "<i class='$icon img'></i>" : "<i class='fa fa-$icon img'></i>");
     echo "<span class='outer solid apps $status'><span id='$id' $menu class='hand'>$image</span><span class='inner'><span class='$update'>$name</span><br><i class='fa fa-$shape $status $color'></i><span class='state'>"._($status)."</span></span></span>";
   }
   $none = count($containers) ? _('No running docker containers') : _('No docker containers defined');


### PR DESCRIPTION
Follow-up to #2693, which added this guard to `DockerContainers.php` but not to the dashboard's copy of the same line in `DashboardApps.php`.

The dashboard renders every container icon like this:

```php
<img src='$icon?...' class='img' onerror=this.src='/plugins/dynamix.docker.manager/images/question.png';>
```

For a container with no icon, `$info['icon']` is already the question.png path (set in `DockerClient.php:346`), so `src` and the `onerror` target are the same file. If question.png is missing, the handler reassigns a URL that also 404s, which fires `onerror` again, and nothing ever detaches it.

I ran into this after question.png was deleted on my server — the bug fixed in #2693. I'm on 7.3.2, so the backport in #2708 hasn't reached me yet. nginx's error log for the two minutes I had the dashboard open:

```
...question.png?    (the src attribute)      5 requests
...question.png     (the onerror target) 18,322 requests
```

The `?` is empty because `filemtime()` returns false for the missing file, which is what makes the two URLs distinguishable in the log. That 5 : 18,322 split is the retry loop — polling would keep the two roughly proportional.

The change is the same one already merged for `DockerContainers.php`: quote the attribute and set `this.onerror=null` before reassigning `src`. The `onerror` fragment is now byte-identical between the two files. A missing fallback then costs one extra failed request per image instead of an unbounded loop.

Containers with a working icon are unaffected, and one whose icon 404s still falls back to question.png and renders it. Only the pathological case is capped.

## Testing

`DashboardApps.php` is byte-identical between 7.3.2 and master at `d3898259`, so I tested the patched master file on a 7.3.2 box.

`php -l` clean. Rendered the expression with the file missing, before and after:

```
before: <img src='...question.png?' class='img' onerror=this.src='...question.png';>
after:  <img src='...question.png?' class='img' onerror="this.onerror=null;this.src='...question.png';">
```

I also confirmed the underlying deletion end-to-end on 7.3.2 before patching: with a throwaway icon-less container registered in docker.json, removing it from the Docker tab (`Events.php` → `removeContainer()` with `cache=1`) deleted question.png at the moment of the click, which inotify caught. That part is already handled by #2693/#2708 — this PR only caps the fallout when the file is missing for any reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image fallback handling to prevent repeated error events when a container image fails to load.
  * Failed images now reliably display the default question-mark icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->