### PR TITLE
fix(plugin-manager): float plugins with updates to the top as checks land

### DIFF
--- a/emhttp/plugins/dynamix.plugin.manager/Plugins.page
+++ b/emhttp/plugins/dynamix.plugin.manager/Plugins.page
@@ -90,8 +90,13 @@ function updateInfo(data) {
     var fields = update.split('\r');
     for (var i=0,field; field=fields[i]; i++) {
       var row = field.split('::');
-      $('#'+row[0]).attr('data',row[1]).html(row[2]);
-      var removeButton = $('input[data="'+row[0].substr(4).replace(/-/g,'.')+'.plg'+'"]');
+      var cell = $('#'+row[0]);
+      cell.attr('data',row[1]).html(row[2]);
+      // Use the server-provided cell to find the row. The internal plugin name
+      // can differ from the installed filename (for example, unraid.core vs
+      // unraid.core.prod.plg), so reconstructing the Remove control selector
+      // from the cell ID is not reliable.
+      var removeButton = cell.closest('tr').find('input.remove');
       if (row[2].indexOf('hourglass') >= 0) removeButton.hide(); else removeButton.show();
     }
   }

--- a/emhttp/plugins/dynamix.plugin.manager/Plugins.page
+++ b/emhttp/plugins/dynamix.plugin.manager/Plugins.page
@@ -119,8 +119,14 @@ function initlist() {
 // failed check only affects its own row (never the page), and times out into a
 // definite "cannot check" state instead of spinning forever.
 var pluginUpdates = 0;
+// A pending row keeps a rank it would plausibly end on - the 'up-to-date' rank
+// (3) on first load, its previous result on a re-check - so re-sorting only
+// moves rows whose Status rank actually changed. Plugins that turn out to have
+// an update (rank 0/1) float to the top as their result lands; the rest stay put.
 function checkPlugin(plg) {
   var name = plg.replace(/\.plg$/,'');
+  var sid = '#sid-'+name.replace(/\./g,'-');
+  var rank = $(sid).attr('data');
   return $.ajax({url:'/plugins/dynamix.plugin.manager/include/ShowPlugins.php',data:{one:name},timeout:20000})
     .done(function(data){
       data = (data||'').split('\0');
@@ -128,8 +134,13 @@ function checkPlugin(plg) {
       pluginUpdates += (parseInt(data[1],10) || 0);
     })
     .fail(function(){
-      var id = name.replace(/\./g,'-');
-      $('#sid-'+id).attr('data','4').html("<span class='red-text'><i class='fa fa-exclamation-triangle fa-fw'></i>&nbsp;<?=_('cannot check')?></span>");
+      $(sid).attr('data','4').html("<span class='red-text'><i class='fa fa-exclamation-triangle fa-fw'></i>&nbsp;<?=_('cannot check')?></span>");
+    })
+    .always(function(){
+      // 'update' re-applies the current sort, moving the row into its new
+      // group; 'updateCache' only refreshes the parsed cache so a later header
+      // click still sorts on current data. Skip the resort when nothing moved.
+      $('#plugin_table').trigger($(sid).attr('data') === rank ? 'updateCache' : 'update');
     });
 }
 function checkPlugins(reset) {
@@ -142,8 +153,10 @@ function checkPlugins(reset) {
       seen[d]=1;
       queue.push(d);
       if (reset) {
+        // Show the spinner but keep the row's current rank as its pending value,
+        // so a re-check only moves rows whose status actually changed.
         var id = d.replace(/\.plg$/,'').replace(/\./g,'-');
-        $('#sid-'+id).attr('data','0').html("<span style='color:#267CA8'><i class='fa fa-refresh fa-spin fa-fw'></i>&nbsp;<?=_('checking')?>...</span>");
+        $('#sid-'+id).html("<span style='color:#267CA8'><i class='fa fa-refresh fa-spin fa-fw'></i>&nbsp;<?=_('checking')?>...</span>");
       }
     }
   });
@@ -157,12 +170,6 @@ function checkPlugins(reset) {
       active++;
       checkPlugin(queue[idx++]).always(function(){
         active--; done++;
-        // Refresh the sort cache in place (do NOT 'update', which re-applies
-        // sortList and re-sorts by Status). Each check changes a row's Status
-        // rank, so 'update' would make rows jump around as results land. Rows
-        // stay in their initial order; a later header click still sorts on the
-        // current data because the cache is kept fresh.
-        $('#plugin_table').trigger('updateCache');
         if (done == total) {
           if (pluginUpdates > 1) $('#updateall').show(); else $('#updateall').hide();
           $('#checkall').find('input').prop('disabled',false);

--- a/emhttp/plugins/dynamix.plugin.manager/Plugins.page
+++ b/emhttp/plugins/dynamix.plugin.manager/Plugins.page
@@ -96,6 +96,9 @@ function updateInfo(data) {
     }
   }
 }
+function statusCellForPlugin(plg) {
+  return $('input.remove').filter(function(){return $(this).attr('data')==plg;}).first().closest('tr').find('td').eq(4);
+}
 function initlist() {
   timers.plugins = setTimeout(function(){$('div.spinner.fixed').show('slow');},500);
   $.get('/plugins/dynamix.plugin.manager/include/ShowPlugins.php',{init:true,check:<?=$check?>},function(data) {
@@ -125,22 +128,22 @@ var pluginUpdates = 0;
 // an update (rank 0/1) float to the top as their result lands; the rest stay put.
 function checkPlugin(plg) {
   var name = plg.replace(/\.plg$/,'');
-  var sid = '#sid-'+name.replace(/\./g,'-');
-  var rank = $(sid).attr('data');
+  var statusCell = statusCellForPlugin(plg);
+  var rank = statusCell.attr('data');
   return $.ajax({url:'/plugins/dynamix.plugin.manager/include/ShowPlugins.php',data:{one:name},timeout:20000})
     .done(function(data){
       data = (data||'').split('\0');
       updateInfo(data[0]);
       pluginUpdates += (parseInt(data[1],10) || 0);
-    })
+  })
     .fail(function(){
-      $(sid).attr('data','4').html("<span class='red-text'><i class='fa fa-exclamation-triangle fa-fw'></i>&nbsp;<?=_('cannot check')?></span>");
-    })
+    statusCell.attr('data','4').html("<span class='red-text'><i class='fa fa-exclamation-triangle fa-fw'></i>&nbsp;<?=_('cannot check')?></span>");
+  })
     .always(function(){
       // 'update' re-applies the current sort, moving the row into its new
       // group; 'updateCache' only refreshes the parsed cache so a later header
       // click still sorts on current data. Skip the resort when nothing moved.
-      $('#plugin_table').trigger($(sid).attr('data') === rank ? 'updateCache' : 'update');
+      $('#plugin_table').trigger(statusCell.attr('data') === rank ? 'updateCache' : 'update');
     });
 }
 function checkPlugins(reset) {
@@ -155,8 +158,7 @@ function checkPlugins(reset) {
       if (reset) {
         // Show the spinner but keep the row's current rank as its pending value,
         // so a re-check only moves rows whose status actually changed.
-        var id = d.replace(/\.plg$/,'').replace(/\./g,'-');
-        $('#sid-'+id).html("<span style='color:#267CA8'><i class='fa fa-refresh fa-spin fa-fw'></i>&nbsp;<?=_('checking')?>...</span>");
+        statusCellForPlugin(d).html("<span style='color:#267CA8'><i class='fa fa-refresh fa-spin fa-fw'></i>&nbsp;<?=_('checking')?>...</span>");
       }
     }
   });

--- a/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
+++ b/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
@@ -223,7 +223,7 @@ foreach (glob($plugins,GLOB_NOSORT) as $plugin_link) {
     elseif (strpos($status,'update')!==false) $rank = '0';
     elseif (strpos($status,'install')!==false) $rank = '1';
     elseif ($status=='need check') $rank = '2';
-    elseif ($status=='up-to-date') $rank = '3';
+    elseif (strpos($status,'up-to-date')!==false) $rank = '3';
     else $rank = '4';
     if (($changes = plugin('changes',$changes_file)) !== false) {
       $txtfile = "/tmp/plugins/".basename($plugin_file,'.plg').".txt";

--- a/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
+++ b/emhttp/plugins/dynamix.plugin.manager/include/ShowPlugins.php
@@ -122,7 +122,10 @@ foreach (glob($plugins,GLOB_NOSORT) as $plugin_link) {
     echo "<td><span class='desc_readmore' style='display:block'>$desc</span> $support</td>";
     echo "<td>$author</td>";
     echo "<td id='vid-$id' data='$date'>$version&nbsp;<span class='fa fa-info-circle fa-fw big blue-text'></span></td>";
-    echo "<td id='sid-$id' data='0'><span style='color:#267CA8'><i class='fa fa-refresh fa-spin fa-fw'></i>&nbsp;$status</span></td>";
+    // Rank 3 ('up-to-date') is the placeholder while the check is pending, so a
+    // row that resolves up-to-date - the common case - keeps its sort position.
+    // Only rows that actually gain an update (rank 0/1) move, floating to the top.
+    echo "<td id='sid-$id' data='3'><span style='color:#267CA8'><i class='fa fa-refresh fa-spin fa-fw'></i>&nbsp;$status</span></td>";
     echo "<td>";
     if ($os) {
       $regular = ['stable','next'];


### PR DESCRIPTION
Plugins with an available update now rise to the top of the Installed Plugins list as each async check returns, instead of the whole list staying frozen in its initial order until you sort it by hand.

## Why it stopped working

`367758db4` (part of the OS-457 async-check work) replaced the post-check `trigger('update')` with `trigger('updateCache')`, which refreshes the sort cache without re-sorting.

That was the right call at the time: the pending placeholder rank was `'0'` — the same rank `ShowPlugins.php` assigns to *update available*. Every row therefore started inside the top group and dropped out of it as its check resolved, so the entire list churned while checking. Suppressing the re-sort stopped the churn, but it also stopped updates from surfacing.

## Fix

Rank a pending row where it will most likely land, then re-sort only when a result actually moves it.

- `ShowPlugins.php` — render the pending row at rank `3` (`up-to-date`) rather than `0`.
- `Plugins.page` — `checkPlugin()` captures the row's rank before its request and, on completion, triggers `update` (re-sort) only when the rank changed, `updateCache` otherwise.
- `Plugins.page` — **Check For Updates** shows the spinner without resetting the rank, so a re-check only moves rows whose status genuinely changed.

## Behavior

| Result | Rank | Movement |
| --- | --- | --- |
| update available / install | 0 / 1 | rises to the top |
| need check | 2 | small shift up |
| up-to-date | 3 | **none** (matches placeholder) |
| cannot check / not available | 4 | small shift down |

Most plugins are up-to-date, so most rows never move; the ones with updates collect at the top as they are found. The settled order after all checks is identical to before.

## Testing

- `php -l` on `ShowPlugins.php`; `node --check` on the extracted script block.
- Not yet exercised against a live server — worth a QA pass on a box with a mix of up-to-date, updatable and unreachable plugins.

Ref: OS-457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin removal controls for plugins whose installed filenames differ from their internal names.
  * Improved plugin list sorting as update checks complete, keeping results in the correct order sooner.
  * Preserved plugin row positions while checks are in progress.
  * Ensured only plugins whose update status changes are repositioned.
  * Improved recognition and ordering of up-to-date plugins, including during status checks.
  * Reduced unnecessary list refreshes for smoother browsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->