### PR TITLE
fix(docker): clear the update-available flag after an out-of-band image update

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -615,14 +615,15 @@ class DockerUpdate{
 		$updateStatus = DockerUtil::loadJSON($dockerManPaths['update-status']);
 		$images = $image ? [DockerUtil::ensureImageTag($image)] : array_map(function($ar){return $ar['Tags'][0]??'';}, $DockerClient->getDockerImages());
 		foreach ($images as $img) {
-			$localVersion = null;
-			if (!empty($updateStatus[$img]) && array_key_exists('local', $updateStatus[$img])) {
+			$remoteVersion = $this->getRemoteVersionV2($img);
+			// always re-inspect the local image: its digest changes whenever the image is replaced
+			// outside the docker manager (docker pull/recreate via CLI or API), and a cached digest
+			// would keep reporting a stale update status forever
+			$localVersion = $this->inspectLocalVersion($img, $remoteVersion);
+			if ($localVersion === null && !empty($updateStatus[$img]) && array_key_exists('local', $updateStatus[$img])) {
+				// image has no repo digest (e.g. built locally), keep the last known value
 				$localVersion = $updateStatus[$img]['local'];
 			}
-			if ($localVersion === null) {
-				$localVersion = $this->inspectLocalVersion($img);
-			}
-			$remoteVersion = $this->getRemoteVersionV2($img);
 			$status = ($localVersion && $remoteVersion) ? (($remoteVersion == $localVersion) ? 'true' : 'false') : 'undef';
 			$updateStatus[$img] = ['local' => $localVersion, 'remote' => $remoteVersion, 'status' => $status];
 			//$this->debug("Update status: Image='$img', Local='$localVersion', Remote='$remoteVersion', Status='$status'");
@@ -630,16 +631,24 @@ class DockerUpdate{
 		DockerUtil::saveJSON($dockerManPaths['update-status'], $updateStatus);
 	}
 
-	public function inspectLocalVersion($image) {
+	public function inspectLocalVersion($image, $remote=null) {
 		$DockerClient = new DockerClient();
 		$inspect      = $DockerClient->getDockerJSON('/images/'.$image.'/json');
 		if (empty($inspect['RepoDigests'])) return null;
 
-		$repoDigest = $inspect['RepoDigests'][array_key_last($inspect['RepoDigests'])];
-		$shaPos = strpos($repoDigest, '@sha256:');
-		if ($shaPos === false) return null;
+		$digests = [];
+		foreach ($inspect['RepoDigests'] as $repoDigest) {
+			$shaPos = strpos($repoDigest, '@sha256:');
+			if ($shaPos !== false) $digests[] = substr($repoDigest, $shaPos + 1);
+		}
+		if (!$digests) return null;
 
-		return substr($repoDigest, $shaPos + 1);
+		// one image can carry several digests for the same repo (a multiarch tag that got re-pushed
+		// keeps the older manifest list too), and the tag does not always point at the newest entry.
+		// If the digest the tag currently resolves to is among them, this image is that tag.
+		if ($remote !== null && in_array($remote, $digests, true)) return $remote;
+
+		return end($digests);
 	}
 
 	public function setUpdateStatus($image, $version) {


### PR DESCRIPTION
Fixes #2710.

`DockerUpdate::reloadUpdateStatus()` read the local digest out of `/var/lib/docker/unraid-update-status.json` and only called `inspectLocalVersion()` when that entry was missing. Once an image had been checked, its cached digest was trusted forever. Replacing the image outside the Docker tab (a `docker pull`, or a recreate driven through the API or CLI) never refreshed it, so the tab stayed on "update available" and `scripts/dockerupdate` kept sending a version notification on every run. "Check for Updates" could not clear it either, because it reaches the same code through `getAllInfo(true)`.

The fix is to inspect the local image on every check and keep the cached digest only as a fallback for images that carry no repo digest, such as locally built ones. The inspect is a local Docker socket call, so this costs nothing next to `getRemoteVersionV2()`, which the same loop already calls unconditionally.

Making the live inspect authoritative uncovered a second problem in `inspectLocalVersion()`. An image can carry several digests for the same repo, because a multiarch tag that was re-pushed keeps the older manifest list as well, and the tag does not always resolve to the last one. On my server `redis:latest` has two:

```
["redis@sha256:344e3945a0b4...","redis@sha256:39353c6a2f31..."]
```

and `docker buildx imagetools inspect redis:latest` resolves to `sha256:344e3945a0b4`, the first entry. Taking the last entry unconditionally (#2581) therefore reports a spurious update as soon as the digest is read live instead of from the cache. So `inspectLocalVersion()` now takes the digest the tag actually resolves to when the local image carries it, and keeps the last entry as the fallback when it does not. Membership is the right test here: if the registry's current digest is among the image's repo digests, the local image is what the tag points at.

`inspectLocalVersion()` gained an optional second parameter, so existing one-argument callers are unaffected.

### Verification

Tested on Unraid 7.3.2, PHP 8.4.23, against the real Docker socket and the real registry, with the update-status cache redirected to a scratch file.

End to end, with no mocking at all: tag a throwaway `alpine:3.19` to an older image, run the check, then update the image out of band with `docker pull` and run the check again, which is exactly what "Check for Updates" does.

```
======== master ========
  [1] first check while genuinely outdated
    local=de0eb0b3f2a4  remote=6baf43584bcb  status=false  ->  UPDATE AVAILABLE
  [2] out-of-band 'docker pull alpine:3.19'
  [3] user clicks 'Check for Updates'
    local=de0eb0b3f2a4  remote=6baf43584bcb  status=false  ->  UPDATE AVAILABLE   (stuck)

======== patched ========
  [1] first check while genuinely outdated
    local=de0eb0b3f2a4  remote=6baf43584bcb  status=false  ->  UPDATE AVAILABLE
  [2] out-of-band 'docker pull alpine:3.19'
  [3] user clicks 'Check for Updates'
    local=6baf43584bcb  remote=6baf43584bcb  status=true   ->  up-to-date
```

A case matrix driven through `reloadUpdateStatus()` with the registry digest as a controlled input passes on the patched code and fails on master for the out-of-band cases:

| case | expected | master | patched |
| --- | --- | --- | --- |
| out-of-band update, cache stale | up-to-date | update available | up-to-date |
| out-of-band rollback, cache too new | update available | up-to-date | update available |
| cold cache, image up to date | up-to-date | up-to-date | up-to-date |
| genuine update available | update available | update available | update available |
| already in sync, cache correct | up-to-date | up-to-date | up-to-date |
| tag resolves to a non-last digest | up-to-date | update available | up-to-date |
| no repo digest, cached value kept | up-to-date | up-to-date | up-to-date |

To check for false positives I compared every image on the server, 53 in total, cached digest against live inspect: 48 identical, so the patch changes nothing for them, 3 with a stale cache entry, and 2 without a repo digest that correctly keep their cached value. Resolving those against the real registry, master and the patched code report the same status for all of them, including `redis:latest`, which stays up-to-date only because of the digest preference described above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image update checks by refreshing local image information on each reload.
  * Improved digest matching between local images and remote registries.
  * Preserved the previously detected local version when a repository digest is unavailable.
  * More reliably identifies whether a local image matches the latest remote version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->