### PR TITLE
fix(boot): backport mounted usage stats to 7.3

### DIFF
--- a/emhttp/plugins/dynamix/nchan/device_list
+++ b/emhttp/plugins/dynamix/nchan/device_list
@@ -682,11 +682,11 @@ function effective_fs_size(&$disk) {
 }
 
 function fs_info(&$disk,$online = false) {
-  global $display, $var;
+  global $display;
   $echo = [];
   if (empty(_var($disk,'fsStatus','')))
     return "<td colspan='4'></td>";
-  if (_var($disk,'fsStatus')=='Mounted' && _var($var,'fsState') == 'Started') {
+  if (_var($disk,'fsStatus')=='Mounted') {
     $fsSize = effective_fs_size($disk);
     $echo[] = "<td>".vfs_type($disk,$online)."</td>";
     $echo[] = "<td>".my_scale($fsSize*1024,$unit,-1)." $unit</td>";

--- a/tests/stopped-array-utilization.php
+++ b/tests/stopped-array-utilization.php
@@ -104,7 +104,8 @@ my_usage();
 $navigationUsage = ob_get_clean();
 assertContainsText('50%', $navigationUsage, 'Started arrays must keep showing the usage percentage.');
 
-$disk = [
+$bootPartition = [
+  'type' => 'Cache',
   'fsStatus' => 'Mounted',
   'fsType' => 'xfs',
   'fsSize' => 100,
@@ -112,12 +113,25 @@ $disk = [
   'fsFree' => 75,
 ];
 $var['fsState'] = 'Stopped';
-$diskInfo = fs_info($disk, true);
-assertContainsText('Mounted', $diskInfo, 'Stopped filesystems must keep showing their status.');
-assertNotContainsText('usage-disk', $diskInfo, 'Stopped filesystems must not show a usage bar.');
+$bootInfo = fs_info($bootPartition, true);
+assertContainsText('25', $bootInfo, 'Stopped mounted boot partitions must show used space.');
+assertContainsText('75', $bootInfo, 'Stopped mounted boot partitions must show free space.');
+assertContainsText('usage-disk', $bootInfo, 'Stopped mounted boot partitions must show usage bars.');
+
+$flashBootDisk = $bootPartition;
+$flashBootDisk['type'] = 'Flash';
+$flashBootInfo = fs_info($flashBootDisk, true);
+assertContainsText('25', $flashBootInfo, 'Stopped mounted flash boot devices must show used space.');
+assertContainsText('75', $flashBootInfo, 'Stopped mounted flash boot devices must show free space.');
+
+$dataPartition = $bootPartition;
+$dataPartition['fsStatus'] = 'Unmounted';
+$dataInfo = fs_info($dataPartition, true);
+assertContainsText('Unmounted', $dataInfo, 'Stopped unmounted data partitions must show their status.');
+assertNotContainsText('usage-disk', $dataInfo, 'Stopped unmounted data partitions must not show a usage bar.');
 
 $var['fsState'] = 'Started';
-$diskInfo = fs_info($disk, true);
+$diskInfo = fs_info($bootPartition, true);
 assertContainsText('usage-disk', $diskInfo, 'Started filesystems must keep showing a usage bar.');
 
 echo "Stopped array utilization regression test passed.\n";


### PR DESCRIPTION
## Summary

The 7.3.3 release-line backport restores used/free statistics for mounted boot partitions while keeping the aggregate navigation usage widget `offline` when the array is stopped.

## Why This Exists

The `7.3` branch already contains the stopped-array utilization change from OS-804. Its array-state check also suppresses valid row-level statistics for a mounted boot partition, even though the corresponding data partition can be unmounted and should remain status-only. This backport addresses the OS-852 regression on the 7.3.3 release line.

## Resolution

Keep the stopped-state guard in `my_usage()`, which owns the navigation widget, and restore `fs_info()` to use filesystem mount status as its row-level display contract. Mounted filesystems render their supplied used/free values regardless of array state; unmounted filesystems render status text. This is the targeted release-line equivalent of [PR #2739](https://github.com/unraid/webgui/pull/2739).

## Reviewer Considerations

- The target branch is `7.3`, the branch carrying the 7.3.3 release line.
- `fs_info()` intentionally does not inspect `fsState`; the filesystem status distinguishes a mounted boot partition from an unmounted data partition.
- The backport changes only `device_list` and the existing regression test; it does not alter the already-backported navigation behavior.

## Behavior Changes

- Stopped arrays show `offline` instead of a navigation usage percentage.
- Stopped mounted boot partitions show used/free statistics.
- Stopped unmounted data partitions show filesystem status without usage bars.
- Started arrays retain their existing usage displays.

## Implementation Summary

- Restore `fs_info()` to gate usage on `fsStatus == Mounted` only.
- Update the regression test for mounted internal/Flash boot partitions and an unmounted data partition.

## Verification

- `php tests/stopped-array-utilization.php` — passed.
- `php -l emhttp/plugins/dynamix/nchan/device_list` — passed.
- `php -l emhttp/plugins/dynamix/include/Helpers.php` — passed.
- `php -l tests/stopped-array-utilization.php` — passed.
- `git diff --check` — passed.

## Risk

Low; the change restores the existing mount-status contract and leaves the stopped-array navigation guard unchanged.

## Linear

Related to [OS-852](https://linear.app/lime-technology/issue/OS-852/740-beta12-regression-boot-device-usedfree-stats-missing-when-array-is).

- Backport tracking: [OS-867](https://linear.app/lime-technology/issue/OS-867/733-backport-restore-boot-device-usedfree-stats-when-array-is-stopped)