### PR TITLE
fix(updater): pin OS release archives with SHA256

### DIFF
--- a/emhttp/plugins/unRAIDServer/unRAIDServer.plg
+++ b/emhttp/plugins/unRAIDServer/unRAIDServer.plg
@@ -9,7 +9,7 @@
 <!ENTITY category  "">
 <!ENTITY pluginURL "">
 <!ENTITY zip       "">
-<!ENTITY md5       "">
+<!ENTITY sha256    "">
 <!ENTITY notes     "">
 <!ENTITY files     "bz*,make_bootable.bat,make_bootable_linux,make_bootable_mac,memtest*,changes.txt,license.txt,syslinux/syslinux.cfg-">
 <!ENTITY infozip   "infozip-6.0-i486-1.txz">
@@ -82,10 +82,6 @@ if [[ "${version:0:2}" == "5." ]]; then
   # download the release
   if ! wget --no-check-certificate &zip; -O /tmp/&name;.zip ; then
     echo "&zip; download error $?"
-    exit 1
-  fi
-  if ! wget --no-check-certificate &md5; -O /tmp/&name;.md5 ; then
-    echo "&md5; download error $?"
     exit 1
   fi
 fi
@@ -279,19 +275,24 @@ For unRAID-6 we download here, verifying certificiate
 -->
 <FILE Name="/tmp/&name;.zip">
 <URL>&zip;</URL>
-</FILE>
-<FILE Name="/tmp/&name;.md5">
-<URL>&md5;</URL>
+<SHA256>&sha256;</SHA256>
 </FILE>
 
 <FILE Name="/tmp/&name;.sh" Run="/bin/bash">
 <INLINE>
 rm /tmp/&name;.sh
