### PR TITLE
fix(themes): fix white header background bug in gray theme for Unraid 7

### DIFF
--- a/emhttp/plugins/dynamix/styles/themes/gray.css
+++ b/emhttp/plugins/dynamix/styles/themes/gray.css
@@ -59,7 +59,7 @@
     --brand-red: var(--red-800);
 
     --header-text-color: var(--customer-header-text-color, #ffffff);
-    --header-background-color: var(--custom-header-background-color, var(--theme-gray--black-alt));
+    --header-background-color: var(--customer-header-background-color, var(--theme-gray--black-alt));
     --header-text-primary: #ffffff;
     --header-text-secondary: var(--theme-gray--cyan-300);
 

--- a/emhttp/plugins/dynamix/styles/themes/gray.css
+++ b/emhttp/plugins/dynamix/styles/themes/gray.css
@@ -59,7 +59,7 @@
     --brand-red: var(--red-800);
 
     --header-text-color: var(--customer-header-text-color, var(--inverse-text-color));
-    --header-background-color: var(--custom-header-background-color, var(--gray-100));
+    --header-background-color: var(--custom-header-background-color, var(--theme-gray--black-alt));
 
     --title-header-background-color: var(--mild-background-color);
 

--- a/emhttp/plugins/dynamix/styles/themes/gray.css
+++ b/emhttp/plugins/dynamix/styles/themes/gray.css
@@ -58,8 +58,10 @@
     --brand-orange: var(--orange-500);
     --brand-red: var(--red-800);
 
-    --header-text-color: var(--customer-header-text-color, var(--inverse-text-color));
+    --header-text-color: var(--customer-header-text-color, #ffffff);
     --header-background-color: var(--custom-header-background-color, var(--theme-gray--black-alt));
+    --header-text-primary: #ffffff;
+    --header-text-secondary: var(--theme-gray--cyan-300);
 
     --title-header-background-color: var(--mild-background-color);
 


### PR DESCRIPTION
### Problem
In Unraid 7, when using the "gray" theme, the main webUI header bar remains bright white (`var(--gray-100)`), while the text components inside it render in dark mode (`class="unapi dark"`). This causes severe readability issues and breaks the dark aesthetic of the theme.

### Solution
This PR changes the default header background color fallback in `gray.css` from the light `var(--gray-100)` to the dark theme-specific background variable `var(--theme-gray--black-alt)`. This ensures that the header scales beautifully into dark mode if no custom banner image is uploaded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the gray theme’s default header background and text colors for improved contrast.
  - Added distinct primary and secondary header text colors.
  - Custom header color overrides continue to be supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->