### PR TITLE
fix(utilization): hide usage when array is stopped

### DIFF
--- a/emhttp/plugins/dynamix/include/Helpers.php
+++ b/emhttp/plugins/dynamix/include/Helpers.php
@@ -150,7 +150,7 @@ function my_usage() {
       $arrayfree += _var($disk,'fsFree',0);
     }
   }
-  if (_var($var,'fsNumMounted',0) > 0) {
+  if (_var($var,'fsState') == 'Started' && _var($var,'fsNumMounted',0) > 0) {
     $used = $arraysize ? 100-round(100*$arrayfree/$arraysize) : 0;
     echo "<div class='usage-bar'><span style='width:{$used}%' class='".usage_color($display,$used,false)."'>{$used}%</span></div>";
   } else {

--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -686,11 +686,11 @@ function effective_fs_size(&$disk) {
 }
 
 function fs_info(&$disk,$online = false) {
-  global $display;
+  global $display, $var;
   $echo = [];
   if (empty(_var($disk,'fsStatus','')))
     return "<td colspan='4'></td>";
-  if (_var($disk,'fsStatus')=='Mounted') {
+  if (_var($disk,'fsStatus')=='Mounted' && _var($var,'fsState') == 'Started') {
     $fsSize = effective_fs_size($disk);
     $echo[] = "<td>".vfs_type($disk,$online)."</td>";
     $echo[] = "<td>".my_scale($fsSize*1024,$unit,-1)." $unit</td>";

--- a/tests/stopped-array-utilization.php
+++ b/tests/stopped-array-utilization.php
@@ -1,0 +1,123 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+function extractFunction(string $source, string $name): string
+{
+  $source = preg_replace('/<\?(?!php|=|xml)/i', '<?php', $source) ?? $source;
+  $tokens = token_get_all($source);
+  $capturing = false;
+  $braces = 0;
+  $inDoubleQuote = false;
+  $code = '';
+  $tokenCount = count($tokens);
+
+  for ($i = 0; $i < $tokenCount; $i++) {
+    $token = $tokens[$i];
+    if (!$capturing && is_array($token) && $token[0] === T_FUNCTION) {
+      $j = $i + 1;
+      while ($j < $tokenCount && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) $j++;
+      if ($j < $tokenCount && $tokens[$j] === '&') $j++;
+      while ($j < $tokenCount && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) $j++;
+      if ($j >= $tokenCount || !is_array($tokens[$j]) || $tokens[$j][0] !== T_STRING || $tokens[$j][1] !== $name) continue;
+      $capturing = true;
+    }
+
+    if (!$capturing) continue;
+
+    $code .= is_array($token) ? $token[1] : $token;
+    if (is_string($token)) {
+      if ($token === '"') {
+        $inDoubleQuote = !$inDoubleQuote;
+      } elseif (!$inDoubleQuote && $token === '{') {
+        $braces++;
+      } elseif (!$inDoubleQuote && $token === '}' && --$braces === 0) {
+        break;
+      }
+    }
+  }
+
+  if ($code === '') {
+    throw new RuntimeException("Could not extract $name");
+  }
+
+  return $code;
+}
+
+function _var(&$name, $key = null, $default = '')
+{
+  return is_null($key) ? ($name ?? $default) : ($name[$key] ?? $default);
+}
+
+function usage_color(&$disk, $limit, $free)
+{
+  return '';
+}
+
+function my_scale($value, &$unit, $decimals = null)
+{
+  $unit = 'GB';
+  return (string)$value;
+}
+
+function vfs_type(&$disk, $online = false)
+{
+  return 'xfs';
+}
+
+function effective_fs_size(&$disk)
+{
+  return _var($disk, 'fsSize', 0);
+}
+
+$repo = dirname(__DIR__);
+$myUsageFunction = extractFunction(file_get_contents("$repo/emhttp/plugins/dynamix/include/Helpers.php"), 'my_usage');
+eval($myUsageFunction);
+$fsInfoFunction = extractFunction(file_get_contents("$repo/emhttp/plugins/dynamix/nchan/device_list"), 'fs_info');
+eval($fsInfoFunction);
+
+function assertContainsText(string $needle, string $haystack, string $message): void
+{
+  if (!str_contains($haystack, $needle)) throw new RuntimeException($message);
+}
+
+function assertNotContainsText(string $needle, string $haystack, string $message): void
+{
+  if (str_contains($haystack, $needle)) throw new RuntimeException($message);
+}
+
+$display = ['text' => 2, 'critical' => 0, 'warning' => 0];
+$disks = [
+  ['name' => 'disk1', 'sizeSb' => 100, 'fsFree' => 50],
+];
+$var = ['fsState' => 'Stopped', 'fsNumMounted' => 1];
+
+ob_start();
+my_usage();
+$navigationUsage = ob_get_clean();
+assertContainsText('offline', $navigationUsage, 'Stopped arrays must show offline in navigation.');
+assertNotContainsText('%', $navigationUsage, 'Stopped arrays must not show a navigation usage percentage.');
+
+$var['fsState'] = 'Started';
+ob_start();
+my_usage();
+$navigationUsage = ob_get_clean();
+assertContainsText('50%', $navigationUsage, 'Started arrays must keep showing the usage percentage.');
+
+$disk = [
+  'fsStatus' => 'Mounted',
+  'fsType' => 'xfs',
+  'fsSize' => 100,
+  'fsUsed' => 25,
+  'fsFree' => 75,
+];
+$var['fsState'] = 'Stopped';
+$diskInfo = fs_info($disk, true);
+assertContainsText('Mounted', $diskInfo, 'Stopped filesystems must keep showing their status.');
+assertNotContainsText('usage-disk', $diskInfo, 'Stopped filesystems must not show a usage bar.');
+
+$var['fsState'] = 'Started';
+$diskInfo = fs_info($disk, true);
+assertContainsText('usage-disk', $diskInfo, 'Started filesystems must keep showing a usage bar.');
+
+echo "Stopped array utilization regression test passed.\n";


### PR DESCRIPTION
## Summary

A stopped array can report 100% utilization because the UI treats missing free-space data as zero; this hides usage percentages until the array is started.

## Why This Exists

When the array stops, filesystem size can remain available while free-space metrics are absent. The existing fallback converts the missing value to zero, which makes the used-space formula render 100%. This appears in the navigation usage bar and pool filesystem rows.

## Resolution

Require the array state to be Started before rendering utilization. Stopped arrays now show offline or filesystem status text, while started arrays keep the current usage display.

## Reviewer Considerations

- The guard is intentionally state-based because stopped-array metrics are incomplete even when a boot or pool filesystem remains mounted.
- The same source change applies to the master and 7.3 release lines.
- This change does not alter filesystem metrics or started-array calculations.

## Behavior Changes

Stopped arrays no longer show a usage percentage in the navigation bar or filesystem rows. Started arrays behave as before.

## Implementation Summary

- Gate the navigation usage bar on fsState=Started.
- Gate filesystem usage bars on fsState=Started.
- Add a regression test for stopped and started rendering behavior.

## Verification

- php tests/stopped-array-utilization.php
- php -l emhttp/plugins/dynamix/include/Helpers.php
- php -l emhttp/plugins/dynamix/nchan/device_list
- php -l tests/stopped-array-utilization.php
- git diff --check

## Risk

Low; the change only suppresses usage rendering while the array is stopped and preserves the existing status output.

## Linear

Related to OS-803: https://linear.app/lime-technology/issue/OS-803/733-stopped-array-shows-100percent-utilization
Related to OS-804: https://linear.app/lime-technology/issue/OS-804/740-stopped-array-shows-100percent-utilization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Usage bars and filesystem capacity details are now shown only when the array is started and filesystems are mounted.
  * Stopped arrays now correctly display offline status without utilization percentages or usage bars.

* **Tests**
  * Added regression coverage to verify utilization behavior for both stopped and started arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
