### PR TITLE
Stream CR-only progress ticks in run() instead of buffering them into one message

### DIFF
--- a/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/emhttp/plugins/dynamix.plugin.manager/scripts/plugin
@@ -204,10 +204,21 @@ function write(...$messages){
 }
 
 // Run command and obtain output
+// Output is read character by character and flushed on CR or LF, this way progress
+// lines which only use CR (no LF in between) are passed on tick by tick. fgets()
+// breaks on LF only, causing all CR ticks to pile up into a single message which
+// the receiving side can no longer render in place. Same approach as 'multiplugin'
 //
 function run($command) {
   $run = popen($command,'r');
-  while (!feof($run)) write(fgets($run));
+  $line = '';
+  while (!feof($run)) {
+    $char = fgetc($run);
+    if ($char === false) break;
+    $line .= $char;
+    if (in_array($char,["\r","\n"])) {write($line); $line = '';}
+  }
+  if ($line !== '') write($line);
   return pclose($run);
 }
 


### PR DESCRIPTION
Fixes the plugin-install progress garbling reported on the [Unraid forum](https://forums.unraid.net/), confirmed by @JorgeB.

## The bug

`emhttp/plugins/dynamix.plugin.manager/scripts/plugin`'s `run()` read subprocess output with `fgets()`, which only splits on `\n`. A command whose output uses `\r`-only progress ticks (no `\n` between them, the classic in-place progress bar) gets every tick buffered into one `fgets()` read that doesn't return until an actual `\n` shows up or the process exits. That single, already-clumped blob then goes out as one nchan message. The client's per-message `\r` handling in `renderMessage()` operates on whole received messages, but cannot separate progress updates inside an already-clumped message. Reproduced live: a real install produced a single 3486-character message with 41 embedded `\r`.

## The fix

Ports the pattern this repo already uses correctly in the sibling script `multiplugin`: read one character at a time with `fgetc()` and flush on `\r` or `\n`, so each tick becomes its own message.

```diff
 function run($command) {
   $run = popen($command,'r');
-  while (!feof($run)) write(fgets($run));
+  $line = '';
+  while (!feof($run)) {
+    $char = fgetc($run);
+    if ($char === false) break;
+    $line .= $char;
+    if (in_array($char,["\r","\n"])) {write($line); $line = '';}
+  }
+  if ($line !== '') write($line);
   return pclose($run);
 }
```

The browser renderer also removes the final character only when it is a newline. This preserves unterminated output and a literal `0`, which previously reached the client but were truncated during rendering. The carriage-return replacement branch and `multiplugin` are unchanged.

Two small, deliberate differences from `multiplugin`'s version, both strictly better and both verified against real output:
- An explicit `$char === false` break on end-of-stream, instead of relying on `fgets`-style implicit end-of-stream handling. This also means a stream that errors without ever setting EOF can't spin the loop forever, which the old code was theoretically exposed to.
- A trailing `if ($line !== '') write($line)` after the loop, so output with no final terminator (or output that's just the literal string `"0"`) still reaches the client. `multiplugin`'s own `!empty($line)` guard would drop a bare `"0"`, since `empty("0")` is true in PHP; this uses `!== ''` instead.

## Testing

Emitted bytes are unchanged in every case tested (only the message boundaries differ): `\r`-only progress ticks, normal `\n`-terminated lines, a mix of both, output with no trailing terminator, a bare `"0"` with no terminator, and no output at all. Verified against the five call sites of `run()` in this file (`pre_hooks`, `post_hooks`, and the three run variants) that none of them depend on the old message granularity, only on the return value. `php -l` passes.

One pre-existing property, unchanged by this PR and already present in `multiplugin`: a stream that mixes `\n`-only lines with later `\r\n`-terminated lines can lose one line at the transition, because the client's renderer treats a `\r`-terminated message as "replace the previous line." Not introduced here, and unlikely on the Linux run-scripts this path executes (`wget`/`curl`-style progress is `\r`-only, not CRLF).

### Renderer follow-up validation

On Unraid 7.4.0-beta.1.3 with the original PR plugin plus the one-line renderer change, a real browser install showed live download progress, separate normal lines, the complete unterminated message, and literal `0`. A deliberate exit-7 fixture still displayed Error and the command failure. Six focused checks against the extracted renderer passed: unterminated tail, zero, LF lines, spaces, blank lines, and repeated CR updates.

The rebuilt PR plugin version 2026.09.16.2354 was installed cleanly on Unraid 7.4.0-beta.1.3 after removing the temporary renderer edit. After a browser reload, the real download fixture displayed the complete trailing message and literal `0`; the exit-7 fixture still displayed Error correctly. Installed renderer and reader hashes matched the tested sources, and all eight reader contract checks passed again. Build and CodeRabbit checks passed for head c4d48c8c948d6db66c624c87f6630206f80b0b16.
