### PR TITLE
fix(plugin-manager): defer payload validation until install

### DIFF
--- a/emhttp/plugins/dynamix.plugin.manager/pre-hooks/pre_plugin_checks
+++ b/emhttp/plugins/dynamix.plugin.manager/pre-hooks/pre_plugin_checks
@@ -41,6 +41,11 @@ case 'plugin':
     $new_plugin = "/tmp/plugins/$name";
     $invalid    = "/tmp/plugins/$name.invalid";
     if (plugin('version', $new_plugin) > plugin('version', $plugin)) {
+      if (plugin('skipPrecheckValidation', $new_plugin) === 'true') {
+        // Defer URL-backed FILE validation until install when requested by the manifest.
+        @unlink($invalid);
+        break;
+      }
       echo "Validating $name update\n";
       $new_version = plugin('version', $new_plugin);
       // scripts/plugin exits non-zero and prints "plugin: <reason>" on failure


### PR DESCRIPTION
## Summary

Legacy plugin update checks can download every URL-backed payload. This change honors an optional manifest flag so payload validation is deferred until installation.

## Why This Exists

The update checker downloads the latest plugin manifest and then validates its URL-backed files before reporting the result. For large packages, that duplicates work and consumes substantial storage and bandwidth before the user chooses to install the update.

## Resolution

The pre-check hook now reads the optional `skipPrecheckValidation="true"` attribute from the downloaded manifest. When present, it still completes version detection but skips the payload validation command. Manifests without the attribute retain the existing validation behavior.

## Reviewer Considerations

- The guard is generic and does not name a specific plugin.
- The existing built-in plugin handling and update flow are unchanged.
- The change affects only pre-check validation; installation continues to perform the existing downloads and checksum verification.
- A stale validation-failure marker is cleared when validation is intentionally deferred.

## Behavior Changes

- An opted-out manifest can report an available update without downloading its payload during the check.
- An ordinary manifest, or one without the flag, continues to use pre-check validation.
- Real installation and update operations retain their existing integrity checks.

## Implementation Summary

- Gate the legacy pre-check validation command on the manifest metadata.
- Preserve version comparison and all install-time behavior.

## Verification

- `php -l emhttp/plugins/dynamix.plugin.manager/pre-hooks/pre_plugin_checks`
- `git diff --check`
- Isolated hook checks confirmed the flagged path skips validation and the unflagged path retains it.

Related task: [OS-851](https://linear.app/lime-technology/issue/OS-851/733-plugin-update-checks-download-package-payloads)

## Risk

Low; the default remains validation, and only manifests that explicitly opt in defer it until installation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin updates that skip precheck validation now proceed without unnecessary file downloads or verification.
  * Stale invalid-status markers are cleared when validation is intentionally bypassed.
  * Standard validation remains unchanged for other plugin updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->