### PR TITLE
Colour-picker swatch for container-template fields with a #RRGGBB value

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -628,8 +628,28 @@ function makeConfig(opts) {
     value.prop("autocomplete","new-password");
     value.prop("type", "password");
   }
+  // Colour field: a Variable whose value is a #RRGGBB hex gets a native colour
+  // swatch beside the text box (synced both ways by the delegated handlers below).
+  // The text box stays — typing, pasting and an empty value keep working, and the
+  // swatch never changes the value unless clicked. Backwards-compatible: no new
+  // template attribute, and existing "#rrggbb" defaults upgrade for free.
+  if (opts.Type == "Variable" && opts.Mask != "true" && /^#[0-9a-fA-F]{6}$/i.test(opts.Value || opts.Default)) {
+    value.addClass("dockerColorText");
+    var swatchVal = /^#[0-9a-fA-F]{6}$/i.test(opts.Value) ? opts.Value : opts.Default;
+    value.after("<input type='color' class='dockerColorSwatch' value='"+swatchVal+"' title='_(Pick a colour)_' aria-label='_(Pick a colour)_'>");
+  }
   return newConfig.prop('outerHTML');
 }
+
+// Keep a colour field's text box and its swatch in sync, both directions.
+$(document).on("input", ".dockerColorSwatch", function() {
+  var t = $(this).siblings("input.dockerColorText").first();
+  if (t.length) t.val(this.value).trigger("change");
+});
+$(document).on("input", "input.dockerColorText", function() {
+  if (/^#[0-9a-fA-F]{6}$/i.test(this.value))
+    $(this).siblings(".dockerColorSwatch").first().val(this.value);
+});
 
 function stripTags(string) {
   return string.replace(/(<([^>]+)>)/ig,"");

--- a/emhttp/plugins/dynamix.docker.manager/sheets/CreateDocker.css
+++ b/emhttp/plugins/dynamix.docker.manager/sheets/CreateDocker.css
@@ -48,3 +48,18 @@ label.checkbox {
     grid-template-columns: minmax(0, 230px) minmax(0, 120px) minmax(0, 160px) 1fr;
     gap: .25rem;
 }
+/* Colour picker swatch shown next to a text field whose value is a #RRGGBB hex. */
+.dockerColorSwatch {
+    width: 38px;
+    height: 28px;
+    padding: 0;
+    border: 1px solid var(--gray-400, #888);
+    border-radius: 4px;
+    background: none;
+    cursor: pointer;
+    vertical-align: middle;
+    flex: none;
+}
+.dockerColorSwatch::-webkit-color-swatch-wrapper { padding: 2px; }
+.dockerColorSwatch::-webkit-color-swatch { border: none; border-radius: 3px; }
+.dockerColorSwatch::-moz-color-swatch { border: none; border-radius: 3px; }


### PR DESCRIPTION
On the Add/Edit Container form, a template **Variable** whose value is a `#RRGGBB` hex (a theme or accent colour, say) now shows a small native colour swatch next to its text box, kept in sync both ways: picking a colour fills the text box (and fires `change` so the form stays dirty-tracked), and typing or pasting a valid `#rrggbb` updates the swatch.

The text box itself is unchanged, so typing, pasting and leaving the field empty all keep working, and the swatch never alters the value unless the user clicks it.

### Why

Several templates already expose a colour field (an accent, a theme tint) as a plain Variable with a hex default, so users have to hand-type a hex code with no visual feedback. A native swatch turns that into a one-click pick while staying fully backwards-compatible.

### How

Detection is by value pattern only (`^#[0-9a-fA-F]{6}$`) in `makeConfig()` in `include/CreateDocker.php`, mirroring how `Mask="true"` already switches a field to a password input a few lines above. There is **no new template attribute** and no schema change, so existing templates with a hex default upgrade automatically and every other field is untouched. Two delegated `input` handlers keep the swatch and text box in sync, and a small CSS rule styles the swatch. Only the browser-native `<input type="color">` is used, so there is no new dependency.

### Files

- `emhttp/plugins/dynamix.docker.manager/include/CreateDocker.php`
- `emhttp/plugins/dynamix.docker.manager/sheets/CreateDocker.css`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native color swatches for compatible six-digit hex color fields in Docker configuration.
  * Color selections and valid text values now remain synchronized automatically.

* **Style**
  * Improved color swatch sizing, borders, alignment, cursor behavior, and browser rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->