### PR TITLE
fix(power): activate power-button files in full releases

### DIFF
--- a/.github/workflows/pr-plugin-build.yml
+++ b/.github/workflows/pr-plugin-build.yml
@@ -7,6 +7,7 @@ on:
       - 'etc/**'
       - 'sbin/**'
       - 'share/**'
+      - 'tests/**'
       - '.github/workflows/pr-plugin-build.yml'
       - '.github/scripts/**'
 
@@ -24,6 +25,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Test power-button runtime paths
+        run: bash tests/power-button-runtime.sh
       
       - name: Get changed files
         id: changed-files

--- a/etc/rc.d/rc.acpid
+++ b/etc/rc.d/rc.acpid
@@ -11,6 +11,7 @@ DAEMON="ACPI power management daemon"
 
 # run & log functions
 . /etc/rc.d/rc.runlog
+. /etc/rc.d/rc.powerbutton
 
 acpid_running(){
   sleep 0.1
@@ -23,12 +24,7 @@ acpid_running(){
 # Options > Power Button) live from dynamix.cfg, so no reload is needed when
 # the setting changes.
 acpid_configure(){
-  local SRC=/etc/acpi/unraid_power_handler.sh
-  # Drop-in dir for plugin-provided power button actions (see README there).
-  mkdir -p /etc/acpi/powerbutton.d
-  if [[ -f $SRC ]]; then
-    install -m 0755 "$SRC" /etc/acpi/acpi_handler.sh
-  fi
+  powerbutton_configure_acpid
 }
 
 acpid_start(){

--- a/etc/rc.d/rc.elogind
+++ b/etc/rc.d/rc.elogind
@@ -26,6 +26,7 @@ PIDFILE="/run/elogind.pid"
 
 # run & log functions
 . /etc/rc.d/rc.runlog
+. /etc/rc.d/rc.powerbutton
 
 elogind_running(){
   sleep 0.1
@@ -36,6 +37,7 @@ elogind_start(){
   log "Starting $DAEMON..."
   local REPLY
   [[ -x $ELOGIND ]] || exit 1
+  powerbutton_configure_elogind
   [[ -d /run/user ]] || mkdir -p /run/user
   if [[ ! -d /run/systemd ]]; then
     mkdir -p /run/elogind /sys/fs/cgroup/elogind

--- a/etc/rc.d/rc.powerbutton
+++ b/etc/rc.d/rc.powerbutton
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Shared runtime configuration for the configurable power button.
+#
+# The webgui repository is extracted under /usr/local in a full Unraid
+# release, while PR test plugins apply etc/* directly under /. Resolve both
+# layouts into the runtime /etc paths consumed by acpid and elogind.
+
+powerbutton_configure_acpid(){
+  local root="${POWERBUTTON_RUNTIME_ROOT:-}"
+  local runtime_dir="$root/etc/acpi"
+  local source="$runtime_dir/unraid_power_handler.sh"
+
+  if [[ ! -f $source ]]; then
+    source="$root/usr/local/etc/acpi/unraid_power_handler.sh"
+  fi
+  [[ -f $source ]] || return 0
+
+  mkdir -p "$runtime_dir/powerbutton.d"
+  install -m 0755 "$source" "$runtime_dir/acpi_handler.sh"
+}
+
+powerbutton_configure_elogind(){
+  local root="${POWERBUTTON_RUNTIME_ROOT:-}"
+  local target="$root/etc/elogind/logind.conf.d/20-unraid-powerbutton.conf"
+  local packaged="$root/usr/local/etc/elogind/logind.conf.d/20-unraid-powerbutton.conf"
+
+  [[ -f $target ]] && return 0
+  [[ -f $packaged ]] || return 0
+
+  mkdir -p "$(dirname "$target")"
+  install -m 0644 "$packaged" "$target"
+}

--- a/tests/power-button-runtime.sh
+++ b/tests/power-button-runtime.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/etc/rc.d/rc.powerbutton"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+assert_same_file() {
+  local expected=$1
+  local actual=$2
+  [[ -f "$actual" ]] || { echo "missing: $actual" >&2; exit 1; }
+  cmp -s "$expected" "$actual" || {
+    echo "content mismatch: $actual" >&2
+    exit 1
+  }
+}
+
+run_case() {
+  local name=$1
+  local source_root=$2
+  local source_acpi="$source_root/acpi/unraid_power_handler.sh"
+  local source_elogind="$source_root/elogind/logind.conf.d/20-unraid-powerbutton.conf"
+
+  export POWERBUTTON_RUNTIME_ROOT="$TMP_ROOT/$name"
+  mkdir -p "$(dirname "$source_acpi")" "$(dirname "$source_elogind")"
+  printf '%s\n' "$name acpi" > "$source_acpi"
+  printf '%s\n' "$name elogind" > "$source_elogind"
+
+  powerbutton_configure_acpid
+  powerbutton_configure_elogind
+
+  assert_same_file "$source_acpi" "$POWERBUTTON_RUNTIME_ROOT/etc/acpi/acpi_handler.sh"
+  assert_same_file "$source_elogind" "$POWERBUTTON_RUNTIME_ROOT/etc/elogind/logind.conf.d/20-unraid-powerbutton.conf"
+  [[ -x "$POWERBUTTON_RUNTIME_ROOT/etc/acpi/acpi_handler.sh" ]] || exit 1
+}
+
+run_case full-release "$TMP_ROOT/full-release/usr/local/etc"
+run_case preview-plugin "$TMP_ROOT/preview-plugin/etc"
+
+echo "power-button runtime path tests passed"


### PR DESCRIPTION
## Summary

The released OS included PR 2671's power-button files under `/usr/local/etc`, but boot services consume runtime files under `/etc`. This PR resolves the release layout before acpid and elogind start, while preserving the existing preview-plugin layout.

## Why This Exists

The latest full-release QA on [DST-139 / OS-463](https://linear.app/lime-technology/issue/DST-139/configurable-power-button-behavior-acpi-prevent-accidental-shutdowns) failed: Larry tested Unraid 7.4.0-beta.0.2 with PR 2671 included and a clean boot, but **Do nothing** still shut the server down. The UI passed; the stock ACPI handler remained active.

## Resolution

A shared boot helper detects the direct `/etc` preview-plugin layout and the `/usr/local/etc` full-release layout. It materializes the handler and elogind drop-in into the runtime `/etc` paths before the services start.

## Reviewer Considerations

- The direct `/etc` layout remains authoritative when present, so preview-plugin overlays continue to work.
- Full releases copy only the packaged files that are missing from runtime `/etc`; no existing runtime override is overwritten.
- The fix is limited to boot-time file integration. The dispatcher behavior and UI are unchanged.

## Behavior Changes

On a clean full-release boot, the configurable ACPI handler is installed and elogind loads the power-key ignore drop-in. The Power Options setting now controls a physical power-button event without requiring a plugin or manual daemon restarts.

## Implementation Summary

- Added shared `rc.powerbutton` runtime path configuration.
- Wired `rc.acpid` and `rc.elogind` to configure their runtime files before starting.
- Added a two-layout regression test for full releases and preview plugins.
- Runs the regression test in the PR-plugin build workflow.

## Verification

- `bash tests/power-button-runtime.sh`
- `bash -n` on the changed shell scripts and PR-plugin generator
- `shellcheck --severity=warning` on the new helper and test
- `git diff --check`

## Risk

Low. The change only adds a fallback copy from the known release packaging location and leaves existing runtime files untouched. A clean full-release QAVM retest is still required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved configurable power-button setup across ACPI and elogind environments.
  * Supports multiple runtime layouts and preserves existing elogind configurations.

* **Bug Fixes**
  * Ensures ACPI power-button handlers are installed with the required executable permissions.

* **Tests**
  * Added runtime coverage for full-release and preview plugin configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->