### PR TITLE
fix: don't cache question.png fallback as a resolved icon

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -338,6 +338,7 @@ class DockerTemplates {
 			$labelIconUrl = $ct['Icon'] ?? null;
 			if (!$communityApplications) {
 				$iconExists = !empty($tmp['icon'])
+					&& $tmp['icon'] !== '/plugins/dynamix.docker.manager/images/question.png'
 					&& (is_file($tmp['icon']) || is_file($docroot . $tmp['icon']));
 				if (!$iconExists || $reload) {
 					$tmp['icon'] = $this->getIcon($image, $name, $labelIconUrl ?: ($tmp['icon'] ?? ''));


### PR DESCRIPTION
Fixes #2713 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker icon handling by refreshing icons when cached data contains the shared fallback icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->