### PR TITLE
fix(docker): preserve additional networks on update

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/emhttp/plugins/dynamix.docker.manager/include/Helpers.php
@@ -584,9 +584,10 @@ function xmlToCommand($xml, $create_paths=false) {
 function connectExtraNetworks($name, $extra, $primary='', $echo=false) {
   global $docroot;
   if (is_array($extra)) $extra = implode(',', $extra);
-  if (!is_string($extra) || !strlen(trim($extra)) || !strlen(trim($name))) return;
+  if (!is_string($extra) || !strlen(trim($extra)) || !strlen(trim($name))) return true;
   $script = $docroot.'/plugins/dynamix.docker.manager/scripts/docker';
   $done = [];
+  $success = true;
   foreach (preg_split('/[\s,]+/', trim($extra)) as $net) {
     $net = trim($net);
     if (!strlen($net)) continue;
@@ -594,11 +595,13 @@ function connectExtraNetworks($name, $extra, $primary='', $echo=false) {
     if ($key == strtolower(trim($primary)) || isset($done[$key])) continue;
     $done[$key] = true;
     exec($script.' network connect '.escapeshellarg($net).' '.escapeshellarg($name).' 2>&1', $o, $rc);
+    if ($rc !== 0) $success = false;
     if ($echo) {
       $msg = $rc===0 ? _('Connected network') : _('Could not connect network');
       echo "<script>addLog('<b>".addslashes(htmlspecialchars($msg.": $net"))."</b>');</script>\n"; @flush();
     }
   }
+  return $success;
 }
 
 function stopContainer($name, $t=false, $echo=true) {

--- a/emhttp/plugins/dynamix.docker.manager/scripts/update_container
+++ b/emhttp/plugins/dynamix.docker.manager/scripts/update_container
@@ -162,6 +162,8 @@ foreach (explode('*',rawurldecode($argv[1])) as $value) {
   $xml = file_get_contents($tmpl);
   [$cmd, $Name, $Repository] = xmlToCommand($tmpl);
   $Registry = getXmlVal($xml, "Registry");
+  $Network = getXmlVal($xml, "Network");
+  $ExtraNetworks = getXmlVal($xml, "ExtraNetworks");
   $TS_Enabled = getXmlVal($xml, "TailscaleEnabled");
   $oldImageID = $DockerClient->getImageID($Repository);
   // pull image
@@ -195,6 +197,7 @@ foreach (explode('*',rawurldecode($argv[1])) as $value) {
     exec("/usr/local/emhttp/plugins/dynamix.docker.manager/scripts/docker rm '" . escapeshellarg($Name) . "'");
   }
   execCommand_nchan($cmd);
+  connectExtraNetworks($Name, $ExtraNetworks, $Network);
   if ($startContainer) addRoute($Name); // add route for remote WireGuard access
   $DockerClient->flushCaches();
   $newImageID = $DockerClient->getImageID($Repository);

--- a/emhttp/plugins/dynamix.docker.manager/scripts/update_container
+++ b/emhttp/plugins/dynamix.docker.manager/scripts/update_container
@@ -196,8 +196,10 @@ foreach (explode('*',rawurldecode($argv[1])) as $value) {
     // Remove preliminary container
     exec("/usr/local/emhttp/plugins/dynamix.docker.manager/scripts/docker rm '" . escapeshellarg($Name) . "'");
   }
-  execCommand_nchan($cmd);
-  connectExtraNetworks($Name, $ExtraNetworks, $Network);
+  $recreated = execCommand_nchan($cmd);
+  if ($recreated && !connectExtraNetworks($Name, $ExtraNetworks, $Network)) {
+    write("addLog\0<span class='error'><b>"._('Error').":</b> "._('Could not connect one or more additional networks')."</span>");
+  }
   if ($startContainer) addRoute($Name); // add route for remote WireGuard access
   $DockerClient->flushCaches();
   $newImageID = $DockerClient->getImageID($Repository);


### PR DESCRIPTION
## Summary
Docker updates now reattach the additional networks saved in the container template after the container is recreated.

## Why This Exists
The Docker multi-network feature saved additional networks and handled the foreground create/update path. The normal background Update action uses `scripts/update_container`, which recreated the container without reconnecting those networks.

## Resolution
The background update script reads the saved primary and additional network values and calls the existing `connectExtraNetworks()` helper after successful recreation. The helper now returns an aggregate success status, and any failed additional-network attachment is written to the background update log. It skips the primary network and remains idempotent.

## Reviewer Considerations
- The change is limited to the background update path used by the standard Update and Update all actions.
- The existing helper remains the single owner of additional-network attachment behavior.
- Live Docker update execution was not available in this development environment.

## Behavior Changes
Containers updated from the Docker UI retain their configured additional network attachments. If a configured additional network is unavailable, the update log reports the restoration failure instead of silently completing. Containers without additional networks behave as before.

## Implementation Summary
- Read `<Network>` and `<ExtraNetworks>` from the saved template in `scripts/update_container`.
- Reconnect the additional networks after successful container recreation.
- Propagate network connection status and report failures through the background update log.

## Verification
- `php -d short_open_tag=On -l emhttp/plugins/dynamix.docker.manager/scripts/update_container`
- `php -d short_open_tag=On -l emhttp/plugins/dynamix.docker.manager/include/Helpers.php`
- PHP XML parsing check for primary and additional network values.
- `git diff --check upstream/master...HEAD`
- GitHub Actions `build-plugin` check passed.
- CodeRabbit review check passed.

## Risk
Low; the patch reuses the existing attachment helper and does not change template format or primary-network handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Container updates now preserve and reconnect the primary and additional Docker networks defined in the container’s template.
  * Network reconnection occurs only after successful container recreation.
  * Failed network connections are now detected and logged as errors.
  * Recreated containers retain their configured network connectivity after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
