### PR TITLE
fix(plugins): retain install URL while task starts

### DIFF
--- a/emhttp/plugins/dynamix.plugin.manager/PluginInstall.page
+++ b/emhttp/plugins/dynamix.plugin.manager/PluginInstall.page
@@ -19,7 +19,6 @@ Tag="download"
 
   function installPlugin(file) {
     if (file == null) {
-      $('#plugin_file').val('');
       openPlugin(my.cmd, my.title, my.plg);
       return;
     }


### PR DESCRIPTION
## Summary
The Plugin Install page discarded a pasted URL before task startup was confirmed; this keeps the URL visible while the install task starts.

Related to OS-646

## Why This Exists
On Unraid 7.4.0-beta.0.3, clicking Install immediately emptied the URL field. If task creation or foreground display then failed, the user saw no installation and also lost the value needed to retry or diagnose the problem.

## Resolution
Stop clearing the URL in the continuation that opens the plugin task. Keeping the submitted value is safe after success and preserves actionable context when startup fails.

## Reviewer Considerations
- This intentionally changes only field retention. Silent preflight and task-creation error handling are separate concerns and are not expanded into this one-line fix.
- The shared task API and plugin command construction are unchanged.

## Behavior Changes
The pasted plugin URL remains visible after Install is pressed. Plugin installation otherwise follows the existing task-queue flow.

## Implementation Summary
- Remove the premature `#plugin_file` value clear before `openPlugin()`.

## Verification
- `git diff --check` — passed.
- Embedded JavaScript syntax check with `node --check` — passed.
- Focused source assertion confirms the continuation opens the task without modifying `#plugin_file` — passed.

## Risk
Low; one DOM mutation is removed and the install command path is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the selected plugin file when an installation attempt is made without providing a new file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->