### PR TITLE
fix(webgui): scale task sheet width with viewport

### DIFF
--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -302,11 +302,11 @@ function fireTaskCallback(t) {
 var NCHAN_SHEET_WIDTH_KEY = 'unraid.nchanSheet.width';
 function nchanSheetWidthBounds() {
   var cap = Math.round(window.innerWidth * 0.9);
-  return { min: Math.min(600, cap), max: Math.max(Math.min(600, cap), cap) }; // 600px == the 60rem default
+  return { min: Math.min(600, cap), max: Math.max(Math.min(600, cap), cap) }; // allow resizing below the 80rem CSS default
 }
 function applyNchanSheetWidth() {
   var w = parseInt(localStorage.getItem(NCHAN_SHEET_WIDTH_KEY), 10);
-  if (!w) return;                                   // no preference -> CSS default (60rem)
+  if (!w) return;                                   // no preference -> CSS default (80rem)
   var b = nchanSheetWidthBounds();
   w = Math.max(b.min, Math.min(w, b.max));
   document.documentElement.style.setProperty('--nchan-sheet-width', w + 'px');

--- a/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
+++ b/emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php
@@ -302,11 +302,11 @@ function fireTaskCallback(t) {
 var NCHAN_SHEET_WIDTH_KEY = 'unraid.nchanSheet.width';
 function nchanSheetWidthBounds() {
   var cap = Math.round(window.innerWidth * 0.9);
-  return { min: Math.min(600, cap), max: Math.max(Math.min(600, cap), cap) }; // allow resizing below the 80rem CSS default
+  return { min: Math.min(600, cap), max: Math.max(Math.min(600, cap), cap) }; // allow the full 600px-to-90vw resize range
 }
 function applyNchanSheetWidth() {
   var w = parseInt(localStorage.getItem(NCHAN_SHEET_WIDTH_KEY), 10);
-  if (!w) return;                                   // no preference -> CSS default (80rem)
+  if (!w) return;                                   // no preference -> responsive CSS default
   var b = nchanSheetWidthBounds();
   w = Math.max(b.min, Math.min(w, b.max));
   document.documentElement.style.setProperty('--nchan-sheet-width', w + 'px');

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2062,8 +2062,8 @@ label.checkbox input:disabled ~ .checkmark {
     /* user-resizable width: drag the right-edge grip to widen. The chosen width
        is stored per browser in localStorage and re-applied via --nchan-sheet-width
        (see applyNchanSheetWidth / ensureNchanResizer in BodyInlineJS), shared by
-       every .nchan sheet. Defaults to the 60rem width, always capped to viewport. */
-    width: min(var(--nchan-sheet-width, 60rem), 90vw);
+       every .nchan sheet. Defaults to the 80rem width, always capped to viewport. */
+    width: min(var(--nchan-sheet-width, 80rem), 90vw);
     height: 75vh;          /* fixed (overrides swal's @media 95vh) so the log scrolls in place and the Dismiss button never moves; scales with the viewport */
     max-height: 85vh;
     margin: 0;

--- a/emhttp/plugins/dynamix/styles/default-base.css
+++ b/emhttp/plugins/dynamix/styles/default-base.css
@@ -2062,8 +2062,9 @@ label.checkbox input:disabled ~ .checkmark {
     /* user-resizable width: drag the right-edge grip to widen. The chosen width
        is stored per browser in localStorage and re-applied via --nchan-sheet-width
        (see applyNchanSheetWidth / ensureNchanResizer in BodyInlineJS), shared by
-       every .nchan sheet. Defaults to the 80rem width, always capped to viewport. */
-    width: min(var(--nchan-sheet-width, 80rem), 90vw);
+       every .nchan sheet. The default follows the viewport from 60rem to
+       100rem, and the outer cap always keeps it inside the viewport. */
+    width: min(var(--nchan-sheet-width, clamp(60rem, 70vw, 100rem)), 90vw);
     height: 75vh;          /* fixed (overrides swal's @media 95vh) so the log scrolls in place and the Dismiss button never moves; scales with the viewport */
     max-height: 85vh;
     margin: 0;


### PR DESCRIPTION
## Summary

Tracked-task sheets open too narrow on desktop. This change scales their default width with the browser viewport and keeps the responsive safeguards.

## Why This Exists

The foreground sheet shows task logs and progress output. The `60rem` default leaves unused desktop space and causes unnecessary text wrapping.

## Resolution

The shared Nchan sheet now uses `clamp(60rem, 70vw, 100rem)` as its default. The existing `90vw` cap keeps it inside narrow desktop viewports.

The full-screen mobile rule, stored widths, and `600px` resize minimum remain unchanged.

## Reviewer Considerations

- This default applies to all shared Nchan sheets, including tracked tasks, Release Notes, and alert viewers.
- A saved browser width still overrides the default and can be as small as `600px`.
- The task tray remains `320px` wide.

## Behavior Changes

- Desktop sheets without a saved preference scale from `60rem` to `100rem` with the browser viewport.
- Existing saved preferences and mobile sheets do not change.

## Implementation Summary

- Set the CSS fallback for `--nchan-sheet-width` to `clamp(60rem, 70vw, 100rem)`.
- Keep `90vw` as the outer viewport cap.
- Update the width-management comments to describe the responsive default and unchanged resize range.

## Verification

- `php -l emhttp/plugins/dynamix/include/DefaultPageLayout/BodyInlineJS.php` completed with no syntax errors.
- `git diff --check` completed with no errors.
- Width calculations produced `600px` at 768px, `840px` at 1200px, and `1000px` at 1440px and 1920px.
- A static CSS assertion found the responsive desktop rule and the `100vw` mobile override.

## Risk

Low. This change updates one CSS fallback expression and comments. It does not change task state, stored width handling, or mobile behavior.

Related to OS-645.

Follow-up to OS-377.
