### PR TITLE
fix(dynamix): align mover progress values with emhttpd

### DIFF
--- a/emhttp/plugins/dynamix/MoverSettings.page
+++ b/emhttp/plugins/dynamix/MoverSettings.page
@@ -17,8 +17,6 @@ Tag="calendar-check-o"
 <?
 $mode = ['Disabled','Hourly','Daily','Weekly','Monthly'];
 $days = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
-$share_cfg = (array)@parse_ini_file('/boot/config/share.cfg');
-$shareMoverProgress = ($share_cfg['shareMoverProgress'] ?? '') === 'enabled' ? 'enabled' : 'disabled';
 $setup = true;
 $buttontext = _('Move now');
 if (!$pool_devices) {
@@ -138,8 +136,9 @@ _(Mover logging)_:
 
 _(Mover Progress)_:
 : <select name="shareMoverProgress">
-  <?=mk_option($shareMoverProgress, "enabled", _("Enabled"))?>
-  <?=mk_option($shareMoverProgress, "disabled", _("Disabled"))?>
+  <?$var['shareMoverProgress'] = $var['shareMoverProgress'] ?? "no"; ?>
+  <?=mk_option($var['shareMoverProgress'], "yes", _("Enabled"))?>
+  <?=mk_option($var['shareMoverProgress'], "no", _("Disabled"))?>
   </select>
 
 :mover_progress_help:

--- a/emhttp/plugins/dynamix/MoverSettings.page
+++ b/emhttp/plugins/dynamix/MoverSettings.page
@@ -17,6 +17,8 @@ Tag="calendar-check-o"
 <?
 $mode = ['Disabled','Hourly','Daily','Weekly','Monthly'];
 $days = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+$share_cfg = (array)@parse_ini_file('/boot/config/share.cfg');
+$shareMoverProgress = ($share_cfg['shareMoverProgress'] ?? '') === 'enabled' ? 'enabled' : 'disabled';
 $setup = true;
 $buttontext = _('Move now');
 if (!$pool_devices) {
@@ -136,9 +138,8 @@ _(Mover logging)_:
 
 _(Mover Progress)_:
 : <select name="shareMoverProgress">
-  <?$var['shareMoverProgress'] = $var['shareMoverProgress'] ?? "disabled"; ?>
-  <?=mk_option($var['shareMoverProgress'], "enabled", _("Enabled"))?>
-  <?=mk_option($var['shareMoverProgress'], "disabled", _("Disabled"))?>
+  <?=mk_option($shareMoverProgress, "enabled", _("Enabled"))?>
+  <?=mk_option($shareMoverProgress, "disabled", _("Disabled"))?>
   </select>
 
 :mover_progress_help:


### PR DESCRIPTION
## Summary

The Mover Progress setting now uses the emhttpd `yes`/`no` values while retaining the existing Enabled and Disabled labels.

## Why This Exists

In Unraid 7.4.0-beta.2, the runtime setting can be `no`, but the WebGUI compared it with `enabled` and `disabled`. Neither option matched, so the browser selected Enabled as the first option.

## Resolution

Keep `$var['shareMoverProgress']` as the source of the setting. Default a missing value to `no`. Map `yes` to Enabled and `no` to Disabled.

This matches the emhttpd contract and preserves the existing user-facing labels.

## Reviewer Considerations

- Confirm that the runtime `$var['shareMoverProgress']` value uses the emhttpd `yes`/`no` contract.
- Confirm that missing values default to `no`, which displays Disabled.
- The labels remain Enabled and Disabled.
- No `share.cfg` parsing or mover script changes are included.

## Behavior Changes

- A missing value displays Disabled.
- `shareMoverProgress="yes"` displays Enabled.
- `shareMoverProgress="no"` displays Disabled.
- Applying the setting persists the `yes` or `no` value expected by emhttpd and mover.

## Implementation Summary

- Default `$var['shareMoverProgress']` to `no`.
- Use `yes` and `no` as the select option values.
- Keep the existing Enabled and Disabled labels.

## Verification

- Focused PHP source harness for the default and `yes`/`no` option mappings passed.
- `php -l emhttp/plugins/dynamix/MoverSettings.page`
- `bash -n sbin/mover`
- `git diff --check`

## Risk

Low; the change is limited to the Mover Progress select values and fallback in the WebGUI.

Related to [OS-866](https://linear.app/lime-technology/issue/OS-866/740-beta2-mover-progress-uses-enableddisabled-instead-of-emhttpd-yesno).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mover Progress settings now use the configured `shareMoverProgress` value.
  * When no value is configured, Mover Progress defaults to Disabled.
  * The setting offers clear Enabled and Disabled options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->