### PR TITLE
Send user agent for docker update checks

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -820,10 +820,12 @@ function getCurlHandle($url, $method='GET') {
   curl_setopt($ch, CURLOPT_ENCODING, "");
   curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
   curl_setopt($ch, CURLOPT_REFERER, "");
+  curl_setopt($ch, CURLOPT_USERAGENT, "docker/Unraid os/Docker-Client");
   if ($method === 'HEAD') {
     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'HEAD');
     curl_setopt($ch, CURLOPT_HEADER, true);
     curl_setopt($ch, CURLOPT_NOBODY, true);
+    curl_setopt($ch, CURLOPT_USERAGENT, "docker/Unraid os/Docker-Client");
   }
   return $ch;
 }

--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -825,7 +825,6 @@ function getCurlHandle($url, $method='GET') {
     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'HEAD');
     curl_setopt($ch, CURLOPT_HEADER, true);
     curl_setopt($ch, CURLOPT_NOBODY, true);
-    curl_setopt($ch, CURLOPT_USERAGENT, "docker/Unraid os/Docker-Client");
   }
   return $ch;
 }


### PR DESCRIPTION
The docker curl update check doesnt send any user agent and that can end up being blocked (as a lot of botted traffic is user agent less). Docker/dynamix curl actions should clearly identify themselves as such.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a Docker/Unraid client identifier to all requests, improving compatibility with connected services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->