### PR TITLE
fix(docker): fixed listing height when a plugin adds a tab to the Docker page

### DIFF
--- a/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
@@ -136,7 +136,12 @@ function scheduleNextLoad(delay) {
   }
   setTimeout(loadlist, delay);
 }
+var dockerLoading = false;
 function loadlist(init,focus=false) {
+  // A focus reload is only there to re-render the list once the tab is visible. If a request is already
+  // in flight its response will do that, so don't start an overlapping request.
+  if (focus && dockerLoading) return;
+  dockerLoading = true;
   timers.docker = setTimeout(function(){$('div.spinner.fixed').show('slow');},500);
   docker = [];
   $.get('/plugins/dynamix.docker.manager/include/DockerContainers.php',function(d) {
@@ -210,7 +215,7 @@ function loadlist(init,focus=false) {
     <?endif;?>
     if (!update) $('input#updateAll').prop('disabled',true);
     if (rebuild) rebuildAll();
-  });
+  }).always(function(){dockerLoading = false;});
 }
 function contSizes() {
   // show spinner over window

--- a/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
@@ -4,7 +4,7 @@ Tag="cubes"
 Cond="is_file('/var/run/dockerd.pid')"
 Markdown="false"
 Nchan="docker_load,tailscale_status"
-Tabs="false"
+Focus="loadlist"
 ---
 <?PHP
 /* Copyright 2005-2025, Lime Technology
@@ -26,6 +26,11 @@ $width   = $themeHelper->isTopNavTheme() ? -58: -44; // $themeHelper set in Defa
 $top     = $themeHelper->isTopNavTheme() ? 40 : 20;
 $busy    = "<i class='fa fa-spin fa-circle-o-notch'></i> <span class='font-sans'>"._('Please wait')."... "._('starting up containers')."</span>";
 $cpus    = cpu_list();
+
+// if a plugin adds a new tab and settings are in non-tabbed view, then force automatic listing height on the docker containers table.    Fixed height doesn't make sense in this situation.
+$dockerFixedHeight = _var($display,'resize');
+if ( (count($pages??[]) > 2) && !$tabbed) $dockerFixedHeight = false;
+
 ?>
 <link type="text/css" rel="stylesheet" href="<?autov('/webGui/styles/jquery.switchbutton.css')?>">
 
@@ -179,7 +184,7 @@ function loadlist(init) {
     listview();
     $('div.spinner.fixed').hide('slow');
     if (data[2]==1) {$('#busy').show(); scheduleNextLoad(5000);} else if ($('#busy').is(':visible')) {$('#busy').hide(); scheduleNextLoad(3000);}
-    <?if (_var($display,'resize')):?>
+    <?if ($dockerFixedHeight):?>
         function resizeTableColumns() { // Handle table header fixed positioning after resize
           $('#docker_containers thead,#docker_containers tbody').removeClass('fixed');
           $('#docker_containers thead tr th').each(function(){$(this).width($(this).width());});
@@ -192,7 +197,7 @@ function loadlist(init) {
             '.js-actions',
             '#docker_containers thead',
           ],
-          manualSpacingOffset: 30, // without this, the main content will still be scrollable by like 20px
+          manualSpacingOffset: 100, // without this, the main content will still be scrollable by like 20px
         });
         resizeTableColumns()
         if (init) {

--- a/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
+++ b/emhttp/plugins/dynamix.docker.manager/DockerContainers.page
@@ -4,7 +4,7 @@ Tag="cubes"
 Cond="is_file('/var/run/dockerd.pid')"
 Markdown="false"
 Nchan="docker_load,tailscale_status"
-Focus="loadlist"
+Focus="dockerFixedHeightFix"
 ---
 <?PHP
 /* Copyright 2005-2025, Lime Technology
@@ -136,7 +136,7 @@ function scheduleNextLoad(delay) {
   }
   setTimeout(loadlist, delay);
 }
-function loadlist(init) {
+function loadlist(init,focus=false) {
   timers.docker = setTimeout(function(){$('div.spinner.fixed').show('slow');},500);
   docker = [];
   $.get('/plugins/dynamix.docker.manager/include/DockerContainers.php',function(d) {
@@ -183,8 +183,10 @@ function loadlist(init) {
     }
     listview();
     $('div.spinner.fixed').hide('slow');
-    if (data[2]==1) {$('#busy').show(); scheduleNextLoad(5000);} else if ($('#busy').is(':visible')) {$('#busy').hide(); scheduleNextLoad(3000);}
-    <?if ($dockerFixedHeight):?>
+    if ( !focus ) {
+      if (data[2]==1) {$('#busy').show(); scheduleNextLoad(5000);} else if ($('#busy').is(':visible')) {$('#busy').hide(); scheduleNextLoad(3000);}
+    }
+      <?if ($dockerFixedHeight):?>
         function resizeTableColumns() { // Handle table header fixed positioning after resize
           $('#docker_containers thead,#docker_containers tbody').removeClass('fixed');
           $('#docker_containers thead tr th').each(function(){$(this).width($(this).width());});
@@ -242,5 +244,7 @@ $(function() {
   dockerload.start();
   tailscaleStatus.start();
 });
-
+function dockerFixedHeightFix() {
+  loadlist(false,true);
+}
 </script>


### PR DESCRIPTION
Fixes the Docker Containers table being rendered with corrupted column widths when a plugin adds a tab to the Docker page and **Listing height** is set to **Fixed**.

Linear: [OS-868](https://linear.app/lime-technology/issue/OS-868)

## Changes

- `Focus="loadlist"` is added to the page header so the container list is reloaded and re-sized when the Docker Containers tab is selected in tabbed mode. This fixes the corrupted column widths seen when another plugin tab was displayed while the list first loaded.
- **Non-tabbed mode with a plugin tab:** automatic listing height is forced for the container list, since the other sections are stacked below it and a fixed height makes no sense there.
- **No plugin tab:** behaviour is unchanged.
- `manualSpacingOffset` raised from 30 to 100 so the action buttons sit correctly under the fixed-height list. This applies regardless of plugins.

## Testing

1. With a plugin that adds a Docker tab (e.g. StaXX), Fixed listing height, Tabbed display: open the Docker page with the plugin tab active, then click Docker Containers. Columns lay out normally.
2. Same with Non-tabbed display: the container list uses its automatic height and the plugin section follows below.
3. Without the plugin: Fixed listing height behaves as before in both display modes, with the buttons positioned correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved focus behavior when loading the Docker Containers page.
  * Updated container list sizing to better respond to resize settings.
  * Adjusted table spacing for improved display in relevant layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->