### PR TITLE
fix(boot): restore stopped boot usage stats

### DIFF
--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -380,7 +380,6 @@ function pool_function_row(string $label, ?array $poolDisk, ?array $firstMember,
   $disk['fsStatus'] = _var($fsOverride,'fsStatus',_var($poolDisk,'fsStatus',_var($firstMember,'fsStatus','')));
   $disk['fsType']   = _var($fsOverride,'fsType',_var($poolDisk,'fsType',_var($firstMember,'fsType','')));
   $disk['fsMountpoint'] = _var($fsOverride,'fsMountpoint',_var($poolDisk,'fsMountpoint',_var($firstMember,'fsMountpoint','')));
-  $disk['showUsageWhenStopped'] = _var($fsOverride,'showUsageWhenStopped',false);
   $disk['fsSize']   = _var($metrics,'fsSize',_var($poolDisk,'fsSize',_var($firstMember,'fsSize','')));
   $disk['fsUsed']   = _var($metrics,'fsUsed',_var($poolDisk,'fsUsed',_var($firstMember,'fsUsed','')));
   $disk['fsFree']   = _var($metrics,'fsFree',_var($poolDisk,'fsFree',_var($firstMember,'fsFree','')));
@@ -687,14 +686,11 @@ function effective_fs_size(&$disk) {
 }
 
 function fs_info(&$disk,$online = false) {
-  global $display, $var;
+  global $display;
   $echo = [];
   if (empty(_var($disk,'fsStatus','')))
     return "<td colspan='4'></td>";
-  $showUsage = _var($var,'fsState') == 'Started'
-    || _var($disk,'type') == 'Flash'
-    || _var($disk,'showUsageWhenStopped',false);
-  if (_var($disk,'fsStatus')=='Mounted' && $showUsage) {
+  if (_var($disk,'fsStatus')=='Mounted') {
     $fsSize = effective_fs_size($disk);
     $echo[] = "<td>".vfs_type($disk,$online)."</td>";
     $echo[] = "<td>".my_scale($fsSize*1024,$unit,-1)." $unit</td>";
@@ -1148,7 +1144,6 @@ while (true) {
           'fsType' => $bootFsType,
           'fsStatus' => $bootFsStatus,
           'fsMountpoint' => $bootMountPoint,
-          'showUsageWhenStopped' => true,
         ],
         true,
         $bootPoolName,
@@ -1294,7 +1289,6 @@ while (true) {
             'fsType' => $bootFsType,
             'fsStatus' => $bootFsStatus,
             'fsMountpoint' => $bootMountPoint,
-            'showUsageWhenStopped' => true,
           ],
           true,
           $bootPoolName,
@@ -1436,7 +1430,6 @@ while (true) {
             'fsType' => $bootFsType,
             'fsStatus' => $bootFsStatus,
             'fsMountpoint' => $bootMountPoint,
-            'showUsageWhenStopped' => true,
           ],
           true,
           $bootPoolName,

--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -380,6 +380,7 @@ function pool_function_row(string $label, ?array $poolDisk, ?array $firstMember,
   $disk['fsStatus'] = _var($fsOverride,'fsStatus',_var($poolDisk,'fsStatus',_var($firstMember,'fsStatus','')));
   $disk['fsType']   = _var($fsOverride,'fsType',_var($poolDisk,'fsType',_var($firstMember,'fsType','')));
   $disk['fsMountpoint'] = _var($fsOverride,'fsMountpoint',_var($poolDisk,'fsMountpoint',_var($firstMember,'fsMountpoint','')));
+  $disk['showUsageWhenStopped'] = _var($fsOverride,'showUsageWhenStopped',false);
   $disk['fsSize']   = _var($metrics,'fsSize',_var($poolDisk,'fsSize',_var($firstMember,'fsSize','')));
   $disk['fsUsed']   = _var($metrics,'fsUsed',_var($poolDisk,'fsUsed',_var($firstMember,'fsUsed','')));
   $disk['fsFree']   = _var($metrics,'fsFree',_var($poolDisk,'fsFree',_var($firstMember,'fsFree','')));
@@ -690,7 +691,10 @@ function fs_info(&$disk,$online = false) {
   $echo = [];
   if (empty(_var($disk,'fsStatus','')))
     return "<td colspan='4'></td>";
-  if (_var($disk,'fsStatus')=='Mounted' && _var($var,'fsState') == 'Started') {
+  $showUsage = _var($var,'fsState') == 'Started'
+    || _var($disk,'type') == 'Flash'
+    || _var($disk,'showUsageWhenStopped',false);
+  if (_var($disk,'fsStatus')=='Mounted' && $showUsage) {
     $fsSize = effective_fs_size($disk);
     $echo[] = "<td>".vfs_type($disk,$online)."</td>";
     $echo[] = "<td>".my_scale($fsSize*1024,$unit,-1)." $unit</td>";
@@ -1144,6 +1148,7 @@ while (true) {
           'fsType' => $bootFsType,
           'fsStatus' => $bootFsStatus,
           'fsMountpoint' => $bootMountPoint,
+          'showUsageWhenStopped' => true,
         ],
         true,
         $bootPoolName,
@@ -1289,6 +1294,7 @@ while (true) {
             'fsType' => $bootFsType,
             'fsStatus' => $bootFsStatus,
             'fsMountpoint' => $bootMountPoint,
+            'showUsageWhenStopped' => true,
           ],
           true,
           $bootPoolName,
@@ -1430,6 +1436,7 @@ while (true) {
             'fsType' => $bootFsType,
             'fsStatus' => $bootFsStatus,
             'fsMountpoint' => $bootMountPoint,
+            'showUsageWhenStopped' => true,
           ],
           true,
           $bootPoolName,

--- a/tests/stopped-array-utilization.php
+++ b/tests/stopped-array-utilization.php
@@ -104,7 +104,8 @@ my_usage();
 $navigationUsage = ob_get_clean();
 assertContainsText('50%', $navigationUsage, 'Started arrays must keep showing the usage percentage.');
 
-$disk = [
+$bootPartition = [
+  'type' => 'Cache',
   'fsStatus' => 'Mounted',
   'fsType' => 'xfs',
   'fsSize' => 100,
@@ -112,28 +113,25 @@ $disk = [
   'fsFree' => 75,
 ];
 $var['fsState'] = 'Stopped';
-$diskInfo = fs_info($disk, true);
-assertContainsText('Mounted', $diskInfo, 'Stopped filesystems must keep showing their status.');
-assertNotContainsText('usage-disk', $diskInfo, 'Stopped filesystems must not show a usage bar.');
+$bootInfo = fs_info($bootPartition, true);
+assertContainsText('25', $bootInfo, 'Stopped mounted boot partitions must show used space.');
+assertContainsText('75', $bootInfo, 'Stopped mounted boot partitions must show free space.');
+assertContainsText('usage-disk', $bootInfo, 'Stopped mounted boot partitions must show usage bars.');
 
-$bootDisk = $disk;
-$bootDisk['type'] = 'Flash';
-$bootInfo = fs_info($bootDisk, true);
-assertContainsText('25', $bootInfo, 'Stopped flash boot devices must show used space.');
-assertContainsText('75', $bootInfo, 'Stopped flash boot devices must show free space.');
+$flashBootDisk = $bootPartition;
+$flashBootDisk['type'] = 'Flash';
+$flashBootInfo = fs_info($flashBootDisk, true);
+assertContainsText('25', $flashBootInfo, 'Stopped mounted flash boot devices must show used space.');
+assertContainsText('75', $flashBootInfo, 'Stopped mounted flash boot devices must show free space.');
 
-$bootPoolDisk = $disk;
-$bootPoolDisk['type'] = 'Cache';
-$bootPoolDisk['showUsageWhenStopped'] = true;
-$bootPoolInfo = fs_info($bootPoolDisk, true);
-assertContainsText('25', $bootPoolInfo, 'Stopped internal boot pools must show used space.');
-assertContainsText('75', $bootPoolInfo, 'Stopped internal boot pools must show free space.');
-
-$dataPoolInfo = fs_info($disk, true);
-assertNotContainsText('usage-disk', $dataPoolInfo, 'Stopped data pools must not show a usage bar.');
+$dataPartition = $bootPartition;
+$dataPartition['fsStatus'] = 'Unmounted';
+$dataInfo = fs_info($dataPartition, true);
+assertContainsText('Unmounted', $dataInfo, 'Stopped unmounted data partitions must show their status.');
+assertNotContainsText('usage-disk', $dataInfo, 'Stopped unmounted data partitions must not show a usage bar.');
 
 $var['fsState'] = 'Started';
-$diskInfo = fs_info($disk, true);
+$diskInfo = fs_info($bootPartition, true);
 assertContainsText('usage-disk', $diskInfo, 'Started filesystems must keep showing a usage bar.');
 
 echo "Stopped array utilization regression test passed.\n";

--- a/tests/stopped-array-utilization.php
+++ b/tests/stopped-array-utilization.php
@@ -116,6 +116,22 @@ $diskInfo = fs_info($disk, true);
 assertContainsText('Mounted', $diskInfo, 'Stopped filesystems must keep showing their status.');
 assertNotContainsText('usage-disk', $diskInfo, 'Stopped filesystems must not show a usage bar.');
 
+$bootDisk = $disk;
+$bootDisk['type'] = 'Flash';
+$bootInfo = fs_info($bootDisk, true);
+assertContainsText('25', $bootInfo, 'Stopped flash boot devices must show used space.');
+assertContainsText('75', $bootInfo, 'Stopped flash boot devices must show free space.');
+
+$bootPoolDisk = $disk;
+$bootPoolDisk['type'] = 'Cache';
+$bootPoolDisk['showUsageWhenStopped'] = true;
+$bootPoolInfo = fs_info($bootPoolDisk, true);
+assertContainsText('25', $bootPoolInfo, 'Stopped internal boot pools must show used space.');
+assertContainsText('75', $bootPoolInfo, 'Stopped internal boot pools must show free space.');
+
+$dataPoolInfo = fs_info($disk, true);
+assertNotContainsText('usage-disk', $dataPoolInfo, 'Stopped data pools must not show a usage bar.');
+
 $var['fsState'] = 'Started';
 $diskInfo = fs_info($disk, true);
 assertContainsText('usage-disk', $diskInfo, 'Started filesystems must keep showing a usage bar.');


### PR DESCRIPTION
## Summary

Stopped-array display now keeps filesystem rendering based on mount status, so mounted boot partitions retain used/free statistics while unmounted data partitions show status; the aggregate navigation usage widget shows `offline` while the array is stopped. Related to [OS-852](https://linear.app/lime-technology/issue/OS-852/740-beta12-regression-boot-device-usedfree-stats-missing-when-array-is) and [OS-804](https://linear.app/lime-technology/issue/OS-804/740-stopped-array-shows-100percent-utilization).

## Why This Exists

The OS-804 utilization fix correctly prevents the aggregate usage bar from presenting a percentage for a stopped array, but applying the same array-state check inside `fs_info()` also hid valid statistics for a mounted boot partition. An internal boot device can expose a mounted boot partition alongside an unmounted data partition, so filesystem mount status is the correct discriminator for the row-level display.

## Resolution

The stopped-array protection remains in `my_usage()`, which owns the navigation usage widget. `fs_info()` is restored to its existing contract: render filesystem usage when `fsStatus` is `Mounted`, regardless of array state, and render filesystem status for unmounted partitions. The boot-only usage override is removed because the filesystem status already identifies which partition can show statistics.

## Reviewer Considerations

- The navigation usage widget and device-list filesystem cells have different responsibilities; only the aggregate widget needs the array-state guard.
- `fs_info()` intentionally does not inspect `fsState`. If a filesystem is mounted, its supplied metrics remain eligible for display; if it is unmounted, the row remains status-only.
- The regression coverage models both internal boot behavior and an external Flash boot device without introducing a new per-row flag.

## Behavior Changes

- Stopped arrays show `offline` instead of a navigation usage percentage.
- Stopped mounted boot partitions show used/free statistics.
- Stopped unmounted data partitions show filesystem status without usage bars.
- Started arrays retain their existing navigation and filesystem usage displays.

## Implementation Summary

- Restored `fs_info()` to use `fsStatus` as its row-level usage gate.
- Removed the unused `showUsageWhenStopped` propagation and boot-row overrides.
- Updated the stopped-array regression test for mounted boot, Flash boot, unmounted data, and started cases.

## Verification

- `php tests/stopped-array-utilization.php` — passed.
- `php -l emhttp/plugins/dynamix/nchan/device_list` — passed.
- `php -l emhttp/plugins/dynamix/include/Helpers.php` — passed.
- `php -l tests/stopped-array-utilization.php` — passed.
- `git diff --check` — passed.

## Risk

Low; the change restores the renderer’s existing mount-status contract and keeps the stopped-array guard limited to the aggregate navigation widget.