-# check download and extract
-sum1=$(/usr/bin/md5sum /tmp/&name;.zip)
-sum2=$(cat /tmp/&name;.md5)
-if [[ "${sum1:0:32}" != "${sum2:0:32}" ]]; then
-  echo "wrong md5"
+# Check before extraction even on older plugin managers that ignore SHA256 tags.
+sha256expect="&sha256;"
+if [[ ! "$sha256expect" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "missing or invalid release SHA256"
+  exit 1
+fi
+if ! sha256actual=$(/usr/bin/sha256sum /tmp/&name;.zip); then
+  echo "cannot calculate release SHA256"
+  exit 1
+fi
+if [[ "${sha256actual:0:64}" != "$sha256expect" ]]; then
+  echo "wrong release SHA256"
   exit 1
 fi
 # check if enough free space on flash

--- a/tests/unraidserver-integrity.py
+++ b/tests/unraidserver-integrity.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Exercise only the archive integrity gate; never run the OS installer."""
+
+import hashlib
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+
+TEMPLATE = (
+    Path(__file__).resolve().parents[1]
+    / "emhttp/plugins/unRAIDServer/unRAIDServer.plg"
+).read_text()
+PAYLOAD = b"release archive fixture\n"
+DIGEST = hashlib.sha256(PAYLOAD).hexdigest()
+
+
+def manifest(digest):
+    # Same entity declaration used by release generation.
+    source = re.sub(r'(<!ENTITY sha256\s+)"[^"]*"', rf'\g<1>"{digest}"', TEMPLATE)
+    return ET.fromstring(source)
+
+
+class ReleaseIntegrityTest(unittest.TestCase):
+    def run_gate(self, digest=DIGEST, payload=PAYLOAD, hash_command=None):
+        root = manifest(digest)
+        script = next(
+            file.findtext("INLINE")
+            for file in root.findall("FILE")
+            if "missing or invalid release SHA256" in (file.findtext("INLINE") or "")
+        )
+        # Do not execute cleanup, extraction, flash writes, or other install hooks.
+        gate = script.split('sha256expect=', 1)[1].split(
+            '# check if enough free space on flash', 1
+        )[0]
+        gate = 'sha256expect=' + gate
+        with tempfile.TemporaryDirectory(prefix="unraid-integrity-") as directory:
+            archive = Path(directory) / "release.zip"
+            if payload is not None:
+                archive.write_bytes(payload)
+            gate = gate.replace('/tmp/unRAIDServer.zip', shlex.quote(str(archive)))
+            command = hash_command or shutil.which("sha256sum")
+            self.assertIsNotNone(command, "sha256sum must be installed")
+            gate = gate.replace('/usr/bin/sha256sum', shlex.quote(command))
+            return subprocess.run(
+                ["bash", "-c", gate + '\necho extraction-permitted\n'],
+                capture_output=True, text=True, check=False,
+            )
+
+    def assert_rejected(self, result, message):
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(message, result.stdout)
+        self.assertNotIn("extraction-permitted", result.stdout)
+
+    def test_archive_has_declared_pin_and_no_md5_sidecar(self):
+        downloads = [file for file in manifest(DIGEST).findall("FILE") if file.find("URL") is not None]
+        self.assertEqual(len(downloads), 1)
+        self.assertEqual(downloads[0].get("Name"), "/tmp/unRAIDServer.zip")
+        self.assertEqual(downloads[0].findtext("SHA256"), DIGEST)
+        self.assertNotIn("&md5;", TEMPLATE)
+        self.assertNotIn("/tmp/&name;.md5", TEMPLATE)
+
+    def test_matching_archive_reaches_extraction(self):
+        result = self.run_gate()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("extraction-permitted", result.stdout)
+
+    def test_substituted_archive_is_rejected(self):
+        self.assert_rejected(self.run_gate(payload=b"substituted archive"), "wrong release SHA256")
+
+    def test_empty_digest_is_rejected(self):
+        self.assert_rejected(self.run_gate(digest=""), "missing or invalid release SHA256")
+
+    def test_malformed_digests_are_rejected(self):
+        for digest in ("a" * 63, "a" * 65, "g" * 64, "unfilled"):
+            with self.subTest(digest=digest):
+                self.assert_rejected(self.run_gate(digest=digest), "missing or invalid release SHA256")
+
+    def test_missing_archive_is_rejected(self):
+        self.assert_rejected(self.run_gate(payload=None), "cannot calculate release SHA256")
+
+    def test_hash_command_failure_is_rejected(self):
+        self.assert_rejected(self.run_gate(hash_command="/bin/false"), "cannot calculate release SHA256")
+
+    def test_integrity_gate_precedes_extraction(self):
+        script = next(
+            file.findtext("INLINE") for file in manifest(DIGEST).findall("FILE")
+            if "wrong release SHA256" in (file.findtext("INLINE") or "")
+        )
+        self.assertLess(script.index("wrong release SHA256"), script.index("unzip "))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Pin the OS release ZIP to the SHA256 stored in its published plugin manifest, and enforce that pin before extraction on older plugin managers too.

## Why This Exists
The updater currently compares the ZIP with a separately downloaded MD5 file. Replacing both files defeats that check. The release publisher already fills a `sha256` entity, but this template does not declare or use it.

## Resolution
Declare the existing `sha256` entity, use it in the ZIP's `<SHA256>` element, and verify it explicitly in the install script before extraction. Remove the redundant MD5 sidecar download and comparison, including the legacy Unraid 5 download path.

## Reviewer Considerations
- Unraid 6.9.0 recognizes `<SHA256>`. The 6.8.3 plugin manager ignores it, so the inline check is necessary for compatibility.
- This changes the OS updater template only. It does not impose a new requirement on other plugins or change the plugin manager.
- The release publisher's existing `OsVersionFull::getPluginFile()` and `OsVersionBase::updateEntityTag()` fill the new template without a publisher deployment. Older templates continue to generate with their existing MD5 behavior.
- Publish the template through the normal release process so the hash is populated. An unfilled or malformed hash stops installation.

## Behavior Changes
A mismatched archive, absent/malformed digest, or failed SHA256 calculation stops the upgrade before archive extraction. The separate MD5 file is no longer fetched. Existing SHA256 checks of extracted boot files remain.

## Implementation Summary
- Wire the archive digest into both the XML download declaration and the inline verification.
- Add focused tests that execute only the integrity gate, never the OS installer.

## Verification
- `python3 tests/unraidserver-integrity.py`: all 8 tests passed with Bash 5.3 and Bash 3.2.
- Confirmed the declaration regression test fails against the base template.
- Docker contract check using the actual current publisher classes with an isolated SQLite row: new and stored templates receive the digest in both the XML and inline script; versioned/channel publication and legacy MD5 templates pass; a missing stored hash is rejected.
- Inspected the 6.8.3 and 6.9.0 plugin-manager implementations for element handling and inline execution.
- `git diff --check`: passed.

## Risk
This changes OS upgrade verification. No complete upgrade or Unraid 5 runtime test was performed. Older systems must provide `/usr/bin/sha256sum`; if it is unavailable, installation stops. The hash pins the archive to the manifest; authenticity of the manifest remains a separate trust boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Replaced MD5-based plugin archive verification with SHA-256 validation.
  * Installations now stop when the expected hash is missing, malformed, or does not match the downloaded archive.

* **Bug Fixes**
  * Added integrity checks covering valid, invalid, missing, and altered plugin archives before extraction.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->